### PR TITLE
Fix radial charge density gradients in cartesian space

### DIFF
--- a/src/Geometries/Points.jl
+++ b/src/Geometries/Points.jl
@@ -25,6 +25,14 @@ function CartesianPoint( pt::CylindricalPoint{T} )::CartesianPoint{T} where {T <
     return CartesianPoint{T}(pt.r * cφ, pt.r * sφ, pt.z)
 end
 
+@inline function CylindricalPoint( pt::CylindricalPoint{T} )::CylindricalPoint{T} where {T <: RealQuantity} 
+    pt
+end
+
+@inline function CartesianPoint( pt::CartesianPoint{T} )::CartesianPoint{T} where {T <: RealQuantity}
+    pt
+end
+
 function convert(type::Type{CylindricalPoint}, origin::SolidStateDetectors.CartesianPoint{T})::CylindricalPoint{T} where T
     return CylindricalPoint(origin)
 end

--- a/src/Geometries/VolumePrimitives/plot_recipes.jl
+++ b/src/Geometries/VolumePrimitives/plot_recipes.jl
@@ -52,19 +52,19 @@ function LineSegments(c::Cone{T})::Vector{AbstractLine{T, 3, :cartesian}} where 
     end
     for φ in ((c.φStop - c.φStart ≈ 2π) ? [c.φStart] : [c.φStart, c.φStop])
         push!(ls, LineSegment(
-            CartesianPoint{T}(c.rStart1 * sin(φ), c.rStart1 * cos(φ), c.zStart) + translate,
-            CartesianPoint{T}(c.rStart2 * sin(φ), c.rStart2 * cos(φ), c.zStop) + translate))
+            CartesianPoint{T}(c.rStart1 * cos(φ), c.rStart1 * sin(φ), c.zStart) + translate,
+            CartesianPoint{T}(c.rStart2 * cos(φ), c.rStart2 * sin(φ), c.zStop) + translate))
         push!(ls, LineSegment(
-            CartesianPoint{T}(c.rStop1 * sin(φ), c.rStop1 * cos(φ), c.zStart) + translate,
-            CartesianPoint{T}(c.rStop2 * sin(φ), c.rStop2 * cos(φ), c.zStop) + translate))
+            CartesianPoint{T}(c.rStop1 * cos(φ), c.rStop1 * sin(φ), c.zStart) + translate,
+            CartesianPoint{T}(c.rStop2 * cos(φ), c.rStop2 * sin(φ), c.zStop) + translate))
     end
     for φ in ((c.φStop - c.φStart ≈ 2π) ? [c.φStart] : [c.φStart, c.φStop])
         push!(ls, LineSegment(
-            CartesianPoint{T}(c.rStart1 * sin(φ),  c.rStart1 * cos(φ),  c.zStart) + translate,
-            CartesianPoint{T}(c.rStop1 * sin(φ),   c.rStop1 * cos(φ), c.zStart) + translate))
+            CartesianPoint{T}(c.rStart1 * cos(φ),  c.rStart1 * sin(φ),  c.zStart) + translate,
+            CartesianPoint{T}(c.rStop1 * cos(φ),   c.rStop1 * sin(φ), c.zStart) + translate))
         push!(ls, LineSegment(
-            CartesianPoint{T}(c.rStart2 * sin(φ),  c.rStart2 * cos(φ),  c.zStop) + translate,
-            CartesianPoint{T}(c.rStop2 * sin(φ),   c.rStop2 * cos(φ), c.zStop) + translate))
+            CartesianPoint{T}(c.rStart2 * cos(φ),  c.rStart2 * sin(φ),  c.zStop) + translate,
+            CartesianPoint{T}(c.rStop2 * cos(φ),   c.rStop2 * sin(φ), c.zStop) + translate))
     end
     return ls
 end

--- a/src/PotentialSimulation/plot_recipes.jl
+++ b/src/PotentialSimulation/plot_recipes.jl
@@ -43,7 +43,7 @@ end
     seriescolor --> :viridis
     title --> "Electric Potential @ $(cross_section) = $(round(value,sigdigits=2))"*(cross_section == :φ ? "°" : "m")
 
-    ep, g, cross_section, idx, value
+    ep, cross_section, idx, value
 end
 
 
@@ -60,7 +60,7 @@ end
     clims --> (0,1)
     title --> "Weighting Potential @ $(cross_section) = $(round(value,sigdigits=2))"*(cross_section == :φ ? "°" : "m")
 
-    wp, g, cross_section, idx, value
+    wp, cross_section, idx, value
 end
 
 
@@ -76,7 +76,7 @@ end
     seriescolor --> :inferno
     title --> "Effective Charge Density @ $(cross_section) = $(round(value,sigdigits=2))"*(cross_section == :φ ? "°" : "m")
 
-    ρ, g, cross_section, idx, value
+    ρ, cross_section, idx, value
 end
 
 
@@ -93,11 +93,11 @@ end
     clims --> (0,7)
     title --> "Point Type Map @ $(cross_section) = $(round(value,sigdigits=2))"*(cross_section == :φ ? "°" : "m")
 
-    pt, g, cross_section, idx, value
+    pt, cross_section, idx, value
 end
 
 
-@recipe function f(sp::ScalarPotential{T,3,:cylindrical}, g::Grid{T, 3, :cylindrical}, cross_section::Symbol, idx::Int, value::T) where {T}
+@recipe function f(sp::ScalarPotential{T,3,:cylindrical}, cross_section::Symbol, idx::Int, value::T) where {T}
 
     g::Grid{T, 3, :cylindrical} = sp.grid
     
@@ -164,6 +164,161 @@ end
         elseif cross_section == :z
             projection --> :polar
             rad2deg_backend.(gφ_ext), gr_ext, ϵ.data[:,:,idx]
+        end
+    end
+end
+
+
+
+function get_crosssection_idx_and_value(g::Grid{T, 3, :cartesian}, x, y, z)::Tuple{Symbol,Int,T} where {T <: SSDFloat}
+
+    cross_section::Symbol, idx::Int = if ismissing(x) && ismissing(y) && ismissing(z)
+        :y, 1
+    elseif !ismissing(x) && ismissing(y) && ismissing(z)
+        :x, searchsortednearest(g.x, T(x))
+    elseif ismissing(x) && !ismissing(y) && ismissing(z)
+        :y, searchsortednearest(g.y, T(y))
+    elseif ismissing(x) && ismissing(y) && !ismissing(z)
+        :z, searchsortednearest(g.z, T(z))
+    else
+        error(ArgumentError, ": Only one of the keywords `x, y, z` is allowed.")
+    end
+    value::T = g[cross_section][idx]
+    cross_section, idx, value
+end
+
+@recipe function f(ep::ElectricPotential{T,3,:cartesian}; x = missing, y = missing, z = missing) where {T <: SSDFloat}
+
+    g::Grid{T, 3, :cartesian} = ep.grid
+    cross_section::Symbol, idx::Int, value::T = get_crosssection_idx_and_value(g, x, y, z)
+
+    seriescolor --> :viridis
+    title --> "Electric Potential @ $(cross_section) = $(round(value,sigdigits=2))m"
+
+    ep, cross_section, idx, value
+end
+
+@recipe function f(wp::WeightingPotential{T,3,:cartesian}; x = missing, y = missing, z = missing) where {T <: SSDFloat}
+
+    g::Grid{T, 3, :cartesian} = wp.grid
+    cross_section::Symbol, idx::Int, value::T = get_crosssection_idx_and_value(g, x, y, z)
+
+    seriescolor --> :viridis
+    clims --> (0,1)
+    title --> "Weighting Potential @ $(cross_section) = $(round(value,sigdigits=2))m"
+
+    wp, cross_section, idx, value
+end
+
+
+@recipe function f(ρ::ChargeDensity{T,3,:cartesian}; x = missing, y = missing, z = missing) where {T <: SSDFloat}
+
+    g::Grid{T, 3, :cartesian} = ρ.grid
+    cross_section::Symbol, idx::Int, value::T = get_crosssection_idx_and_value(g, x, y, z)
+
+    seriescolor --> :inferno
+    title --> "Effective Charge Density @ $(cross_section) = $(round(value,sigdigits=2))m"
+
+    ρ, cross_section, idx, value
+end
+
+
+@recipe function f(pt::PointTypes{T,3,:cartesian}; x = missing, y = missing, z = missing) where {T <: SSDFloat}
+
+    g::Grid{T, 3, :cartesian} = pt.grid
+    cross_section::Symbol, idx::Int, value::T = get_crosssection_idx_and_value(g, x, y, z)
+
+    seriescolor --> :viridis
+    clims --> (0,7)
+    title --> "Point Type Map @ $(cross_section) = $(round(value,sigdigits=2))m"
+
+    pt, cross_section, idx, value
+end
+
+
+@recipe function f(sp::ScalarPotential{T,3,:cartesian}, cross_section::Symbol, idx::Int, value::T) where {T}
+
+    g::Grid{T, 3, :cartesian} = sp.grid
+    
+    if minimum(sp.data) == maximum(sp.data)
+        #@info "Set colorbar to display heatmap with non uniform axes"
+        clims --> (sp.data[1], sp.data[1]+1)
+    end
+        
+
+    @series begin
+        seriestype := :heatmap
+        foreground_color_border --> nothing
+        tick_direction --> :out
+        if cross_section == :x
+            aspect_ratio --> 1
+            xguide --> "y / m"
+            yguide --> "z / m"
+            xlims --> (g.y[1],g.y[end])
+            ylims --> (g.z[1],g.z[end])
+            gy_ext = midpoints(get_extended_ticks(g.y))
+            gz_ext = midpoints(get_extended_ticks(g.z))
+            midpoints(gy_ext), midpoints(gz_ext), sp.data[idx,:,:]'
+        elseif cross_section == :y
+            aspect_ratio --> 1
+            xguide --> "x / m"
+            yguide --> "z / m"
+            xlims --> (g.x[1],g.x[end])
+            ylims --> (g.z[1],g.z[end])
+            gx_ext = midpoints(get_extended_ticks(g.x))
+            gz_ext = midpoints(get_extended_ticks(g.z))
+            midpoints(gx_ext), midpoints(gz_ext), sp.data[:,idx,:]'
+        elseif cross_section == :z
+            aspect_ratio --> 1
+            xguide --> "x / m"
+            yguide --> "y / m"
+            xlims --> (g.x[1],g.x[end])
+            ylims --> (g.y[1],g.y[end])
+            gx_ext = midpoints(get_extended_ticks(g.x))
+            gy_ext = midpoints(get_extended_ticks(g.y))
+            midpoints(gx_ext), midpoints(gy_ext), sp.data[:,:,idx]'
+        end
+    end
+end
+
+
+@recipe function f(ϵ::DielectricDistribution{T,3,:cartesian}; x = missing, y = missing, z = missing) where {T <: SSDFloat}
+
+    g::Grid{T, 3, :cartesian} = ϵ.grid
+    cross_section::Symbol, idx::Int, value::T = get_crosssection_idx_and_value(g, x, y, z)
+
+    seriestype --> :heatmap
+    seriescolor --> :inferno
+    foreground_color_border --> nothing
+    tick_direction --> :out
+    title --> "Dielectric Distribution @ $(cross_section) = $(round(value,sigdigits=2))m"
+
+    gx_ext::Array{T,1} = midpoints(get_extended_ticks(g.x))
+    gy_ext::Array{T,1} = midpoints(get_extended_ticks(g.y))
+    gz_ext::Array{T,1} = midpoints(get_extended_ticks(g.z))
+
+    @series begin
+        if cross_section == :x
+            aspect_ratio --> 1
+            xguide --> "y / m"
+            yguide --> "z / m"
+            xlims --> (g.y[1],g.y[end])
+            ylims --> (g.z[1],g.z[end])
+            gy_ext, gz_ext, ϵ.data[idx,:,:]'
+        elseif cross_section == :y
+            aspect_ratio --> 1
+            xguide --> "x / m"
+            yguide --> "z / m"
+            xlims --> (g.x[1],g.x[end])
+            ylims --> (g.z[1],g.z[end])
+            gx_ext, gz_ext, ϵ.data[:,idx,:]'
+        elseif cross_section == :z
+            aspect_ratio --> 1
+            xguide --> "x / m"
+            yguide --> "y / m"
+            xlims --> (g.x[1],g.x[end])
+            ylims --> (g.y[1],g.y[end])
+            gx_ext, gy_ext, ϵ.data[:,:,idx]'
         end
     end
 end

--- a/src/PotentialSimulation/plot_recipes.jl
+++ b/src/PotentialSimulation/plot_recipes.jl
@@ -101,11 +101,6 @@ end
 
     g::Grid{T, 3, :cylindrical} = sp.grid
     
-    if minimum(sp.data) == maximum(sp.data)
-        #@info "Set colorbar to display heatmap with non uniform axes"
-        clims --> (sp.data[1], sp.data[1]+1)
-    end
-    
     @series begin
         seriestype := :heatmap
         foreground_color_border --> nothing
@@ -240,12 +235,6 @@ end
 
     g::Grid{T, 3, :cartesian} = sp.grid
     
-    if minimum(sp.data) == maximum(sp.data)
-        #@info "Set colorbar to display heatmap with non uniform axes"
-        clims --> (sp.data[1], sp.data[1]+1)
-    end
-        
-
     @series begin
         seriestype := :heatmap
         foreground_color_border --> nothing


### PR DESCRIPTION
This pull request is a follow-up to #80 to fix #75.

A new field to the `LinearChargeDensityModel` was added, `CS`, which saves the coordinate system of the gradient. This should be either `:cartesian` or `:cylindrical`. In the detector config file, the coordinate system is determined from the coordinates that define the charge density.

If only `r` (and `z`) are given, it is assumed to be a `:cylindrical` geometry, whereas if `x` or `y` are passed, a `:cartesian` geometry is assumed. If both `r` and either `x` or `y` are passed, this results in an `ErrorException` which asks to adjust the config file.

This might add a conversion of `CylindricalPoint` to `CartesianPoint` and vice versa. Regarding the fact that we want to refactor the update step of the boundary conditions and pass both the `CylindricalPoint` and `CartesianPoint` to the functions, this might be easily incorporated then.

Do not merge before #80 is merged!
