### PR TITLE
Toroidalprimitive

### DIFF
--- a/examples/coaxial_torus_config.json
+++ b/examples/coaxial_torus_config.json
@@ -1,0 +1,118 @@
+{
+    "name": "Coaxial Torus",
+    "units": {
+        "length": "mm",
+        "angle": "deg",
+        "potential": "V",
+        "temperature": "K"
+    },
+    "grid": {
+        "coordinates": "cylindrical",
+        "axes": {
+            "r": {
+                "to": 20.0,
+                "boundaries": "inf"
+            },
+            "phi": {
+                "from": 0,
+                "to":0,
+                "boundaries": "periodic"
+            },
+            "z": {
+                "from": -10,
+                "to": 10.0,
+                "boundaries": {
+                    "left": "inf",
+                    "right": "inf"
+                }
+            }
+        }
+    },
+    "medium": "vacuum",
+    "objects": [
+        {
+            "type": "semiconductor",
+            "material": "HPGe",
+            "bulk_type": "p",
+            "temperature": 77.0,
+            "charge_density_model": {
+                "name": "linear",
+                "r": {
+                    "init": 0,
+                    "gradient": 0
+                },
+                "phi": {
+                    "init": 0.0,
+                    "gradient": 0.0
+                },
+                "z": {
+                    "init": -1e7,
+                    "gradient": 0.0
+                }
+            },
+            "geometry": {
+                "type": "torus",
+                "c": 10.0,
+                "a": {
+                    "from": 2.0,
+                    "to": 5.0
+                },
+                "phi": {
+                    "from": 0.0,
+                    "to": 360.0
+                },
+                "theta": {
+                    "from": 0.0,
+                    "to": 360.0
+                }
+            }
+        },
+
+        {
+            "name": "p contact",
+            "type": "contact",
+            "material": "HPGe",
+            "channel": 1,
+            "potential": 0.0,
+            "geometry": {
+              "type": "torus",
+              "c": 10.0,
+              "a": {
+                  "from": 2.0,
+                  "to": 2.0
+              },
+              "phi": {
+                  "from": 0.0,
+                  "to": 360.0
+              },
+              "theta": {
+                  "from": 0,
+                  "to": 360.0
+              }
+            }
+        },
+        {
+            "name": "n contact",
+            "type": "contact",
+            "material": "HPGe",
+            "channel": 2,
+            "potential": 100.0,
+            "geometry": {
+              "type": "torus",
+              "c": 10.0,
+              "a": {
+                  "from": 5.0,
+                  "to": 5.0
+              },
+              "phi": {
+                  "from": 0.0,
+                  "to": 360.0
+              },
+              "theta": {
+                  "from": 0.0,
+                  "to": 360.0
+              }
+            }
+        }
+    ]
+}

--- a/examples/example_detector_config_files/coaxial_torus_config.json
+++ b/examples/example_detector_config_files/coaxial_torus_config.json
@@ -52,8 +52,8 @@
             },
             "geometry": {
                 "type": "torus",
-                "c": 10.0,
-                "a": {
+                "r_torus": 10.0,
+                "r_tube": {
                     "from": 2.0,
                     "to": 5.0
                 },
@@ -76,8 +76,8 @@
             "potential": 0.0,
             "geometry": {
               "type": "torus",
-              "c": 10.0,
-              "a": {
+              "r_torus": 10.0,
+              "r_tube": {
                   "from": 2.0,
                   "to": 2.0
               },
@@ -99,8 +99,8 @@
             "potential": 100.0,
             "geometry": {
               "type": "torus",
-              "c": 10.0,
-              "a": {
+              "r_torus": 10.0,
+              "r_tube": {
                   "from": 5.0,
                   "to": 5.0
               },

--- a/src/Geometries/LinePrimitives/LinePrimitives.jl
+++ b/src/Geometries/LinePrimitives/LinePrimitives.jl
@@ -88,14 +88,21 @@ struct PartialCircle{T,N,S} <: AbstractLine{T,N,S}
     Rotate::AbstractMatrix{T}
 end
 
-function PartialCircle(r::T, phiStart::T, phiStop::T, Translate::CartesianVector{T} = CartesianVector{T}([0,0,0]), Rotate::AngleAxis{T} = AngleAxis{T}(0,0,0,1)) where {T}
+function PartialCircle(r::T, phiStart::T, phiStop::T, Translate::CartesianVector{T} = CartesianVector{T}([0,0,0]), Rotate::Rotation{3,Float32} = RotZ{T}(0)) where {T}
     PartialCircle{T, 3, :cartesian}(r, phiStart, phiStop, Translate, Rotate)
 end
 
-function PartialCircle(r::T, phiStart::T, phiStop::T, Translate::Missing,  Rotate::Missing) where {T}
-    PartialCircle{T, 3, :cartesian}(r, phiStart, phiStop, CartesianVector{T}([0,0,0]),  AngleAxis{T}(0,0,0,1))
+function PartialCircle(r::T, phiStart::T, phiStop::T, Translate::CartesianVector{T}, Rotate::Missing) where {T}
+    PartialCircle{T, 3, :cartesian}(r, phiStart, phiStop, Translate, RotZ{T}(0))
 end
 
+function PartialCircle(r::T, phiStart::T, phiStop::T, Translate::Missing, Rotate::Rotation{3,Float32}) where {T}
+    PartialCircle{T, 3, :cartesian}(r, phiStart, phiStop, CartesianVector{T}([0,0,0]), Rotate)
+end
+
+function PartialCircle(r::T, phiStart::T, phiStop::T, Translate::Missing, Rotate::Missing) where {T}
+    PartialCircle{T, 3, :cartesian}(r, phiStart, phiStop, CartesianVector{T}([0,0,0]),  RotZ{T}(0))
+end
 
 
 # Plot Recipes:

--- a/src/Geometries/LinePrimitives/LinePrimitives.jl
+++ b/src/Geometries/LinePrimitives/LinePrimitives.jl
@@ -75,48 +75,50 @@ end
 """
     struct PartialCircle{T, N, S} <: AbstractLine{T, N, S}
         ________
-      _/        \\_ 
+      _/        \\_
      /            \\
     A              B
-    
+
 """
 struct PartialCircle{T,N,S} <: AbstractLine{T,N,S}
     r::T
     phiStart::T
     phiStop::T
     Translate::AbstractCoordinateVector{T,N,S}
+    Rotate::AbstractMatrix{T}
 end
 
-function PartialCircle(r::T, phiStart::T, phiStop::T, Translate::CartesianVector{T} = CartesianVector{T}([0,0,0])) where {T}
-    PartialCircle{T, 3, :cartesian}(r, phiStart, phiStop, Translate)
+function PartialCircle(r::T, phiStart::T, phiStop::T, Translate::CartesianVector{T} = CartesianVector{T}([0,0,0]), Rotate::AngleAxis{T} = AngleAxis{T}(0,0,0,1)) where {T}
+    PartialCircle{T, 3, :cartesian}(r, phiStart, phiStop, Translate, Rotate)
 end
 
-function PartialCircle(r::T, phiStart::T, phiStop::T, Translate::Missing) where {T}
-    PartialCircle{T, 3, :cartesian}(r, phiStart, phiStop, CartesianVector{T}([0,0,0]))
+function PartialCircle(r::T, phiStart::T, phiStop::T, Translate::Missing,  Rotate::Missing) where {T}
+    PartialCircle{T, 3, :cartesian}(r, phiStart, phiStop, CartesianVector{T}([0,0,0]),  AngleAxis{T}(0,0,0,1))
 end
 
 
 
 # Plot Recipes:
 @recipe function f(l::AbstractLine{T, 3, :cartesian}) where {T}
-    x::Vector{T} = [l.org.x, l.org.x + l.dir.x] 
-    y::Vector{T} = [l.org.y, l.org.y + l.dir.y] 
-    z::Vector{T} = [l.org.z, l.org.z + l.dir.z] 
+    x::Vector{T} = [l.org.x, l.org.x + l.dir.x]
+    y::Vector{T} = [l.org.y, l.org.y + l.dir.y]
+    z::Vector{T} = [l.org.z, l.org.z + l.dir.z]
     x, y, z
 end
 
 @recipe function f(l::AbstractLine{T, 2, :cartesian}) where {T}
-    x::Vector{T} = [l.org.x, l.org.x + l.dir.x] 
-    y::Vector{T} = [l.org.y, l.org.y + l.dir.y] 
+    x::Vector{T} = [l.org.x, l.org.x + l.dir.x]
+    y::Vector{T} = [l.org.y, l.org.y + l.dir.y]
     x, y
 end
 
 @recipe function f(pc::PartialCircle{T, 3, :cartesian}; n = 30) where {T}
     phirange = range(pc.phiStart, pc.phiStop, length = round(Int, n + 1))
-    x::Vector{T} = pc.r .* cos.(phirange) .+ pc.Translate.x
-    y::Vector{T} = pc.r .* sin.(phirange) .+ pc.Translate.y
-    z::Vector{T} = map(phi -> pc.Translate.z, phirange)
-    x, y, z
+    x::Vector{T} = pc.r .* cos.(phirange)
+    y::Vector{T} = pc.r .* sin.(phirange)
+    z::Vector{T} = map(phi -> 0.0, phirange)
+    points = map(p -> pc.Rotate*p + pc.Translate, CartesianPoint{T}.(x,y,z))
+    points
 end
 
 @recipe function f(ls::Array{<:AbstractLine{T, 3, :cartesian}, 1}) where {T}

--- a/src/Geometries/VolumePrimitives/Torus.jl
+++ b/src/Geometries/VolumePrimitives/Torus.jl
@@ -1,0 +1,134 @@
+struct Torus{T} <: AbstractVolumePrimitive{T, 3} ## Only upright Toruss at the moment
+    c::T
+    a_interval::AbstractInterval{T}
+    φ_interval::AbstractInterval{T}
+    θ_interval::AbstractInterval{T}
+    translate::Union{CartesianVector{T},Missing}
+end
+
+
+function Torus{T}(dict::Dict{Any, Any}, inputunit_dict::Dict{String,Unitful.Units})::Torus{T} where {T <: SSDFloat}
+
+    if haskey(dict, "translate")
+        translate = CartesianVector{T}( haskey(dict["translate"],"x") ? geom_round(ustrip(uconvert(u"m", T(dict["translate"]["x"]) * inputunit_dict["length"] ))) : T(0),
+                                        haskey(dict["translate"],"y") ? geom_round(ustrip(uconvert(u"m", T(dict["translate"]["y"]) * inputunit_dict["length"] ))) : T(0),
+                                        haskey(dict["translate"],"z") ? geom_round(ustrip(uconvert(u"m", T(dict["translate"]["z"]) * inputunit_dict["length"] ))) : T(0))
+    else
+        translate = missing
+    end
+
+    if haskey(dict,"c")
+        c = geom_round(ustrip(uconvert(u"m", T(dict["c"]) * inputunit_dict["length"] )))
+    else
+        @warn "please specify the radius from the center of the hole to the center of the torus tube 'c'"
+    end
+
+    θ_interval =  if haskey(dict, "theta")
+        Interval(geom_round(T(ustrip(uconvert(u"rad", T(dict["theta"]["from"]) * inputunit_dict["angle"])))),
+                 geom_round(T(ustrip(uconvert(u"rad", T(dict["theta"]["to"]) * inputunit_dict["angle"])))))
+    else
+        Interval(T(0), geom_round(T(2π)))
+    end
+
+    φ_interval =  if haskey(dict, "phi")
+        Interval(geom_round(T(ustrip(uconvert(u"rad", T(dict["phi"]["from"]) * inputunit_dict["angle"])))),
+                 geom_round(T(ustrip(uconvert(u"rad", T(dict["phi"]["to"]) * inputunit_dict["angle"])))))
+    else
+        Interval(T(0), geom_round(T(2π)))
+    end
+
+    if haskey(dict,"a")
+        if haskey(dict["a"], "from")
+            a_interval =  Interval(geom_round(ustrip(uconvert(u"m", T(dict["a"]["from"]) * inputunit_dict["length"] ))), geom_round(ustrip(uconvert(u"m", T(dict["a"]["to"]) * inputunit_dict["length"]))))
+        else
+            a_interval = Interval(T(0), geom_round(ustrip(uconvert(u"m", T(dict["a"]) * inputunit_dict["length"]))))
+        end
+    else
+        @warn "please specify the radius of torus tube 'a'"
+    end
+
+    return Torus{T}(
+        c,
+        a_interval,
+        φ_interval,
+        θ_interval,
+        translate
+    )
+end
+
+function Geometry(T::DataType, t::Val{:torus}, dict::Dict{Union{Any,String}, Any},inputunit_dict::Dict{String,Unitful.Units})
+    return Torus{T}(Dict{Any,Any}(dict), inputunit_dict)
+end
+
+function in(point::CartesianPoint{T}, Torus::Torus{T})::Bool where {T <: SSDFloat}
+    (ismissing(Torus.translate) || Torus.translate == CartesianVector{T}(0.0,0.0,0.0)) ? nothing : point -= Torus.translate
+    point = convert(CylindricalPoint,point)
+    a = sqrt((point.r - Torus.c)^2 + point.z^2)
+    θ = acos((point.r - Torus.c)/a)
+    if point.z < 0
+        θ = 2π - θ
+    end
+    return (a in Torus.a_interval && point.φ in Torus.φ_interval && θ in Torus.θ_interval)
+end
+
+function in(point::CylindricalPoint{T}, Torus::Torus{T})::Bool where {T <: SSDFloat}
+    (ismissing(Torus.translate) || Torus.translate == CartesianVector{T}(0.0,0.0,0.0)) ? nothing  : point = CylindricalPoint(CartesianPoint(point)-Torus.translate)
+    a = sqrt((point.r - Torus.c)^2 + point.z^2)
+    θ = acos((point.r - Torus.c)/a)
+    if point.z < 0
+        θ = 2π - θ
+    end
+    return (a in Torus.a_interval && point.φ in Torus.φ_interval && θ in Torus.θ_interval)
+end
+
+
+function get_important_points(t::Torus{T}, ::Val{:a})::Vector{T} where {T <: SSDFloat}
+    return geom_round.(T[t.a_interval.left, t.a_interval.right])
+end
+
+function get_important_points(t::Torus{T}, ::Val{:r})::Vector{T} where {T <: SSDFloat}
+    return geom_round.(T[t.c-t.a_interval.right, t.a_interval.right+t.c])
+end
+
+function get_important_points(t::Torus{T}, ::Val{:φ})::Vector{T} where {T <: SSDFloat}
+    return geom_round.(T[t.φ_interval.left, t.φ_interval.right])
+end
+
+function get_important_points(t::Torus{T}, ::Val{:θ})::Vector{T} where {T <: SSDFloat}
+    return geom_round.(T[t.θ_interval.left, t.θ_interval.right])
+end
+
+function get_important_points(t::Torus{T}, ::Val{:x})::Vector{T} where {T <: SSDFloat}
+    return geom_round.(T[-(t.a_interval.right+t.c), -(t.c-t.a_interval.right), (t.c-t.a_interval.right), (t.a_interval.right+t.c)])
+end
+
+function get_important_points(t::Torus{T}, ::Val{:y})::Vector{T} where {T <: SSDFloat}
+    return geom_round.(T[-(t.a_interval.right+t.c), -(t.c-t.a_interval.right), (t.c-t.a_interval.right), (t.a_interval.right+t.c)])
+end
+
+function get_important_points(t::Torus{T}, ::Val{:z})::Vector{T} where {T <: SSDFloat}
+    return geom_round.(T[-t.a_interval.right, t.a_interval.right])
+end
+
+function sample(t::Torus{T}, stepsize::Vector{T}) where {T <: SSDFloat}
+    samples = CylindricalPoint[]
+    for a in t.a_interval.left:stepsize[1]: t.a_interval.right
+        for φ in t.φ_interval.left:stepsize[2]: t.φ_interval.right
+            for θ in t.θ_interval.left:stepsize[3]: t.θ_interval.right
+                push!(samples, CylindricalPoint{T}(t.c+a*cos(θ),φ,a*sin(θ)))
+            end
+        end
+    end
+    ismissing(t.translate) ? nothing : samples = map(x -> CylindricalPoint(CartesianPoint(x) + t.translate), samples)
+    return samples
+end
+
+function (+)(t::Torus{T}, translate::Union{CartesianVector{T},Missing})::Torus{T} where {T <: SSDFloat}
+    if ismissing(translate)
+        return t
+    elseif ismissing(t.translate)
+        return Torus(t.c, t.a_interval, t.φ_interval, t.θ_interval, translate)
+    else
+        return Torus(t.c, t.a_interval, t.φ_interval, t.θ_interval, t.translate + translate)
+    end
+ end

--- a/src/Geometries/VolumePrimitives/VolumePrimitives.jl
+++ b/src/Geometries/VolumePrimitives/VolumePrimitives.jl
@@ -13,5 +13,6 @@ include("Tube.jl")
 include("Cone.jl")
 include("Sphere.jl")
 include("HexagonalPrism.jl")
+include("Torus.jl")
 
 include("plot_recipes.jl")

--- a/src/Geometries/VolumePrimitives/plot_recipes.jl
+++ b/src/Geometries/VolumePrimitives/plot_recipes.jl
@@ -85,24 +85,24 @@ end
 function LineSegments(t::Torus{T})::Vector{AbstractLine{T,3,:cartesian}} where {T <: SSDFloat}
     ls = AbstractLine{T, 3, :cartesian}[]
     translate::CartesianVector{T} = ismissing(t.translate) ? CartesianVector{T}([0, 0, 0]) : t.translate
-    for a in (t.a_interval.left == 0 ? [t.a_interval.right] : [t.a_interval.left, t.a_interval.right])
+    for r_tube in (t.r_tube_interval.left == 0 ? [t.r_tube_interval.right] : [t.r_tube_interval.left, t.r_tube_interval.right])
         θ_circles = (t.θ_interval.right - t.θ_interval.left) ≈ 2π ? [t.θ_interval.left] : [t.θ_interval.left, t.θ_interval.right]
         π in OpenInterval(t.θ_interval) ? push!(θ_circles, π) : nothing
         for θ in θ_circles
-            r = a*cos(θ) + t.c
-            z = a*sin(θ)
+            r = r_tube*cos(θ) + t.r_torus
+            z = r_tube*sin(θ)
             push!(ls, PartialCircle(r, t.φ_interval.left, t.φ_interval.right, translate + CartesianVector{T}([0, 0, z])))
         end
     end
     for φ in (t.φ_interval.right - t.φ_interval.left ≈ 2π ? [t.φ_interval.left] : [t.φ_interval.left, t.φ_interval.right])
-        for a in (t.a_interval.left == 0 ? [t.a_interval.right] : [t.a_interval.left, t.a_interval.right])
-            r = a
-            push!(ls, PartialCircle(r, t.θ_interval.left, t.θ_interval.right, translate + CartesianVector{T}([t.c*cos(φ), t.c*sin(φ), 0]), AngleAxis{T}(RotZ(φ)*RotX(π/2))))
+        for r_tube in (t.r_tube_interval.left == 0 ? [t.r_tube_interval.right] : [t.r_tube_interval.left, t.r_tube_interval.right])
+            r = r_tube
+            push!(ls, PartialCircle(r, t.θ_interval.left, t.θ_interval.right, translate + CartesianVector{T}([t.r_torus*cos(φ), t.r_torus*sin(φ), 0]), RotZ{T}(φ)*RotX{T}(π/2)))
         end
         for θ in (t.θ_interval.right - t.θ_interval.left ≈ 2π ? [] : [t.θ_interval.left, t.θ_interval.right])
             push!(ls, LineSegment(
-                RotZ(φ)*RotY(-θ)*CartesianPoint{T}(t.a_interval.left, 0, 0) + CartesianVector{T}([t.c*cos(φ), t.c*sin(φ), 0]) + translate,
-                RotZ(φ)*RotY(-θ)*CartesianPoint{T}(t.a_interval.right, 0, 0) + CartesianVector{T}([t.c*cos(φ), t.c*sin(φ), 0]) + translate))
+                RotZ{T}(φ)*RotY{T}(-θ)*CartesianPoint{T}(t.r_tube_interval.left, 0, 0) + CartesianVector{T}([t.r_torus*cos(φ), t.r_torus*sin(φ), 0]) + translate,
+                RotZ{T}(φ)*RotY{T}(-θ)*CartesianPoint{T}(t.r_tube_interval.right, 0, 0) + CartesianVector{T}([t.r_torus*cos(φ), t.r_torus*sin(φ), 0]) + translate))
         end
     end
     return ls

--- a/src/Geometries/VolumePrimitives/plot_recipes.jl
+++ b/src/Geometries/VolumePrimitives/plot_recipes.jl
@@ -44,7 +44,7 @@ function LineSegments(c::Cone{T})::Vector{AbstractLine{T, 3, :cartesian}} where 
     ls = AbstractLine{T, 3, :cartesian}[]
     translate::CartesianVector{T} = ismissing(c.translate) ? CartesianVector{T}([0, 0, 0]) : c.translate
     for r in [c.rStart1, c.rStop1]
-        push!(ls, PartialCircle(r, c.φStart, c.φStop, translate + CartesianVector{T}([0, 0, c.zStart]))) 
+        push!(ls, PartialCircle(r, c.φStart, c.φStop, translate + CartesianVector{T}([0, 0, c.zStart])))
     end
     for r in [c.rStart2, c.rStop2]
         push!(ls, PartialCircle(r, c.φStart, c.φStop, translate + CartesianVector{T}([0, 0, c.zStop])))
@@ -80,4 +80,43 @@ end
     seriescolor := seriescolor
     label := ""
     LineSegments(c)
+end
+
+function LineSegments(t::Torus{T})::Vector{AbstractLine{T,3,:cartesian}} where {T <: SSDFloat}
+    ls = AbstractLine{T, 3, :cartesian}[]
+    translate::CartesianVector{T} = ismissing(t.translate) ? CartesianVector{T}([0, 0, 0]) : t.translate
+    for a in (t.a_interval.left == 0 ? [t.a_interval.right] : [t.a_interval.left, t.a_interval.right])
+        θ_circles = (t.θ_interval.right - t.θ_interval.left) ≈ 2π ? [t.θ_interval.left] : [t.θ_interval.left, t.θ_interval.right]
+        π in OpenInterval(t.θ_interval) ? push!(θ_circles, π) : nothing
+        for θ in θ_circles
+            r = a*cos(θ) + t.c
+            z = a*sin(θ)
+            push!(ls, PartialCircle(r, t.φ_interval.left, t.φ_interval.right, translate + CartesianVector{T}([0, 0, z])))
+        end
+    end
+    for φ in (t.φ_interval.right - t.φ_interval.left ≈ 2π ? [t.φ_interval.left] : [t.φ_interval.left, t.φ_interval.right])
+        for a in (t.a_interval.left == 0 ? [t.a_interval.right] : [t.a_interval.left, t.a_interval.right])
+            r = a
+            push!(ls, PartialCircle(r, t.θ_interval.left, t.θ_interval.right, translate + CartesianVector{T}([t.c*cos(φ), t.c*sin(φ), 0]), AngleAxis{T}(RotZ(φ)*RotX(π/2))))
+        end
+        for θ in (t.θ_interval.right - t.θ_interval.left ≈ 2π ? [] : [t.θ_interval.left, t.θ_interval.right])
+            push!(ls, LineSegment(
+                RotZ(φ)*RotY(-θ)*CartesianPoint{T}(t.a_interval.left, 0, 0) + CartesianVector{T}([t.c*cos(φ), t.c*sin(φ), 0]) + translate,
+                RotZ(φ)*RotY(-θ)*CartesianPoint{T}(t.a_interval.right, 0, 0) + CartesianVector{T}([t.c*cos(φ), t.c*sin(φ), 0]) + translate))
+        end
+    end
+    return ls
+end
+
+@recipe function f(t::Torus{T}; n = 30, seriescolor = :green) where {T}
+    linewidth --> 2
+    n --> n
+    @series begin
+        seriescolor --> seriescolor
+        label --> "Torus"
+        []
+    end
+    label := ""
+    seriescolor := seriescolor
+    LineSegments(t)
 end

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -39,3 +39,6 @@ SSD_examples[:InfiniteCoaxialCapacitorCartesianCoords] = (
 SSD_examples[:Hexagon] = (
     joinpath(@__DIR__, "../examples/example_detector_config_files/minimum_hexagon_config.json")
 )
+SSD_examples[:CoaxialTorus] = (
+    joinpath(@__DIR__, "../examples/example_detector_config_files/coaxial_torus_config.json")
+)


### PR DESCRIPTION
**Added Torus Primitive
Added Rotation support to PartialCircle LinePrimitive. The plot recipe of Torus depends on this.**
We should discuss how to add Rotation support in general. From what I see rotations in the Cone primitive only allow a for a rotation matrix of type RotXYZ, which will rotate in the order Z->X->Y. We need all permutations of this and thus it requires more user input (order choice). We also need to allow a rotation of type AngleAxis (what I used in PartialCircle). 
Examples of the Torus Primitive follow, including usage of the sample function and potential calculations:
**Whole coaxial torus, added to example config files**
![torus_whole](https://user-images.githubusercontent.com/41748838/99576796-6cb55600-29a8-11eb-8d6d-1690c4b52d2b.png)
![torus_whole_plots](https://user-images.githubusercontent.com/41748838/99576790-6b842900-29a8-11eb-97b1-ffc9ff694002.png)
**Coaxial torus, but with a partial thick n contact section**
![torus_section_whole](https://user-images.githubusercontent.com/41748838/99576842-7dfe6280-29a8-11eb-8e23-bf823ab2a0a7.png)
![torus_section_whole_plots](https://user-images.githubusercontent.com/41748838/99576850-8191e980-29a8-11eb-83ee-4731a5650deb.png)
**A bulletized PPC**
![bulletized_PPC](https://user-images.githubusercontent.com/41748838/99577065-ccabfc80-29a8-11eb-9e80-85482f65c447.png)
![bulletized_PPC_plots](https://user-images.githubusercontent.com/41748838/99577075-d03f8380-29a8-11eb-9386-0f8c37f38755.png)

