### PR TITLE
Minor fixes

### DIFF
--- a/src/ChargeDrift/ChargeDrift.jl
+++ b/src/ChargeDrift/ChargeDrift.jl
@@ -10,22 +10,22 @@ struct EHDriftPath{T <: SSDFloat, TT <: RealQuantity}
     timestamps_h::Vector{TT}
 end
 
-_common_length(dp::EHDriftPath{T} where {T <: SSDFloat})::Int = 
+_common_length(dp::EHDriftPath{T} where {T <: SSDFloat})::Int =
     max(length(dp.timestamps_e), length(dp.timestamps_h))
-_common_length(dps::Vector{EHDriftPath{T}} where {T <: SSDFloat})::Int = 
+_common_length(dps::Vector{EHDriftPath{T}} where {T <: SSDFloat})::Int =
     maximum(_common_length.(dps))
 
-function _common_time(dp::EHDriftPath{T, TT})::TT where {T <: SSDFloat, TT<:RealQuantity}  
+function _common_time(dp::EHDriftPath{T, TT})::TT where {T <: SSDFloat, TT<:RealQuantity}
     max(last(dp.timestamps_e), last(dp.timestamps_h))
 end
-_common_time(dps::Vector{<:EHDriftPath}) = 
+_common_time(dps::Vector{<:EHDriftPath}) =
 maximum(_common_time.(dps))
 
-function _common_timestamps(dp::Union{<:EHDriftPath{T}, Vector{<:EHDriftPath{T}}}, Δt) where {T} 
+function _common_timestamps(dp::Union{<:EHDriftPath{T}, Vector{<:EHDriftPath{T}}}, Δt) where {T}
     range(zero(Δt), step = Δt, stop = typeof(Δt)(_common_time(dp)) + Δt)
 end
 
-function get_velocity_vector(interpolation_field::Interpolations.Extrapolation{<:StaticVector{3}, 3}, point::CartesianPoint{T})::CartesianVector{T} where {T <: SSDFloat}  
+function get_velocity_vector(interpolation_field::Interpolations.Extrapolation{<:StaticVector{3}, 3}, point::CartesianPoint{T})::CartesianVector{T} where {T <: SSDFloat}
     return CartesianVector{T}(interpolation_field(point.x, point.y, point.z))
 end
 
@@ -35,12 +35,12 @@ end
 
 
 function _drift_charges(detector::SolidStateDetector{T}, grid::Grid{T, 3}, point_types::PointTypes{T, 3},
-                        starting_points::Vector{CartesianPoint{T}}, 
+                        starting_points::Vector{CartesianPoint{T}},
                         velocity_field_e::Interpolations.Extrapolation{<:SVector{3}, 3},
                         velocity_field_h::Interpolations.Extrapolation{<:SVector{3}, 3},
                         Δt::RQ; max_nsteps::Int = 2000, verbose::Bool = true)::Vector{EHDriftPath{T}} where {T <: SSDFloat, RQ <: RealQuantity}
 
-    drift_paths::Vector{EHDriftPath{T}} = Vector{EHDriftPath{T}}(undef, length(starting_points)) 
+    drift_paths::Vector{EHDriftPath{T}} = Vector{EHDriftPath{T}}(undef, length(starting_points))
 
     dt::T = T(to_internal_units(internal_time_unit, Δt))
 
@@ -54,11 +54,11 @@ function _drift_charges(detector::SolidStateDetector{T}, grid::Grid{T, 3}, point
         drift_paths[i] = EHDriftPath{T, T}( drift_path_e[1:n_e], drift_path_h[1:n_h], timestamps_e[1:n_e], timestamps_h[1:n_h] )
     end
 
-    return drift_paths 
+    return drift_paths
 end
 
 function _drift_charge( detector::SolidStateDetector{T}, grid::Grid{T, 3}, point_types::PointTypes{T, 3},
-                       starting_point::CartesianPoint{<:SSDFloat}, 
+                       starting_point::CartesianPoint{<:SSDFloat},
                        velocity_field_e::Interpolations.Extrapolation{SVector{3, T}, 3},
                        velocity_field_h::Interpolations.Extrapolation{SVector{3, T}, 3},
                        Δt::RealQuantity, max_nsteps::Int = 2000, verbose::Bool = true)::Vector{EHDriftPath{T}} where {T <: SSDFloat}
@@ -75,23 +75,23 @@ end
 function modulate_driftvector(sv::CartesianVector{T}, cp::CartesianPoint{T}, vdv::Vector{AbstractVirtualVolume{T}})::CartesianVector{T} where {T <: SSDFloat}
     for i in eachindex(vdv)
         if in(cp, vdv[i])
-            return modulate_driftvector(sv, cp, vdv[i]) 
+            return modulate_driftvector(sv, cp, vdv[i])
         end
     end
     return sv
 end
 
 @inline function _is_next_point_in_det(pt_car::CartesianPoint{T}, pt_cyl::CylindricalPoint{T}, det::SolidStateDetector{T, :cylindrical}, point_types::PointTypes{T, 3, :cylindrical})::Bool where {T <: SSDFloat}
-    pt_cyl in point_types || pt_cyl in det 
+    pt_cyl in point_types || pt_cyl in det
 end
 @inline function _is_next_point_in_det(pt_car::CartesianPoint{T}, pt_cyl::CylindricalPoint{T}, det::SolidStateDetector{T, :cartesian}, point_types::PointTypes{T, 3, :cartesian})::Bool where {T <: SSDFloat}
-    pt_car in point_types || pt_car in det 
+    pt_car in point_types || pt_car in det
 end
 
 """
-    _drift_charge(...)
+    _drift_charge!(...)
 
-Before calling this function one should check that `startpos` is inside `det`: `in(startpos, det`
+Before calling this function one should check that `startpos` is inside `det`: `in(startpos, det)`
 """
 function _drift_charge!(
                             drift_path::Vector{CartesianPoint{T}},
@@ -110,15 +110,15 @@ function _drift_charge!(
     timestamps[1] = zero(T)
     null_step::CartesianVector{T} = CartesianVector{T}(0, 0, 0)
     last_real_step_index::Int = 1
-    @inbounds for istep in eachindex(drift_path)[2:end] 
+    @inbounds for istep in eachindex(drift_path)[2:end]
         if done == false
             last_real_step_index += 1
             current_pos::CartesianPoint{T} = drift_path[istep - 1]
             stepvector::CartesianVector{T} = get_velocity_vector(velocity_field, _convert_vector(current_pos, Val(S))) * Δt
             stepvector = modulate_driftvector(stepvector, current_pos, det.virtual_drift_volumes)
-            if geom_round.(stepvector) == null_step 
-                done = true 
-            end 
+            if geom_round.(stepvector) == null_step
+                done = true
+            end
             next_pos::CartesianPoint{T} = current_pos + stepvector
             next_pos_cyl::CylindricalPoint{T} = CylindricalPoint(next_pos)
             if _is_next_point_in_det(next_pos, next_pos_cyl, det, point_types)
@@ -139,7 +139,7 @@ function _drift_charge!(
                     # ToDo: We actually need a time array as well to do this properly...
                     small_projected_vector = projected_vector * T(0.001)
                     i::Int = 0
-                    while i < 1000 && !(next_pos in det) 
+                    while i < 1000 && !(next_pos in det)
                         next_pos -= small_projected_vector
                         i += 1
                     end
@@ -156,7 +156,7 @@ function _drift_charge!(
                     drifttime += Δt
                     timestamps[istep] = drifttime
                     done = true
-                else # elseif cd_point_type == CD_OUTSIDE      
+                else # elseif cd_point_type == CD_OUTSIDE
                     if verbose @warn ("Internal error for charge starting at $startpos") end
                     drift_path[istep] = current_pos
                     drifttime += Δt
@@ -183,7 +183,7 @@ end
 # const CD_BULK = 0x02
 # const CD_FLOATING_BOUNDARY = 0x04 # not 0x03, so that one could use bit operations here...
 
-function get_crossing_pos(  detector::SolidStateDetector{T, S}, grid::Grid{T, 3}, point_in::CartesianPoint{T}, point_out::CartesianPoint{T}; 
+function get_crossing_pos(  detector::SolidStateDetector{T, S}, grid::Grid{T, 3}, point_in::CartesianPoint{T}, point_out::CartesianPoint{T};
                             max_n_iter::Int = 500)::Tuple{CartesianPoint{T}, UInt8, Int, CartesianVector{T}} where {T <: SSDFloat, S}
     point_mid::CartesianPoint{T} = T(0.5) * (point_in + point_out)
     cd_point_type::UInt8, contact_idx::Int, surface_normal::CartesianVector{T} = point_type(detector, grid, _convert_vector(point_mid, Val(S)))

--- a/src/Event/Event.jl
+++ b/src/Event/Event.jl
@@ -2,9 +2,9 @@
     mutable struct Event{T <: SSDFloat}
 
 Collection struct for individual events. This (mutable) struct is ment to be used to look at individual events,
-not to process a hugh amount of events.
+not to process a huge amount of events.
 """
-mutable struct Event{T <: SSDFloat} 
+mutable struct Event{T <: SSDFloat}
     locations::Union{Vector{<:AbstractCoordinatePoint{T}}, Missing}
     energies::Union{Vector{T}, Missing}
     drift_paths::Union{Vector{EHDriftPath{T}}, Missing}
@@ -30,7 +30,7 @@ function Event(evt::NamedTuple{(:evtno, :detno, :thit, :edep, :pos),
         }}, T = missing)
     if ismissing(T) T = eltype(to_internal_units(internal_energy_unit, evt[:edep][:])) end
 
-    event = Event( 
+    event = Event(
         CartesianPoint{T}.(to_internal_units.(internal_length_unit, evt[:pos][:])),
         T.(to_internal_units.(internal_energy_unit, evt[:edep][:]))
     )
@@ -47,16 +47,16 @@ function drift_charges!(event::Event{T}, sim::Simulation{T}; max_nsteps::Int = 1
     nothing
 end
 function get_signal!(event::Event{T}, sim::Simulation{T}, contact_id::Int; Δt::RealQuantity = 5u"ns")::Nothing where {T <: SSDFloat}
-    @assert !ismissing(event.drift_paths) "No drit path for this event. Use `drift_charges(event::Event, sim::Simulation` first."
-    @assert !ismissing(sim.weighting_potentials[contact_id]) "No weighting potential for contact $(contact_id). Use `calculate_weighting_potential!(sim, contact_id)` first."
+    @assert !ismissing(event.drift_paths) "No drift path for this event. Use `drift_charges(event::Event, sim::Simulation)` first."
+    @assert !ismissing(sim.weighting_potentials[contact_id]) "No weighting potential for contact $(contact_id). Use `calculate_weighting_potential!(sim::Simulation, contact_id::Int)` first."
     if ismissing(event.waveforms)
         event.waveforms = Union{Missing, RadiationDetectorSignals.RDWaveform}[missing for i in eachindex(sim.detector.contacts)]
     end
-    event.waveforms[contact_id] = get_signal(sim, event.drift_paths, event.energies, contact_id)
+    event.waveforms[contact_id] = get_signal(sim, event.drift_paths, event.energies, contact_id, Δt = Δt)
     nothing
 end
 function get_signals!(event::Event{T}, sim::Simulation{T}; Δt::RealQuantity = 5u"ns")::Nothing where {T <: SSDFloat}
-    @assert !ismissing(event.drift_paths) "No drit path for this event. Use `drift_charges(event::Event, sim::Simulation` first."
+    @assert !ismissing(event.drift_paths) "No drift path for this event. Use `drift_charges(event::Event, sim::Simulation)` first."
     if ismissing(event.waveforms)
         event.waveforms = Union{Missing, RadiationDetectorSignals.RDWaveform}[missing for i in eachindex(sim.detector.contacts)]
     end

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -6,17 +6,17 @@ abstract type AbstractGrid{T, N} <: AbstractArray{T, N} end
     S: System (Cartesian, Cylindrical...)
 """
 struct Grid{T, N, S} <: AbstractGrid{T, N}
-    axes::NTuple{N, DiscreteAxis{T, BL, BR, I} where {BL, BR, I}} 
+    axes::NTuple{N, DiscreteAxis{T, BL, BR, I} where {BL, BR, I}}
 end
 
-const CartesianGrid{T, N} = Grid{T, N, :cartesian} 
+const CartesianGrid{T, N} = Grid{T, N, :cartesian}
 const CartesianGrid1D{T} = CartesianGrid{T, 1}
 const CartesianGrid2D{T} = CartesianGrid{T, 2}
 const CartesianGrid3D{T} = CartesianGrid{T, 3}
-const RadialGrid{T} = Grid{T, 1, :Radial} 
-const PolarGrid{T} = Grid{T, 2, :Polar} 
-const CylindricalGrid{T} = Grid{T, 3, :cylindrical} 
-const SphericalGrid{T} = Grid{T, 3, :Spherical} 
+const RadialGrid{T} = Grid{T, 1, :Radial}
+const PolarGrid{T} = Grid{T, 2, :Polar}
+const CylindricalGrid{T} = Grid{T, 3, :cylindrical}
+const SphericalGrid{T} = Grid{T, 3, :Spherical}
 
 @inline size(g::Grid{T, N, S}) where {T, N, S} = size.(g.axes, 1)
 @inline length(g::Grid{T, N, S}) where {T, N, S} = prod(size(g))
@@ -82,14 +82,14 @@ end
 
 function check_grid(grid::CylindricalGrid{T})::Nothing where {T}
     nr::Int, nφ::Int, nz::Int = size(grid)
-    @assert iseven(nz) "GridError: Field simulation algorithm in cylindrical coordinates need an even number of grid points in z. This is not the case. #z-ticks = $(nz)."
-    @assert (iseven(nφ) || (nφ == 1)) "GridError: Field simulation algorithm in cylindrical coordinates need an even number of grid points in φ or just one point (2D). This is not the case. #φ-ticks = $(nφ)."
+    @assert iseven(nz) "GridError: Field simulation algorithm in cylindrical coordinates needs an even number of grid points in z. This is not the case. #z-ticks = $(nz)."
+    @assert (iseven(nφ) || (nφ == 1)) "GridError: Field simulation algorithm in cylindrical coordinates needs an even number of grid points in φ or just one point (2D). This is not the case. #φ-ticks = $(nφ)."
     return nothing
 end
 
 function check_grid(grid::CartesianGrid3D{T})::Nothing where {T}
     nx::Int, ny::Int, nz::Int = size(grid)
-    @assert iseven(nx) "GridError: Field simulation algorithm in cartesian coordinates need an even number of grid points in x. This is not the case. #x-ticks = $(nx)."
+    @assert iseven(nx) "GridError: Field simulation algorithm in cartesian coordinates needs an even number of grid points in x. This is not the case. #x-ticks = $(nx)."
     return nothing
 end
 
@@ -122,7 +122,7 @@ function eltype(grid::Grid{T, N, S})::DataType where {T, N, S}
 end
 
 function get_boundary_types(grid::Grid{T, N, S}) where {T, N, S}
-   return get_boundary_types.(grid.axes) 
+   return get_boundary_types.(grid.axes)
 end
 
 
@@ -176,4 +176,3 @@ function NamedTuple(grid::Grid{T, 3, :cartesian}) where {T}
 end
 
 Base.convert(T::Type{NamedTuple}, x::Grid) = T(x)
-

--- a/src/PotentialSimulation/PotentialSimulationSetups/plot_recipes.jl
+++ b/src/PotentialSimulation/PotentialSimulationSetups/plot_recipes.jl
@@ -1,11 +1,11 @@
 
 @recipe function f( pss::PotentialSimulationSetup{T, 3, :cylindrical};
                     r = missing,
-                    φ = 0,
+                    φ = missing,
                     z = missing,
                     n_points_in_φ = 36 ) where {T}
     g::Grid{T, 3, :cylindrical} = pss.grid
-    layout --> (2, 2) 
+    layout --> (2, 2)
 
     cross_section::Symbol, idx::Int = if ismissing(φ) && ismissing(r) && ismissing(z)
         :φ, 1
@@ -28,7 +28,7 @@
     end
     value::T = if cross_section == :φ
         g.φ[idx]
-    elseif cross_section == :r    
+    elseif cross_section == :r
         g.r[idx]
     elseif cross_section == :z
         g.z[idx]
@@ -63,10 +63,10 @@ end
 
 @recipe function f( pss::PotentialSimulationSetup{T, 3, :cartesian};
                     x = missing,
-                    y = 0,
+                    y = missing,
                     z = missing ) where {T}
     g::Grid{T, 3, :cartesian} = pss.grid
-    layout --> (2, 2) 
+    layout --> (2, 2)
 
     size --> (1000, 1000)
 


### PR DESCRIPTION
This pull request deals with minor fixes:
- `get_signal!`, generating the waveforms for a single detector contact, now considers the passed `Δt`.
- plot recipe of the `PotentialSimulationSetup`: the default values for the keyword arguments `φ` and `y` have been changed from `0` to  `missing`. This is needed for the [following **if**-statements](/JuliaPhysics/SolidStateDetectors.jl/blob/master/src/PotentialSimulation/PotentialSimulationSetups/plot_recipes.jl) to work.
- fixed minor typos