### PR TITLE
Added CZT simulation and fixes in LinearChargeDensityModel

### DIFF
--- a/src/ChargeDensityModels/ChargeDensityModels.jl
+++ b/src/ChargeDensityModels/ChargeDensityModels.jl
@@ -52,20 +52,22 @@ end
 
 function ChargeDensityModel(T::DataType, t::Val{:linear}, dict::Union{Dict{String, Any}, Dict{Any, Any}}, inputunit_dict::Dict)
     unit_factor::T = 1
-    if haskey(inputunit_dict, "length") 
+    gradient_unit_factor::T = 1
+    if haskey(inputunit_dict, "length")
         lunit = inputunit_dict["length"]
         unit_factor = inv(ustrip(uconvert( internal_length_unit^3, 1 * lunit^3 )))
+        gradient_unit_factor = inv(ustrip(uconvert( internal_length_unit^4, 1 * lunit^4 )))
     end
-    return LinearChargeDensityModel{T}( dict, unit_factor )
+    return LinearChargeDensityModel{T}( dict, unit_factor, gradient_unit_factor )
 end
 
-function LinearChargeDensityModel{T}(dict::Union{Dict{String, Any}, Dict{Any, Any}}, unit_factor::T)::LinearChargeDensityModel{T} where {T <: SSDFloat}
+function LinearChargeDensityModel{T}(dict::Union{Dict{String, Any}, Dict{Any, Any}}, unit_factor::T, gradient_unit_factor::T)::LinearChargeDensityModel{T} where {T <: SSDFloat}
     offsets, gradients = zeros(T,3), zeros(T,3)
-    if haskey(dict, "r")     offsets[1] = geom_round(unit_factor * T(dict["r"]["init"]));     gradients[1] = geom_round(unit_factor * T(dict["r"]["gradient"]))    end
-    if haskey(dict, "phi")   offsets[2] = geom_round(unit_factor * T(dict["phi"]["init"]));   gradients[2] = geom_round(unit_factor * T(dict["phi"]["gradient"]))  end
-    if haskey(dict, "z")     offsets[3] = geom_round(unit_factor * T(dict["z"]["init"]));     gradients[3] = geom_round(unit_factor * T(dict["z"]["gradient"]))    end
-    if haskey(dict, "x")     offsets[1] = geom_round(unit_factor * T(dict["x"]["init"]));     gradients[1] = geom_round(unit_factor * T(dict["x"]["gradient"]))    end
-    if haskey(dict, "y")     offsets[2] = geom_round(unit_factor * T(dict["y"]["init"]));     gradients[2] = geom_round(unit_factor * T(dict["y"]["gradient"]))    end
+    if haskey(dict, "r")     offsets[1] = geom_round(unit_factor * T(dict["r"]["init"]));     gradients[1] = geom_round(gradient_unit_factor * T(dict["r"]["gradient"]))    end
+    #if haskey(dict, "phi")   offsets[2] = geom_round(unit_factor * T(dict["phi"]["init"]));   gradients[2] = geom_round(unit_factor * T(dict["phi"]["gradient"]))  end
+    if haskey(dict, "z")     offsets[3] = geom_round(unit_factor * T(dict["z"]["init"]));     gradients[3] = geom_round(gradient_unit_factor * T(dict["z"]["gradient"]))    end
+    if haskey(dict, "x")     offsets[1] = geom_round(unit_factor * T(dict["x"]["init"]));     gradients[1] = geom_round(gradient_unit_factor * T(dict["x"]["gradient"]))    end
+    if haskey(dict, "y")     offsets[2] = geom_round(unit_factor * T(dict["y"]["init"]));     gradients[2] = geom_round(gradient_unit_factor * T(dict["y"]["gradient"]))    end
     LinearChargeDensityModel{T}( NTuple{3, T}(offsets), NTuple{3, T}(gradients) )
 end
 

--- a/src/MaterialProperties/MaterialProperties.jl
+++ b/src/MaterialProperties/MaterialProperties.jl
@@ -51,17 +51,25 @@ material_properties[:Co] = (
     ρ = 8.96Unitful.g / (Unitful.ml) # u"g/cm^3" throws warnings in precompilation
 )
 
+material_properties[:CdZnTe] = (
+    name = "Cadmium zinc telluride",
+    E_ionisation = 4.64u"eV",
+    ϵ_r = 10.9,
+    ρ = 5.78Unitful.g / (Unitful.ml) # u"g/cm^3" throws warnings in precompilation
+)
 # Add new materials above this line
 # and just put different spellings into the dict `materials` below
 
-materials = Dict{String, Symbol}( 
+materials = Dict{String, Symbol}(
     "HPGe" => :HPGe,
     "vacuum" => :Vacuum,
     "Vacuum" => :Vacuum,
     "Copper" => :Co,
     "copper" => :Co,
-    "Al"  => :Al
+    "Al"  => :Al,
+    "CZT" => :CdZnTe
 )
+
 
 for key in keys(material_properties)
     if !haskey(materials, string(key))


### PR DESCRIPTION
 - Added CZT material properties from [here](http://www.umich.edu/~ners580/ners-bioe_481/lectures/pdfs/SemiConductor-material_prop.pdf) and a config file for a 11x11 pixelated CZT array. 
- Fixed the unit conversion in the `LinearChargeDriftModel` (gradients have the unit `length^{-4}` and not `length^{-3}` and should be converted accordingly)
