### PR TITLE
Make Grid type stable

### DIFF
--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -5,8 +5,8 @@ abstract type AbstractGrid{T, N} <: AbstractArray{T, N} end
     N: N dimensional
     S: System (Cartesian, Cylindrical...)
 """
-struct Grid{T, N, S} <: AbstractGrid{T, N}
-    axes::NTuple{N, DiscreteAxis{T, BL, BR, I} where {BL, BR, I}}
+struct Grid{T, N, S, AT} <: AbstractGrid{T, N}
+    axes::AT
 end
 
 const CartesianGrid{T, N} = Grid{T, N, :cartesian}
@@ -17,6 +17,9 @@ const RadialGrid{T} = Grid{T, 1, :Radial}
 const PolarGrid{T} = Grid{T, 2, :Polar}
 const CylindricalGrid{T} = Grid{T, 3, :cylindrical}
 const SphericalGrid{T} = Grid{T, 3, :Spherical}
+
+CylindricalGrid{T}(a) where {T} = Grid{T, 3, :cylindrical, typeof(a)}(a)
+CartesianGrid3D{T}(a) where {T} = Grid{T, 3, :cartesian, typeof(a)}(a)
 
 @inline size(g::Grid{T, N, S}) where {T, N, S} = size.(g.axes, 1)
 @inline length(g::Grid{T, N, S}) where {T, N, S} = prod(size(g))

--- a/src/PotentialSimulation/PotentialSimulationSetups/BoundaryConditions/BoundaryConditionsCylindrical.jl
+++ b/src/PotentialSimulation/PotentialSimulationSetups/BoundaryConditions/BoundaryConditionsCylindrical.jl
@@ -72,15 +72,15 @@ function apply_boundary_conditions_on_cyl_z_axis!(  rbpot::Array{T, 4}, ir::Int,
 end
 
 
-function apply_boundary_conditions!(fssrb::PotentialSimulationSetupRB{T, 3, 4, :cylindrical}, update_even_points::Val{even_points}, only2d::Val{only_2d}) where {T, even_points, only_2d}
+function apply_boundary_conditions!(fssrb::PotentialSimulationSetupRB{T, 3, 4, :cylindrical, AT}, update_even_points::Val{even_points}, only2d::Val{only_2d}) where {T, even_points, only_2d, AT}
     rbi::Int = even_points ? rb_even::Int : rb_odd::Int
     nrbi::Int = even_points ? rb_odd::Int : rb_even::Int
-    ax1::typeof(fssrb.grid.axes[1]) = fssrb.grid.axes[1]
-    ax2::typeof(fssrb.grid.axes[2]) = fssrb.grid.axes[2]
-    ax3::typeof(fssrb.grid.axes[3]) = fssrb.grid.axes[3]
-    int1::typeof(ax1.interval) = ax1.interval
-    int2::typeof(ax2.interval) = ax2.interval
-    int3::typeof(ax3.interval) = ax3.interval
+    ax1 = fssrb.grid.axes[1]
+    ax2 = fssrb.grid.axes[2]
+    ax3 = fssrb.grid.axes[3]
+    int1 = ax1.interval
+    int2 = ax2.interval
+    int3 = ax3.interval
     if only_2d
         iφ::Int = 2
         @inbounds for iz in axes(fssrb.potential, 1)

--- a/src/PotentialSimulation/PotentialSimulationSetups/PotentialSimulationSetupRBCartesian3D.jl
+++ b/src/PotentialSimulation/PotentialSimulationSetups/PotentialSimulationSetupRBCartesian3D.jl
@@ -213,7 +213,8 @@ function PotentialSimulationSetupRB(ssd::SolidStateDetector{T, :cartesian}, grid
         pointtypes = clear(pointtypes)
     end # @inbounds
 
-    fssrb::PotentialSimulationSetupRB{T, 3, 4, :cartesian} = PotentialSimulationSetupRB{T, 3, 4, :cartesian}(
+    fssrb::PotentialSimulationSetupRB{T, 3, 4, :cartesian, typeof(geom_weights), typeof(grid.axes)} = 
+        PotentialSimulationSetupRB{T, 3, 4, :cartesian, typeof(geom_weights), typeof(grid.axes)}(
         grid,
         rbpotential,
         rbpointtypes,

--- a/src/PotentialSimulation/PotentialSimulationSetups/PotentialSimulationSetupRBCylindrical.jl
+++ b/src/PotentialSimulation/PotentialSimulationSetups/PotentialSimulationSetupRBCylindrical.jl
@@ -296,7 +296,8 @@ function PotentialSimulationSetupRB(ssd::SolidStateDetector{T, :cylindrical}, gr
         pointtypes = clear(pointtypes)
     end # @inbounds
 
-    fssrb::PotentialSimulationSetupRB{T, 3, 4, :cylindrical} = PotentialSimulationSetupRB{T, 3, 4, :cylindrical}(
+    fssrb::PotentialSimulationSetupRB{T, 3, 4, :cylindrical, typeof(geom_weights), typeof(grid.axes)} = 
+        PotentialSimulationSetupRB{T, 3, 4, :cylindrical, typeof(geom_weights), typeof(grid.axes)}(
         grid,
         rbpotential,
         rbpointtypes,

--- a/src/PotentialSimulation/PotentialSimulationSetups/PotentialSimulationSetups.jl
+++ b/src/PotentialSimulation/PotentialSimulationSetups/PotentialSimulationSetups.jl
@@ -14,15 +14,15 @@ struct PotentialSimulationSetup{T, N, S} <: AbstractPotentialSimulationSetup{T, 
     ϵ::Array{T, N}
 end
 
-struct PotentialSimulationSetupRB{T, N1, N2, S} <: AbstractPotentialSimulationSetup{T, N1}
-    grid::Grid{T, N1, S}
+struct PotentialSimulationSetupRB{T, N1, N2, S, TGW, AT} <: AbstractPotentialSimulationSetup{T, N1}
+    grid::Grid{T, N1, S, AT}
     potential::Array{T, N2}
     pointtypes::Array{PointType, N2}
     volume_weights::Array{T, N2}
     ρ::Array{T, N2}
     ρ_fix::Array{T, N2}
     ϵ::Array{T, N1}
-    geom_weights::NTuple{N1, AbstractGeometricalAxisWeights{T}}        
+    geom_weights::TGW  
     sor_const::Array{T, 1}
     bias_voltage::T
     maximum_applied_potential::T


### PR DESCRIPTION
Makes `Grid` type stable. 

Also increases speed of the relaxation, but should only be measurable for small 2D Grids.