### PR TITLE
Fix display of non-uniform polar plots in GR

### DIFF
--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -96,15 +96,18 @@ end
 include("RefineGrid.jl")
 
 @recipe function f(grid::Grid{T, N, S}) where {T, N, S}
-    layout --> N
-    st --> :stephist
+    
+    #only plot grid point densities for axes with more than one tick
+    iaxs = findall(ax -> length(ax) > 1, grid.axes)
+    layout --> length(iaxs) 
+    seriestype --> :stephist
     legend --> false
 
-    for iax in 1:N
+    for (i,iax) in enumerate(iaxs)
         @series begin
-            subplot := iax
-            nbins --> div(length(grid[iax]), 2)
-            xlabel --> "Grid point density - Axis $(iax)"
+            subplot := i
+            bins --> div(length(grid[iax]), 2)
+            xguide --> "Grid point density - Axis $(iax)"
             grid[iax]
         end
     end

--- a/src/PotentialSimulation/plot_recipes.jl
+++ b/src/PotentialSimulation/plot_recipes.jl
@@ -47,7 +47,7 @@ end
 end
 
 
-@recipe function f(wp::WeightingPotential{T,3,:cylindrical}; r = missing, φ = missing, z = missing) where {T <: SSDFloat}
+@recipe function f(wp::WeightingPotential{T,3,:cylindrical}; r = missing, φ = missing, z = missing, contours_equal_potential = false) where {T <: SSDFloat}
 
     if !(wp.grid[2][end] - wp.grid[2][1] ≈ 2π)
         wp = get_2π_potential(wp, n_points_in_φ = 72)
@@ -60,7 +60,7 @@ end
     clims --> (0,1)
     title --> "Weighting Potential @ $(cross_section) = $(round(value,sigdigits=2))"*(cross_section == :φ ? "°" : "m")
 
-    wp, cross_section, idx, value
+    wp, cross_section, idx, value, contours_equal_potential
 end
 
 
@@ -227,7 +227,7 @@ end
     ep, cross_section, idx, value, contours_equal_potential
 end
 
-@recipe function f(wp::WeightingPotential{T,3,:cartesian}; x = missing, y = missing, z = missing) where {T <: SSDFloat}
+@recipe function f(wp::WeightingPotential{T,3,:cartesian}; x = missing, y = missing, z = missing, contours_equal_potential = false) where {T <: SSDFloat}
 
     g::Grid{T, 3, :cartesian} = wp.grid
     cross_section::Symbol, idx::Int, value::T = get_crosssection_idx_and_value(g, x, y, z)
@@ -236,7 +236,7 @@ end
     clims --> (0,1)
     title --> "Weighting Potential @ $(cross_section) = $(round(value,sigdigits=2))m"
 
-    wp, cross_section, idx, value
+    wp, cross_section, idx, value, contours_equal_potential
 end
 
 


### PR DESCRIPTION
Due to the adaptive grid, the axes of the grid will almost always not be uniform. This leads to non-uniform polar plots when plotting cross sections in `z` on a cylindrical grid. These plots look fine when using the `pyplot` backend. Here is an example:

![segBEGe_pyplot](https://user-images.githubusercontent.com/30291312/99103255-99035800-25df-11eb-8a29-f813671434c1.png)


However, when using the `gr` backend, non-uniform plots are displayed as if the axes were uniform. Thus, regions with high grid point densities are stretched and regions with low grid point densities are compressed. The same polar plot looks like this in `gr`:

![segBEGe_GR](https://user-images.githubusercontent.com/30291312/99103243-96086780-25df-11eb-9c84-0faa0345086c.png)


Thus, a new keyword, `resample = true` is added. It manually resamples the data array for polar plots in a cylindrical coordinate system. The result from this is comparable to the one from `pyplot`:

![segBEGe_GR_new](https://user-images.githubusercontent.com/30291312/99103238-93a60d80-25df-11eb-97cb-c754ac2967dc.png)


Whenever polar plots are created, an `@info` is displayed that data is resampled and how many points are used for the resampling.
If no resampling is wished, it can be omitted by passing the keyword `resample = true` when calling the `plot()` command.
All of this can be removed, if nonuniform polar plotting is implemented in `GR`.


Minor changes:
    - A `WeightingPotential` can now also be displayed with equipotential lines when called with `contours_equal_potential = true`
    - I have also updated the plot recipes for the `Grid`, as it gave errors when plotting axes with only one tick (two-dimensional configurations).
   

