### PR TITLE
Introduce environment variable `SSD_DISABLE_PAINTING`

### DIFF
--- a/src/SolidStateDetector/DetectorGeometries.jl
+++ b/src/SolidStateDetector/DetectorGeometries.jl
@@ -364,10 +364,12 @@ function set_pointtypes_and_fixed_potentials!(pointtypes::Array{PointType, N}, p
         else
             contact.id == weighting_potential_contact_id ? 1 : 0
         end
-        contact_gridpoints = paint_object(ssd, contact, grid)
-        for gridpoint in contact_gridpoints
-            potential[ gridpoint... ] = pot
-            pointtypes[ gridpoint... ] = zero(PointType)
+        if !(haskey(ENV, "SSD_DISABLE_PAINTING"))
+            contact_gridpoints = paint_object(ssd, contact, grid)
+            for gridpoint in contact_gridpoints
+                potential[ gridpoint... ] = pot
+                pointtypes[ gridpoint... ] = zero(PointType)
+            end
         end
     end
     nothing
@@ -428,10 +430,12 @@ function set_pointtypes_and_fixed_potentials!(pointtypes::Array{PointType, N}, p
         else
             contact.id == weighting_potential_contact_id ? 1 : 0
         end
-        contact_gridpoints = paint_object(ssd, contact,grid)
-        for gridpoint in contact_gridpoints
-            potential[ gridpoint... ] = pot
-            pointtypes[ gridpoint... ] = zero(PointType)
+        if !(haskey(ENV, "SSD_DISABLE_PAINTING"))
+            contact_gridpoints = paint_object(ssd, contact,grid)
+            for gridpoint in contact_gridpoints
+                potential[ gridpoint... ] = pot
+                pointtypes[ gridpoint... ] = zero(PointType)
+            end
         end
     end
     nothing


### PR DESCRIPTION
If this variable exists, SSD will not paint the contacts onto the grid.