### PR TITLE
Sampleplotting

### DIFF
--- a/docs/src/tutorial_lit.jl
+++ b/docs/src/tutorial_lit.jl
@@ -12,7 +12,7 @@ plot(simulation.detector)
 
 
 plot(simulation.detector, SSD_style = :samplesurface, alpha_factor = 1)
-# alpha_factor ϵ [0,1) will increase transparency and alpa_factor > 1 will increase opacity.
+# alpha_factor ϵ [0,1) will increase transparency and alpa_factor > 1 will increase opacity. You can choose from the default collor palettes like using keyword 'palette = :tab10' or create your own palette like 'palette = [:yellow, :blue, :red]'
 
 # One can also have a look at how the initial conditions look like on the grid (its starts with a very coarse grid):
 

--- a/docs/src/tutorial_lit.jl
+++ b/docs/src/tutorial_lit.jl
@@ -7,7 +7,12 @@ using Unitful
 T = Float32
 simulation = Simulation{T}(SSD_examples[:InvertedCoax])
 
-plot(simulation.detector, size = (700, 700))
+plot(simulation.detector)
+# This will use the defaul plotting method (SSD_style = :wireframe). You can also use SSD_style = :samplesurface, which will show the "solid" geometry.
+
+
+plot(simulation.detector, SSD_style = :samplesurface, alpha_factor = 1)
+# alpha_factor ϵ [0,1) will increase transparency and alpa_factor > 1 will increase opacity.
 
 # One can also have a look at how the initial conditions look like on the grid (its starts with a very coarse grid):
 

--- a/src/Geometries/LinePrimitives/LinePrimitives.jl
+++ b/src/Geometries/LinePrimitives/LinePrimitives.jl
@@ -88,7 +88,7 @@ struct PartialCircle{T,N,S} <: AbstractLine{T,N,S}
     Rotate::AbstractMatrix{T}
 end
 
-function PartialCircle(r::T, phiStart::T, phiStop::T, Translate::CartesianVector{T} = CartesianVector{T}([0,0,0]), Rotate::Rotation{3,Float32} = RotZ{T}(0)) where {T}
+function PartialCircle(r::T, phiStart::T, phiStop::T, Translate::CartesianVector{T} = CartesianVector{T}([0,0,0]), Rotate::Rotation{3,T} = RotZ{T}(0)) where {T}
     PartialCircle{T, 3, :cartesian}(r, phiStart, phiStop, Translate, Rotate)
 end
 
@@ -96,7 +96,7 @@ function PartialCircle(r::T, phiStart::T, phiStop::T, Translate::CartesianVector
     PartialCircle{T, 3, :cartesian}(r, phiStart, phiStop, Translate, RotZ{T}(0))
 end
 
-function PartialCircle(r::T, phiStart::T, phiStop::T, Translate::Missing, Rotate::Rotation{3,Float32}) where {T}
+function PartialCircle(r::T, phiStart::T, phiStop::T, Translate::Missing, Rotate::Rotation{3,T}) where {T}
     PartialCircle{T, 3, :cartesian}(r, phiStart, phiStop, CartesianVector{T}([0,0,0]), Rotate)
 end
 

--- a/src/Geometries/VolumePrimitives/HexagonalPrism.jl
+++ b/src/Geometries/VolumePrimitives/HexagonalPrism.jl
@@ -102,7 +102,7 @@ end
     linewidth --> 2
     @series begin
         seriescolor --> seriescolor
-        label --> "Hexagon"
+        label --> "HexagonalPrism"
         []
     end
     label := ""

--- a/src/Geometries/VolumePrimitives/Tube.jl
+++ b/src/Geometries/VolumePrimitives/Tube.jl
@@ -28,10 +28,10 @@ function Tube{T}(dict::Dict{Any, Any}, inputunit_dict::Dict{String,Unitful.Units
     else
         @warn "please specify a height of the Tube 'h'"
     end
-    
-    φ_interval =  if haskey(dict, "phi") 
-        Interval(geom_round(T(ustrip(uconvert(u"rad", T(dict["phi"]["from"]) * inputunit_dict["angle"])))), 
-                 geom_round(T(ustrip(uconvert(u"rad", T(dict["phi"]["to"]) * inputunit_dict["angle"])))))                      
+
+    φ_interval =  if haskey(dict, "phi")
+        Interval(geom_round(T(ustrip(uconvert(u"rad", T(dict["phi"]["from"]) * inputunit_dict["angle"])))),
+                 geom_round(T(ustrip(uconvert(u"rad", T(dict["phi"]["to"]) * inputunit_dict["angle"])))))
     else
         Interval(T(0), geom_round(T(2π)))
     end

--- a/src/Geometries/VolumePrimitives/plot_recipes.jl
+++ b/src/Geometries/VolumePrimitives/plot_recipes.jl
@@ -43,7 +43,7 @@ end
     elseif SSD_style == :samplesurface
         st = :scatter
         if ismissing(world_size)
-            r_size = max(t.r_interval.right*(1-cos(max(width(t.φ_interval), π))), width(t.r_interval))
+            r_size = max(t.r_interval.right*(1-cos(min(width(t.φ_interval), π))), width(t.r_interval))
             max_dim = max(r_size, width(t.z_interval))
             world_size = CylindricalVector{T}(max_dim, width(t.φ_interval)/2, max_dim)
         end
@@ -114,7 +114,7 @@ end
         st = :scatter
         if ismissing(world_size)
             r_max = max(c.rStop1, c.rStop2)
-            r_size = max(r_max*(1-cos(max(width(t.φ_interval), π))), abs(r_max - min(c.rStart1, c.rStart2)))
+            r_size = max(r_max*(1-cos(min(width(t.φ_interval), π))), abs(r_max - min(c.rStart1, c.rStart2)))
             max_dim = max(r_size, abs(c.zStop-c.zStart))
             world_size = CylindricalVector{T}(max_dim, width(t.φ_interval)/2, max_dim)
         end
@@ -182,7 +182,7 @@ end
         own_world = false
         if ismissing(world_size)
             own_world = true
-            r_size = max((t.r_torus+t.r_tube_interval.right)*(1-cos(max(width(t.φ_interval), π))), t.r_tube_interval.right*(1-cos(max(width(t.θ_interval), π))), width(t.r_tube_interval))
+            r_size = max((t.r_torus+t.r_tube_interval.right)*(1-cos(min(width(t.φ_interval), π))), t.r_tube_interval.right*(1-cos(min(width(t.θ_interval), π))), width(t.r_tube_interval))
             world_size = CylindricalVector{T}(r_size, width(t.φ_interval)/2, width(t.θ_interval)/2)
         end
         points = 100

--- a/src/Geometries/VolumePrimitives/plot_recipes.jl
+++ b/src/Geometries/VolumePrimitives/plot_recipes.jl
@@ -45,7 +45,7 @@ end
         if ismissing(world_size)
             r_size = t.r_interval.right*width(t.φ_interval)/(π/2) >= width(t.r_interval) ? t.r_interval.right :  width(t.r_interval)
             max_dim = max(r_size, width(t.z_interval))
-            world_size = CylindricalVector{T}(max_dim, π, max_dim)
+            world_size = CylindricalVector{T}(max_dim, width(t.φ_interval)/2, max_dim)
         end
         points = 100
         if typeof(world_size) == CylindricalVector{T}
@@ -116,7 +116,7 @@ end
             r_max = max(c.rStop1, c.rStop2)
             r_size = r_max*width(c.φ_interval)/(π/2) >= abs(r_max - min(c.rStart1, c.rStart2)) ? r_max :  abs(r_max - min(c.rStart1, c.rStart2))
             max_dim = max(r_size, abs(c.zStop-c.zStart))
-            world_size = CylindricalVector{T}(max_dim, π, max_dim)
+            world_size = CylindricalVector{T}(max_dim, width(t.φ_interval)/2, max_dim)
         end
         points = 100
         if typeof(world_size) == CylindricalVector{T}
@@ -179,14 +179,16 @@ end
         plotobject = LineSegments(t)
     elseif SSD_style == :samplesurface
         st = :scatter
+        own_world = false
         if ismissing(world_size)
+            own_world = true
             r_size = (t.r_torus+t.r_tube_interval.right)*width(t.φ_interval)/(π/2) > max(t.r_tube_interval.right*width(t.θ_interval)/(π/2), width(t.r_tube_interval)) ?  t.r_torus+t.r_tube_interval.right : t.r_tube_interval.right
-            world_size = CylindricalVector{T}(r_size, π, r_size)
+            world_size = CylindricalVector{T}(r_size, width(t.φ_interval)/2, width(t.θ_interval)/2)
         end
         points = 100
         if typeof(world_size) == CylindricalVector{T}
             sampling_vector = Array{T}(world_size/points)
-            sampling_vector[3] = π/points
+            own_world ? nothing : sampling_vector[3] = π/points
             plotobject = CylindricalPoint.(sample(t, sampling_vector))
         elseif typeof(world_size) == CartesianVector{T}
             sampling_vector = T.([sqrt(world_size.x^2+world_size.y^2), π, π]/points)

--- a/src/Geometries/VolumePrimitives/plot_recipes.jl
+++ b/src/Geometries/VolumePrimitives/plot_recipes.jl
@@ -43,7 +43,7 @@ end
     elseif SSD_style == :samplesurface
         st = :scatter
         if ismissing(world_size)
-            r_size = t.r_interval.right*width(t.φ_interval)/(π/2) >= width(t.r_interval) ? t.r_interval.right :  width(t.r_interval)
+            r_size = max(t.r_interval.right*(1-cos(max(width(t.φ_interval), π))), width(t.r_interval))
             max_dim = max(r_size, width(t.z_interval))
             world_size = CylindricalVector{T}(max_dim, width(t.φ_interval)/2, max_dim)
         end
@@ -114,7 +114,7 @@ end
         st = :scatter
         if ismissing(world_size)
             r_max = max(c.rStop1, c.rStop2)
-            r_size = r_max*width(c.φ_interval)/(π/2) >= abs(r_max - min(c.rStart1, c.rStart2)) ? r_max :  abs(r_max - min(c.rStart1, c.rStart2))
+            r_size = max(r_max*(1-cos(max(width(t.φ_interval), π))), abs(r_max - min(c.rStart1, c.rStart2)))
             max_dim = max(r_size, abs(c.zStop-c.zStart))
             world_size = CylindricalVector{T}(max_dim, width(t.φ_interval)/2, max_dim)
         end
@@ -182,7 +182,7 @@ end
         own_world = false
         if ismissing(world_size)
             own_world = true
-            r_size = (t.r_torus+t.r_tube_interval.right)*width(t.φ_interval)/(π/2) > max(t.r_tube_interval.right*width(t.θ_interval)/(π/2), width(t.r_tube_interval)) ?  t.r_torus+t.r_tube_interval.right : t.r_tube_interval.right
+            r_size = max((t.r_torus+t.r_tube_interval.right)*(1-cos(max(width(t.φ_interval), π))), t.r_tube_interval.right*(1-cos(max(width(t.θ_interval), π))), width(t.r_tube_interval))
             world_size = CylindricalVector{T}(r_size, width(t.φ_interval)/2, width(t.θ_interval)/2)
         end
         points = 100

--- a/src/Geometries/VolumePrimitives/plot_recipes.jl
+++ b/src/Geometries/VolumePrimitives/plot_recipes.jl
@@ -26,7 +26,7 @@ function LineSegments(t::Tube{T})::Vector{AbstractLine{T,3,:cartesian}} where {T
     return ls
 end
 
-@recipe function f(t::Tube{T}; n = 30, seriescolor = :green) where {T}
+@recipe function f(t::Tube{T}; n = 30, seriescolor = :green, SSD_style = :wireframe, detector = missing, contact = missing, alpha_factor = 1) where {T}
     linewidth --> 2
     n --> n
     @series begin
@@ -36,7 +36,31 @@ end
     end
     label := ""
     seriescolor := seriescolor
-    LineSegments(t)
+    α = 1
+    st = :path
+    if SSD_style == :wireframe
+        plotobject = LineSegments(t)
+    elseif SSD_style == :samplesurface
+        st = :scatter
+        grid = Grid(detector)
+        coord_sys = get_coordinate_system(grid)
+        points = 100
+        if coord_sys == :cylindrical
+            sampling_vector = T.([width(grid.r.interval)/points, π/points, width(grid.z.interval)/points])
+            plotobject = CylindricalPoint{T}.(sample(t, sampling_vector))
+        elseif coord_sys == :cartesian
+            sampling_vector = T.([width(grid.x.interval)/points, width(grid.y.interval)/points, width(grid.z.interval)/points])
+            plotobject = CartesianPoint{T}.(sample(t, sampling_vector))
+        end
+        for neg_geo in contact.geometry_negative
+            filter!(x -> !(x in neg_geo), plotobject)
+        end
+        α = min(alpha_factor*max(1-length(plotobject)/3000,0.05),1)
+    end
+    seriestype  :=  st
+    markerstrokewidth := 0
+    seriesalpha := α
+    plotobject
 end
 
 
@@ -69,7 +93,7 @@ function LineSegments(c::Cone{T})::Vector{AbstractLine{T, 3, :cartesian}} where 
     return ls
 end
 
-@recipe function f(c::Cone{T}; n = 30, seriescolor = :orange) where {T}
+@recipe function f(c::Cone{T}; n = 30, seriescolor = :orange, SSD_style = :wireframe, detector = missing, contact = missing, alpha_factor = 1) where {T}
     linewidth --> 2
     n --> n
     @series begin
@@ -79,7 +103,31 @@ end
     end
     seriescolor := seriescolor
     label := ""
-    LineSegments(c)
+    α = 1
+    st = :path
+    if SSD_style == :wireframe
+        plotobject = LineSegments(c)
+    elseif SSD_style == :samplesurface
+        st = :scatter
+        grid = Grid(detector)
+        coord_sys = get_coordinate_system(grid)
+        points = 100
+        if coord_sys == :cylindrical
+            sampling_vector = T.([width(grid.r.interval)/points, π/points, width(grid.z.interval)/points])
+            plotobject = CylindricalPoint{T}.(sample(c, sampling_vector))
+        elseif coord_sys == :cartesian
+            sampling_vector = T.([width(grid.x.interval)/points, width(grid.y.interval)/points, width(grid.z.interval)/points])
+            plotobject = CartesianPoint{T}.(sample(t, sampling_vector))
+        end
+        for neg_geo in contact.geometry_negative
+            filter!(x -> !(x in neg_geo), plotobject)
+        end
+        α = min(alpha_factor*max(1-length(plotobject)/3000,0.05),1)
+    end
+    seriestype  :=  st
+    markerstrokewidth := 0
+    seriesalpha := α
+    plotobject
 end
 
 function LineSegments(t::Torus{T})::Vector{AbstractLine{T,3,:cartesian}} where {T <: SSDFloat}
@@ -108,7 +156,7 @@ function LineSegments(t::Torus{T})::Vector{AbstractLine{T,3,:cartesian}} where {
     return ls
 end
 
-@recipe function f(t::Torus{T}; n = 30, seriescolor = :green) where {T}
+@recipe function f(t::Torus{T}; n = 30, seriescolor = :red, SSD_style = :wireframe, detector = missing, contact = missing, alpha_factor = 1) where {T}
     linewidth --> 2
     n --> n
     @series begin
@@ -118,5 +166,29 @@ end
     end
     label := ""
     seriescolor := seriescolor
-    LineSegments(t)
+    α = 1
+    st = :path
+    if SSD_style == :wireframe
+        plotobject = LineSegments(t)
+    elseif SSD_style == :samplesurface
+        st = :scatter
+        grid = Grid(detector)
+        coord_sys = get_coordinate_system(grid)
+        points = 100
+        if coord_sys == :cylindrical
+            sampling_vector = T.([width(grid.r.interval)/points, π/points, π/points])
+            plotobject = CylindricalPoint{T}.(sample(t, sampling_vector))
+        elseif coord_sys == :cartesian
+            sampling_vector = T.([width(grid.x.interval)/points, width(grid.y.interval)/points, width(grid.z.interval)/points])
+            plotobject = CartesianPoint{T}.(sample(t, sampling_vector))
+        end
+        for neg_geo in contact.geometry_negative
+            filter!(x -> !(x in neg_geo), plotobject)
+        end
+        α = min(alpha_factor*max(1-length(plotobject)/3000,0.05),1)
+    end
+    seriestype  :=  st
+    markerstrokewidth := 0
+    seriesalpha := α
+    plotobject
 end

--- a/src/SolidStateDetector/plot_recipes.jl
+++ b/src/SolidStateDetector/plot_recipes.jl
@@ -7,7 +7,19 @@
     if !(typeof(clabel) <: AbstractArray) clabel = [clabel] end
     ccolor = (ismissing(seriescolor) ? map(c -> c.id, det.contacts) : seriescolor)
     if !(typeof(ccolor) <: AbstractArray) ccolor = [ccolor] end
-
+    world_size = missing
+    if SSD_style == :samplesurface
+        grid = Grid(det)
+        coord_sys = get_coordinate_system(grid)
+        coord_sys = get_coordinate_system(det)
+        if coord_sys == :cylindrical
+            world_size = CylindricalVector{T}(width(grid.r.interval), π, width(grid.z.interval))
+        elseif coord_sys == :cartesian
+            world_size = CartesianVector{T}(width(grid.x.interval), width(grid.y.interval), width(grid.z.interval))
+        else
+            @error "Could not determine the world size, try SSD_style = :wireframe"
+        end
+    end
     if ismissing(φ)
         xguide --> "x / m"
         yguide --> "y / m"
@@ -20,7 +32,7 @@
                 label := ""
                 n --> n
                 SSD_style --> SSD_style
-                detector --> det
+                world_size --> world_size
                 alpha_factor --> alpha_factor
                 contact
             end
@@ -36,7 +48,7 @@
 end
 
 
-@recipe function f(contact::Contact{T}; SSD_style = :wireframe, n = 30, seriescolor = missing, detector = missing, alpha_factor = 1) where {T}
+@recipe function f(contact::Contact{T}; SSD_style = :wireframe, n = 30, seriescolor = missing, world_size = missing, alpha_factor = 1) where {T}
     ccolor = (ismissing(seriescolor) ? contact.id : seriescolor)
     @series begin
         seriescolor := ccolor
@@ -49,8 +61,8 @@ end
             label := ""
             n --> n
             SSD_style --> SSD_style
-            detector --> detector
-            contact --> contact
+            world_size --> world_size
+            geometry_negative --> contact.geometry_negative
             alpha_factor --> alpha_factor
             c
         end

--- a/src/SolidStateDetector/plot_recipes.jl
+++ b/src/SolidStateDetector/plot_recipes.jl
@@ -1,5 +1,8 @@
-@recipe function f(det::SolidStateDetector{T}; n = 30, φ = missing, seriescolor = missing, label = missing) where {T}
-
+@recipe function f(det::SolidStateDetector{T}; SSD_style = :wireframe, n = 30, φ = missing, seriescolor = missing, label = missing, alpha_factor = 1) where {T}
+    if !(SSD_style in [:wireframe, :samplesurface])
+        @warn "Chose SSD_style from [:wireframe, :samplesurface]. Defaulting to :wireframe"
+        SSD_style = :wireframe
+    end
     clabel = (ismissing(label) ? map(c -> (c.name == "" ? c.id : c.name), det.contacts) : label)
     if !(typeof(clabel) <: AbstractArray) clabel = [clabel] end
     ccolor = (ismissing(seriescolor) ? map(c -> c.id, det.contacts) : seriescolor)
@@ -16,6 +19,9 @@
             @series begin
                 label := ""
                 n --> n
+                SSD_style --> SSD_style
+                detector --> det
+                alpha_factor --> alpha_factor
                 contact
             end
             @series begin
@@ -30,7 +36,7 @@
 end
 
 
-@recipe function f(contact::Contact{T}; n = 30, seriescolor = missing) where {T}
+@recipe function f(contact::Contact{T}; SSD_style = :wireframe, n = 30, seriescolor = missing, detector = missing, alpha_factor = 1) where {T}
     ccolor = (ismissing(seriescolor) ? contact.id : seriescolor)
     @series begin
         seriescolor := ccolor
@@ -42,6 +48,10 @@ end
             seriescolor := ccolor
             label := ""
             n --> n
+            SSD_style --> SSD_style
+            detector --> detector
+            contact --> contact
+            alpha_factor --> alpha_factor
             c
         end
     end


### PR DESCRIPTION
Added a scatter plot method for plotting detectors
This method is based on the sample function of each primitive
It supports negative geometries
Relatively fast for examples. However, will take too long if contacts are too thick in comparison to the world. 
Scatter plotting code (`SSD_style = :samplesurface`) is written in the plot recipe of each primitive 
Plot recipes now pass the detector and the contact to each other so that sampling can be done with respect to world size and negative geometries can be removed. 
`plot(simulation.detector, camera = (20,30))` 
OR
`plot(simulation.detector, camera = (20,30), SSD_style = :wireframe)`
![seg_BEGe_wireframe](https://user-images.githubusercontent.com/41748838/100002876-36eee380-2d93-11eb-916a-150655846f9b.png)
Note that there is a hexagonal negative geometry not shown by :wireframe. This can now be shown by :samplesurface
`plot(simulation.detector, camera = (20,30), SSD_style = :samplesurface)`
OR
`plot(simulation.detector, camera = (20,30), SSD_style = :samplesurface, alpha_factor = 1)`
![seg_BEGe_samplesurface](https://user-images.githubusercontent.com/41748838/100002981-66055500-2d93-11eb-8c16-1d66cf55f875.png)
`alpha_factor` can be any number >= 0. At some point the opacity will saturate. Each positive geometry has a different calculated `alpha`
`plot(simulation.detector, camera = (20,30), SSD_style = :samplesurface, alpha_factor = 0.3`
![seg_BEGe_samplesurface2](https://user-images.githubusercontent.com/41748838/100003035-761d3480-2d93-11eb-9250-3081ddc8651d.png)
)
More examples with default alpha_factor follow:
`plot(simulation.detector, camera = (20,30), SSD_style = :samplesurface)`
![InvertedCoax](https://user-images.githubusercontent.com/41748838/100004627-c4333780-2d95-11eb-8078-a8165cb1ec9c.png)
![Bulletized](https://user-images.githubusercontent.com/41748838/100004643-c8f7eb80-2d95-11eb-8ae7-881172abaca7.png)
![CoaxialTorus](https://user-images.githubusercontent.com/41748838/100004656-ceedcc80-2d95-11eb-8cd1-62a6ad7d3a5b.png)
![Coax](https://user-images.githubusercontent.com/41748838/100004664-d2815380-2d95-11eb-93eb-b02077eea1af.png)
![Hexagon](https://user-images.githubusercontent.com/41748838/100004686-d90fcb00-2d95-11eb-84e4-9c1f63fe0b5e.png)
![SegBEGe_hex](https://user-images.githubusercontent.com/41748838/100004693-dc0abb80-2d95-11eb-86eb-d4da535fca57.png)

