### PR TITLE
Rename VacuumChargeDriftModel

### DIFF
--- a/docs/src/tutorial_lit.jl
+++ b/docs/src/tutorial_lit.jl
@@ -91,7 +91,7 @@ set_charge_drift_model!(simulation, charge_drift_model)
  
 # And apply the charge drift model to the electric field:
  
-apply_charge_drift_model!(simulation)
+calculate_drift_fields!(simulation)
 
 # Now, let's create an "random" (multiside) event:
 

--- a/src/ChargeDriftModels/Vacuum/Vacuum.jl
+++ b/src/ChargeDriftModels/Vacuum/Vacuum.jl
@@ -1,18 +1,20 @@
 """
-    VacuumChargeDriftModel <: AbstractChargeDriftModel
+    ElectricFieldChargeDriftModel <: AbstractChargeDriftModel
 """
-struct VacuumChargeDriftModel{T <: SSDFloat} <: AbstractChargeDriftModel{T} end
+struct ElectricFieldChargeDriftModel{T <: SSDFloat} <: AbstractChargeDriftModel{T} end
 
-function get_electron_drift_field(ef::Array{SVector{3,T},3}, ::VacuumChargeDriftModel)::Array{SVector{3,T},3} where {T <: SSDFloat}
+ElectricFieldChargeDriftModel(T::Type{<:SSDFloat}) = ElectricFieldChargeDriftModel{T}()
+
+function get_electron_drift_field(ef::Array{SVector{3,T},3}, ::ElectricFieldChargeDriftModel)::Array{SVector{3,T},3} where {T <: SSDFloat}
     return -ef
 end
-function get_hole_drift_field(ef::Array{SVector{3,T},3}, ::VacuumChargeDriftModel)::Array{SVector{3,T},3} where {T <: SSDFloat}
+function get_hole_drift_field(ef::Array{SVector{3,T},3}, ::ElectricFieldChargeDriftModel)::Array{SVector{3,T},3} where {T <: SSDFloat}
     return ef
 end
 
-function getVe(fv::SVector{3, T}, cdm::VacuumChargeDriftModel)::SVector{3, T} where {T <: SSDFloat}
+function getVe(fv::SVector{3, T}, cdm::ElectricFieldChargeDriftModel)::SVector{3, T} where {T <: SSDFloat}
     return -fv
 end
-function getVh(fv::SVector{3, T}, cdm::VacuumChargeDriftModel)::SVector{3, T} where {T <: SSDFloat}
+function getVh(fv::SVector{3, T}, cdm::ElectricFieldChargeDriftModel)::SVector{3, T} where {T <: SSDFloat}
     return fv
 end

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -642,12 +642,13 @@ function set_charge_drift_model!(sim::Simulation{T}, charge_drift_model::Abstrac
     nothing
 end
 
-function apply_charge_drift_model!(sim::Simulation{T};
-            use_nthreads::Int = Base.Threads.nthreads())::Nothing where {T <: SSDFloat}
+function calculate_drift_fields!(sim::Simulation{T};
+    use_nthreads::Int = Base.Threads.nthreads())::Nothing where {T <: SSDFloat}
     sim.electron_drift_field = ElectricField(get_electron_drift_field(sim.electric_field.data, sim.charge_drift_model, use_nthreads = use_nthreads), sim.electric_field.grid)
     sim.hole_drift_field = ElectricField(get_hole_drift_field(sim.electric_field.data, sim.charge_drift_model, use_nthreads = use_nthreads), sim.electric_field.grid)
     nothing
 end
+@deprecate apply_charge_drift_model!(args...; kwargs...) calculate_drift_fields!(args...; kwargs...)
 
 function get_interpolated_drift_field(ef::ElectricField)
     get_interpolated_drift_field(ef.data, ef.grid)
@@ -690,7 +691,7 @@ function simulate!(sim::Simulation{T};  max_refinements::Int = 1, verbose::Bool 
     end
     calculate_electric_field!(sim)
     set_charge_drift_model!(sim, sim.charge_drift_model)
-    apply_charge_drift_model!(sim)
+    calculate_drift_fields!(sim)
     @info "Detector simulation done"
 end
 

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -31,7 +31,7 @@ function Simulation{T}() where {T <: SSDFloat}
         missing,
         [missing],
         missing,
-        VacuumChargeDriftModel{T}(),
+        ElectricFieldChargeDriftModel{T}(),
         missing,
         missing
     )

--- a/src/SolidStateDetectors.jl
+++ b/src/SolidStateDetectors.jl
@@ -48,7 +48,7 @@ export update_till_convergence!, refine!
 export set_charge_drift_model!, calculate_drift_fields!
 export get_active_volume
 export generate_charge_signals, generate_charge_signals!
-export VacuumChargeDriftModel, ADLChargeDriftModel
+export ElectricFieldChargeDriftModel, ADLChargeDriftModel
 export Simulation, simulate!
 export Event, drift_charges!
 

--- a/src/SolidStateDetectors.jl
+++ b/src/SolidStateDetectors.jl
@@ -45,7 +45,7 @@ export ElectricPotential, PointTypes, ChargeDensity, DielectricDistribution, Wei
 export apply_initial_state!
 export calculate_electric_potential!, calculate_weighting_potential!, calculate_electric_field!
 export update_till_convergence!, refine!
-export set_charge_drift_model!, apply_charge_drift_model!
+export set_charge_drift_model!, calculate_drift_fields!
 export get_active_volume
 export generate_charge_signals, generate_charge_signals!
 export VacuumChargeDriftModel, ADLChargeDriftModel

--- a/test/test_script.jl
+++ b/test/test_script.jl
@@ -106,7 +106,7 @@ for key in  [:InvertedCoax, :BEGe, :Coax, :CGD, :Spherical]
 
     set_charge_drift_model!(simulation, ADLChargeDriftModel())
 
-    apply_charge_drift_model!(simulation)
+    calculate_drift_fields!(simulation)
 
     pos = if key == :InvertedCoax
         CylindricalPoint{T}[ CylindricalPoint{T}( 0.02, deg2rad(10), 0.025 ) ]


### PR DESCRIPTION
Thanks to @fhagemann and @mguitart we realised that the name `VacuumChargeDriftModel` is actually not correct
since in vacuum charges are accelerated by the electric field and have no limit (except the speed of light...).

So I renamed it to `ElectricFieldChargeDriftModel` since it just takes the electric field vectors as velocity vectors. 
Another option might be `UnityChargeDriftModel`. 

Any opinions?

I also renamed the function `apply_charge_drift_model!` to `calculate_drift_field!` since we also use `calculate_electric_potential!` and `calculate_electric_field!`. `apply_charge_drift_model!` still works, but a deprecation warning is thrown. 