### PR TITLE
[WIP] charge cloud size evolution

### DIFF
--- a/src/ChargeCloudModels/GaussianChargeCloud.jl
+++ b/src/ChargeCloudModels/GaussianChargeCloud.jl
@@ -1,0 +1,82 @@
+function chargecloudsize(
+        electric_field::Interpolations.Extrapolation{<:StaticVector{3}, 3}, 
+        velocity_field::Interpolations.Extrapolation{<:StaticVector{3}, 3}, 
+        cdm::AbstractChargeDriftModel{T}, 
+        drift_path::Vector{CartesianPoint{T}}, 
+        timestamps::Vector{T}, 
+        charge::RealQuantity,
+        energy::RealQuantity; 
+        initial_size::RealQuantity = 0.1u"mm", 
+        max_growth::RealQuantity = 0.05u"mm", 
+        temperature::RealQuantity = 77u"K"
+    )::Vector{T} where {T <: SSDFloat}
+
+    max_Δσ = to_internal_units.(internal_length_unit, max_growth)*10^9 #0.05 mm/ns
+    max_ΔσΔt = to_internal_units.(internal_length_unit, 0.1u"mm")
+    itemperature::T = ustrip(uconvert(u"K", temperature))
+    
+    n = length(timestamps)
+    σ::Vector{T} = zeros(T, n)
+
+    σ[1] = to_internal_units.(internal_length_unit, initial_size)
+    previous_vel = norm(get_velocity_vector(velocity_field, drift_path[1]))
+
+    ncharges =  to_internal_units(internal_energy_unit, energy) / to_internal_units(internal_energy_unit, hpge[:E_ionisation])
+    repulsion_factor = ncharges * elementary_charge / (4*π*hpge[:ϵ_r]*ϵ0) * 0.68^3 #charge in 1σ, unitless
+    
+    for i in 2:n
+
+        Δt = timestamps[i] - timestamps[i-1]
+        σ[i] = σ[i-1]
+
+        ####### acceleration part #######
+        vel = norm(get_velocity_vector(velocity_field, drift_path[i]))
+        σ[i] = σ[i-1] * vel / previous_vel
+
+        ####### repulsion part #######
+        Efield = get_velocity_vector(electric_field, drift_path[i])
+
+        v_over_E = vel / norm(Efield)
+        
+        Efield_2 = Efield.*T(1.30) #arbitrary choice of 30% increase of E
+        vel_2 = vel
+        
+        if charge < 0
+            vel_2 = norm(getVe(Efield_2, cdm))
+        else
+            vel_2 = norm(getVh(Efield_2, cdm))
+        end
+        
+        dv_dE = (vel_2 - vel) / (norm(Efield_2) - norm(Efield))
+        
+        #Δσ_rep = repulsion_factor * v_over_E / (σ[i]^2)
+        Δσ_rep = repulsion_factor * dv_dE / (σ[i]^2)
+
+        if(Δσ_rep > max_Δσ)
+            Δσ_rep = max_Δσ
+        end
+
+        ####### diffusion part #######
+        
+        diff_coeff = boltzmann_constant * itemperature / elementary_charge * v_over_E # k*T/e is in siggen 0.67
+        Δσ_dif = diff_coeff / σ[i]
+
+        ####### final step #######
+
+        Δσ_dt = Δσ_dif + Δσ_rep
+
+        if(Δσ_dt > max_Δσ || (Δσ_dt * Δt) > max_ΔσΔt)
+            σ[i] = σ[i] + sqrt(2 * diff_coeff * Δt + (σ[i]^2 * (3 * Δσ_rep * Δt))^(2/3))
+            #println(i)
+        else
+            σ[i] = σ[i] + (Δσ_dif + Δσ_rep) * Δt
+            #println(i, "\t", dv_dE, "\t", v_over_E)
+        end
+        
+        previous_vel = vel
+
+    end
+
+    return σ
+
+end

--- a/src/ChargeDriftModels/ADL/ADL.jl
+++ b/src/ChargeDriftModels/ADL/ADL.jl
@@ -163,6 +163,11 @@ function getVe(fv::SVector{3, T}, cdm::ADLChargeDriftModel, Emag_threshold::T = 
     getVe(fv, cdmT, Emag_threshold)
 end
 
+function getVe(fv::StaticArrays.FieldVector{3, T}, cdm::ADLChargeDriftModel{T}, Emag_threshold::T = T(1e-5))::SVector{3, T} where {T <: SSDFloat}
+    sv = SVector{3, T}(fv)
+    getVe(sv, cdm, Emag_threshold)
+end
+
 @fastmath function getVe(fv::SVector{3, T}, cdm::ADLChargeDriftModel{T}, Emag_threshold::T = T(1e-5))::SVector{3, T} where {T <: SSDFloat}
     @inbounds begin
         Emag::T = norm(fv)
@@ -236,6 +241,11 @@ end
 function getVh(fv::SVector{3,T}, cdm::ADLChargeDriftModel, Emag_threshold::T = T(1e-5))::SVector{3,T} where {T <: SSDFloat}
     cdmT = ADLChargeDriftModel{T}(cdm)
     getVh(fv, cdmT, Emag_threshold)
+end
+
+function getVh(fv::StaticArrays.FieldVector{3, T}, cdm::ADLChargeDriftModel{T}, Emag_threshold::T = T(1e-5))::SVector{3, T} where {T <: SSDFloat}
+    sv = SVector{3, T}(fv)
+    getVh(sv, cdm, Emag_threshold)
 end
 
 @fastmath function getVh(fv::SVector{3,T}, cdm::ADLChargeDriftModel{T}, Emag_threshold::T = T(1e-5))::SVector{3,T} where {T <: SSDFloat}


### PR DESCRIPTION
Dear all,

Coming back to the diffusion model. The function in this PR does what siggen does for the holes but it can be run also for the electrons and the whole time evolution of the charge cloud size is saved.

The usage would be something like this in the Simulation.jl
`sigma_h = chargecloudsize(
    get_interpolated_drift_field(simulation.electric_field), 
    get_interpolated_drift_field(simulation.hole_drift_field), 
    simulation.charge_drift_model,
    event1.drift_paths[1].h_path, 
    event1.drift_paths[1].timestamps_h, 
    1,
    energy_dep1[1], 
    initial_size = 0.5u"mm", max_growth = 0.05u"mm", temperature = 77u"K"
)`

`sigma_e = chargecloudsize(
    get_interpolated_drift_field(simulation.electric_field), 
    get_interpolated_drift_field(simulation.electron_drift_field), 
    simulation.charge_drift_model,
    event1.drift_paths[1].e_path, 
    event1.drift_paths[1].timestamps_e, 
    -1,
    energy_dep1[1], 
    initial_size = 0.5u"mm", max_growth = 0.05u"mm", temperature = 77u"K"
)`

The output would be something like this for the holes in the example inverted coax detector
![holeschargecloudsize](https://user-images.githubusercontent.com/4508364/80367421-579d9c00-888b-11ea-86d3-704d924eba58.png)
The breaking down at the end is due to drift within the contact, where the signal does not change anymore.

There are in siggen two ways to approximate the mobility which is visible in the function: `dv_dE` or `v_over_E`. The two are used for the different parts from repulsion and diffusion. Both ways are approximations but they make a difference in the result and we don't really know what is the truth. I left the alternative to use only one of the approximations commented out.

The next step would be to convolute the charge cloud size with the signal. I do not fully understand the siggen code but it is only using the final charge cloud size (maximum in the picture) only for the holes and convoluting with the whole signal. This is something we could improve and convolute time dependently for both holes and electrons. How this convolution is done, I don't know yet, so let me know if you already have some ideas.

After this we also have to integrate in the already created structure of `ChargeCloudModels` with all the necessary (initial size) and optional (temperature) inputs.

Thanks,
Anna
