### PR TITLE
Remove setting the clims in plot recipes manually (Plots v1.7.4)

### DIFF
--- a/src/PotentialSimulation/plot_recipes.jl
+++ b/src/PotentialSimulation/plot_recipes.jl
@@ -110,17 +110,14 @@ end
             ylims --> (g.z[1],g.z[end])
             gr_ext::Array{T,1} = midpoints(get_extended_ticks(g.r))
             gz_ext::Array{T,1} = midpoints(get_extended_ticks(g.z))
-            if minimum(sp.data[:,idx,:]) == maximum(sp.data[:,idx,:]) clims --> (sp.data[1,idx,1], sp.data[1,idx,1]+1) end #remove with Plots v1.7.4
             midpoints(gr_ext), midpoints(gz_ext), sp.data[:,idx,:]'
         elseif cross_section == :r
             xguide --> "φ / °"
             yguide --> "z / m"
             ylims --> (g.z[1],g.z[end])
-            if minimum(sp.data[idx,:,:]) == maximum(sp.data[idx,:,:]) clims --> (sp.data[idx,1,1], sp.data[idx,1,1]+1) end #remove with Plots v1.7.4
             g.φ, g.z, sp.data[idx,:,:]'
         elseif cross_section == :z
             projection --> :polar
-            if minimum(sp.data[:,:,idx]) == maximum(sp.data[:,:,idx]) clims --> (sp.data[1,1,idx], sp.data[1,1,idx]+1) end #remove with Plots v1.7.4
             g.φ, g.r, sp.data[:,:,idx]
         end
     end
@@ -268,7 +265,6 @@ end
             ylims --> (g.z[1],g.z[end])
             gy_ext = midpoints(get_extended_ticks(g.y))
             gz_ext = midpoints(get_extended_ticks(g.z))
-            if minimum(sp.data[idx,:,:]) == maximum(sp.data[idx,:,:]) clims --> (sp.data[idx,1,1], sp.data[idx,1,1]+1) end #remove with Plots v1.7.4
             midpoints(gy_ext), midpoints(gz_ext), sp.data[idx,:,:]'
         elseif cross_section == :y
             aspect_ratio --> 1
@@ -278,7 +274,6 @@ end
             ylims --> (g.z[1],g.z[end])
             gx_ext = midpoints(get_extended_ticks(g.x))
             gz_ext = midpoints(get_extended_ticks(g.z))
-            if minimum(sp.data[:,idx,:]) == maximum(sp.data[:,idx,:]) clims --> (sp.data[1,idx,1], sp.data[1,idx,1]+1) end #remove with Plots v1.7.4
             midpoints(gx_ext), midpoints(gz_ext), sp.data[:,idx,:]'
         elseif cross_section == :z
             aspect_ratio --> 1
@@ -288,7 +283,6 @@ end
             ylims --> (g.y[1],g.y[end])
             gx_ext = midpoints(get_extended_ticks(g.x))
             gy_ext = midpoints(get_extended_ticks(g.y))
-            if minimum(sp.data[:,:,idx]) == maximum(sp.data[:,:,idx]) clims --> (sp.data[1,1,idx], sp.data[1,1,idx]+1) end #remove with Plots v1.7.4
             midpoints(gx_ext), midpoints(gy_ext), sp.data[:,:,idx]'
         end
     end

--- a/src/SolidStateDetector/DetectorGeometries.jl
+++ b/src/SolidStateDetector/DetectorGeometries.jl
@@ -417,13 +417,6 @@ function json_to_dict(inputfile::String)::Dict
     end
     return parsed_json_file
 end
-function bounding_box(d::SolidStateDetector{T})::NamedTuple where T
-    (
-    r_range = ClosedInterval{T}(0.0,d.crystal_radius),
-    φ_range = ClosedInterval{T}(0.0,2π),
-    z_range = ClosedInterval{T}(0.0,d.crystal_length)
-    )
-end
 
 function Grid(  detector::SolidStateDetector{T, :cylindrical};
                 init_grid_size::Union{Missing, NTuple{3, Int}} = missing,


### PR DESCRIPTION
This is a follow up to #80. 

So far, `clims` of the `ScalarPotential` are set manually to prevent no plot showing up if all entries of the heatmap are identical.
This was [fixed](https://github.com/JuliaPlots/Plots.jl/pull/3097) and is part of the master branch, but it is not released so far.

If Plots v1.7.4 is released, this pull request will remove the line that sets the `clims` manually. 