### PR TITLE
Electric field plot enhancement

### DIFF
--- a/src/PotentialSimulation/plot_recipes.jl
+++ b/src/PotentialSimulation/plot_recipes.jl
@@ -1,7 +1,7 @@
 function get_crosssection_idx_and_value(g::Grid{T, 3, :cylindrical}, r, φ, z)::Tuple{Symbol,Int,T} where {T <: SSDFloat}
 
     cross_section::Symbol, idx::Int = if ismissing(φ) && ismissing(r) && ismissing(z)
-        :φ, 1
+        return get_crosssection_idx_and_value(g, r, T(0.0), z)
     elseif !ismissing(φ) && ismissing(r) && ismissing(z)
         φ_rad::T = T(deg2rad(φ))
         while !(g.φ.interval.left <= φ_rad <= g.φ.interval.right) && g.φ.interval.right != g.φ.interval.left
@@ -219,7 +219,7 @@ end
 function get_crosssection_idx_and_value(g::Grid{T, 3, :cartesian}, x, y, z)::Tuple{Symbol,Int,T} where {T <: SSDFloat}
 
     cross_section::Symbol, idx::Int = if ismissing(x) && ismissing(y) && ismissing(z)
-        :y, 1
+        return get_crosssection_idx_and_value(g, T(0.0), y, z)
     elseif !ismissing(x) && ismissing(y) && ismissing(z)
         :x, searchsortednearest(g.x, T(x))
     elseif ismissing(x) && !ismissing(y) && ismissing(z)


### PR DESCRIPTION
This pull request will close #93.

- Adding a automatic down scaling of the `sampling` step if it is too big and would lead to unpopulated arrays. The `offset` is scaled accordingly
- Revising default values if no cross-section is passed

Now, for the Hexagon Example detector, the lines
```
plot(sim.electric_field)
plot_electric_fieldlines!(sim)
```
yield
![Hexagon_resampled](https://user-images.githubusercontent.com/6920236/99829941-44228d00-2b5d-11eb-9ace-7a556e046c3c.png)
and a corresponding warning that the specified/default values for `sampling` and `offset` have been modified automatically.