### PR TITLE
Surfaceprimitives

### DIFF
--- a/src/ConstructiveSolidGeometry/ConstructiveSolidGeometry.jl
+++ b/src/ConstructiveSolidGeometry/ConstructiveSolidGeometry.jl
@@ -34,6 +34,7 @@ module ConstructiveSolidGeometry
     include("VolumePrimitives/VolumePrimitives.jl")
     include("SurfacePrimitives/SurfacePrimitives.jl")
     include("Sampling.jl")
+    include("DistanceToSurface.jl")
     include("Transformations.jl")
     include("Intervals.jl")
     include("CSG.jl")

--- a/src/ConstructiveSolidGeometry/DistanceToSurface.jl
+++ b/src/ConstructiveSolidGeometry/DistanceToSurface.jl
@@ -1,0 +1,3 @@
+function distance_to_surface(point::AbstractCoordinatePoint{T}, c::AbstractVolumePrimitive{T}) where {T}
+    minimum([ distance_to_surface(point,surf) for surf in get_decomposed_surfaces(c)])
+end

--- a/src/ConstructiveSolidGeometry/GeometryRounding.jl
+++ b/src/ConstructiveSolidGeometry/GeometryRounding.jl
@@ -20,3 +20,7 @@ end
 function geom_round(pt::CartesianPoint{T})::CartesianPoint{T} where {T <: Real}
     return CartesianPoint{T}( geom_round(pt.x), geom_round(pt.y), geom_round(pt.z)  )
 end
+
+function geom_round(vpt::Vector{CP}) where {CP <: AbstractCoordinatePoint}
+    [geom_round(pt) for pt in vpt]
+end

--- a/src/ConstructiveSolidGeometry/PointsAndVectors.jl
+++ b/src/ConstructiveSolidGeometry/PointsAndVectors.jl
@@ -109,6 +109,11 @@ end
 
 @inline _in_torr_θ(p::CylindricalPoint{T}, r_torus::Real, θ::AbstractInterval) where {T} = mod(atan(p.z, p.r - r_torus), T(2π)) in θ
 
+function Δ_φ(φ1::T, φ2::T)::T where {T}
+    δφ = mod(φ2 - φ1, T(2π))
+    min(δφ, T(2π) - δφ)
+end
+
 """
     struct CartesianVector{T} <: AbstractCoordinateVector{T, Cartesian}
 

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/ConalPlane.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/ConalPlane.jl
@@ -55,3 +55,8 @@ function get_vertices(c::ConalPlane{T}) where {T}
     CartesianPoint{T}(rtopMax * cos(c.φ), rtopMax * sin(c.φ), zMax),
     CartesianPoint{T}(rtopMin * cos(c.φ), rtopMin * sin(c.φ), zMax)]
 end
+
+function distance_to_surface(point::AbstractCoordinatePoint{T}, c::ConalPlane{T})::T where {T}
+    point = CartesianPoint(point)
+    distance_to_surface(point, Plane(unique(geom_round(get_vertices(c)))...; p4_on_plane_check = false))
+end

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/ConalPlane.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/ConalPlane.jl
@@ -58,5 +58,5 @@ end
 
 function distance_to_surface(point::AbstractCoordinatePoint{T}, c::ConalPlane{T})::T where {T}
     point = CartesianPoint(point)
-    distance_to_surface(point, Plane(unique(geom_round(get_vertices(c)))...; p4_on_plane_check = false))
+    distance_to_surface(point, Plane(unique(get_vertices(c))..., p4_on_plane_check = false))
 end

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/ConeMantle.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/ConeMantle.jl
@@ -87,3 +87,23 @@ function sample(c::ConeMantle{T}, Nsamps::NTuple{3,Int}) where {T}
         for φ in (Nsamps[2] ≤ 1 ? φMin : range(φMin, φMax, length = Nsamps[2]))
     ]
 end
+
+function distance_to_surface(point::AbstractCoordinatePoint{T}, c::ConeMantle{T, <:Any, Nothing, <:Any})::T where {T}
+    pcy = CylindricalPoint(point)
+    rbot::T, rtop::T = get_r_limits(c)
+    zMin::T, zMax::T = get_z_limits(c)
+    distance_to_line_segment(CartesianPoint{T}(pcy.r,0,pcy.z), (CartesianPoint{T}(rbot,0,zMin),CartesianPoint{T}(rtop,0,zMax)))
+end
+
+function distance_to_surface(point::AbstractCoordinatePoint{T}, c::ConeMantle{T, <:Any, <:AbstractInterval, <:Any})::T where {T}
+    pcy = CylindricalPoint(point)
+    φMin::T, φMax::T, _ = get_φ_limits(c)
+    rbot::T, rtop::T = get_r_limits(c)
+    zMin::T, zMax::T = get_z_limits(c)
+    if _in_φ(pcy, c.φ)
+        return distance_to_line_segment(CartesianPoint{T}(pcy.r,0,pcy.z), (CartesianPoint{T}(rbot,0,zMin),CartesianPoint{T}(rtop,0,zMax)))
+    else
+        φNear = Δ_φ(T(pcy.φ),φMin) ≤ Δ_φ(T(pcy.φ),φMax) ? φMin : φMax
+        return distance_to_line_segment(point, (CylindricalPoint{T}(rbot,φNear,zMin),CylindricalPoint{T}(rtop,φNear,zMax)))
+    end
+end

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/CylindricalAnnulus.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/CylindricalAnnulus.jl
@@ -68,7 +68,11 @@ function distance_to_surface(point::AbstractCoordinatePoint{T}, a::CylindricalAn
         return _in_cyl_r(pcy, a.r) ? Δz : hypot(Δz, min(abs(pcy.r - rMin), abs(pcy.r - rMax)))
     else
         φNear = Δ_φ(T(pcy.φ),φMin) ≤ Δ_φ(T(pcy.φ),φMax) ? φMin : φMax
-        return distance_to_line_segment(point, (CylindricalPoint{T}(rMin,φNear,a.z),CylindricalPoint{T}(rMax,φNear,a.z)))
+        if rMin == rMax
+            return norm(CartesianPoint(point)-CartesianPoint(CylindricalPoint{T}(rMin,φNear,a.z)))
+        else
+            return distance_to_line_segment(point, (CylindricalPoint{T}(rMin,φNear,a.z),CylindricalPoint{T}(rMax,φNear,a.z)))
+        end
         #=Δφ = min(Δ_φ(T(point.φ),φMin),Δ_φ(T(point.φ),φMax))
         y, x = point.r .* sincos(Δφ)
         d = if x < rMin

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/ToroidalAnnulus.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/ToroidalAnnulus.jl
@@ -54,3 +54,13 @@ function sample(t::ToroidalAnnulus{T}, Nsamps::NTuple{3,Int}) where {T}
         for θ in (Nsamps[3] ≤ 1 ? θMin : range(θMin, θMax, length = Nsamps[3]))
     ]
 end
+
+function distance_to_surface(point::AbstractCoordinatePoint{T}, t::ToroidalAnnulus{T})::T where {T}
+    point = CartesianPoint(point)
+    r_tubeMin::T, r_tubeMax::T = get_r_tube_limits(t)
+    θMin::T, θMax::T, _ = get_θ_limits(t)
+    sφ, cφ = sincos(t.φ)
+    tri = Triangle(CartesianPoint{T}(t.r_torus*cφ, t.r_torus*sφ, 0), CartesianPoint{T}((t.r_torus+r_tubeMax)*cφ, (t.r_torus+r_tubeMax)*sφ, 0), CartesianPoint{T}(t.r_torus*cφ, t.r_torus*sφ, r_tubeMax))
+    point = CartesianPoint{T}((get_planar_coordinates(point, tri).*norm.(get_spanning_vectors(tri)))...,distance_to_infinite_plane(point, tri))
+    distance_to_surface(point, CylindricalAnnulus(r_tubeMin, r_tubeMax, θMin, θMax, T(0)))
+end

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/TorusMantle.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/TorusMantle.jl
@@ -61,3 +61,21 @@ function sample(t::TorusMantle{T}, Nsamps::NTuple{3,Int}) where {T}
         for θ in (Nsamps[3] ≤ 1 ? θMin : range(θMin, θMax, length = Nsamps[3]))
     ]
 end
+
+function distance_to_surface(point::AbstractCoordinatePoint{T}, t::TorusMantle{T, <:Any, <:Any, Nothing, <:Any})::T where {T}
+    point = CylindricalPoint(point)
+    θMin::T, θMax::T, _ = get_θ_limits(t)
+    distance_to_surface(CartesianPoint{T}(point.r-t.r_torus,point.z,T(0)), CylindricalAnnulus(t.r_tube, t.r_tube, θMin, θMax, T(0)))
+end
+
+function distance_to_surface(point::AbstractCoordinatePoint{T}, t::TorusMantle{T, <:Any, <:Any, <:AbstractInterval, <:Any})::T where {T}
+    θMin::T, θMax::T, _ = get_θ_limits(t)
+    if _in_φ(point, t.φ)
+        return distance_to_surface(CartesianPoint{T}(point.r-t.r_torus,point.z,T(0)), CylindricalAnnulus(t.r_tube, t.r_tube, θMin, θMax, T(0)))
+    else
+        φMin::T, φMax::T, _ = get_φ_limits(t)
+        pcy = CylindricalPoint(point)
+        φNear = Δ_φ(T(pcy.φ),φMin) ≤ Δ_φ(T(pcy.φ),φMax) ? φMin : φMax
+        return distance_to_surface(point, ToroidalAnnulus(t.r_torus, t.r_tube, t.r_tube, φNear, θMin, θMax))
+    end
+end

--- a/src/ConstructiveSolidGeometry/VolumePrimitives/Cone.jl
+++ b/src/ConstructiveSolidGeometry/VolumePrimitives/Cone.jl
@@ -99,13 +99,13 @@ get_φ_limits(c::Cone{T, <:Any, <:AbstractInterval, <:Any}) where {T} = (c.φ.le
 
 get_z_limits(c::Cone{T}) where {T} = (_left_linear_interval(c.z), _right_linear_interval(c.z))
 
-function _get_decomposed_surfaces_cone(c::Cone{T}, rbotMax, rtopMax, zMin, zMax) where {T}
+function _get_decomposed_surfaces_cone(c::Cone{T}, rbotMin, rbotMax, rtopMin, rtopMax, zMin, zMax) where {T}
     surfaces = AbstractSurfacePrimitive[]
     #top and bottom annulus
-    if rbotMax ≠ 0
+    if rbotMax ≠ rbotMin
         push!(surfaces, CylindricalAnnulus(c, z = zMin))
     end
-    if rtopMax ≠ 0
+    if rtopMax ≠ rtopMin
         push!(surfaces, CylindricalAnnulus(c, z = zMax))
     end
     #outer conemantle
@@ -118,14 +118,14 @@ end
 function get_decomposed_surfaces(c::Cone{T, <:Union{T, Tuple{T,T}}, Nothing, <:Any}) where {T}
     rbotMin::T, rbotMax::T, rtopMin::T, rtopMax::T = get_r_limits(c)
     zMin::T, zMax::T = get_z_limits(c)
-    surfaces = _get_decomposed_surfaces_cone(c, rbotMax, rtopMax, zMin, zMax)
+    surfaces = _get_decomposed_surfaces_cone(c, rbotMin, rbotMax, rtopMin, rtopMax, zMin, zMax)
     unique(surfaces)
 end
 
 function get_decomposed_surfaces(c::Cone{T, <:Union{<:AbstractInterval{T}, Tuple{I,I}}, Nothing, <:Any}) where {T, I<:AbstractInterval{T}}
     rbotMin::T, rbotMax::T, rtopMin::T, rtopMax::T = get_r_limits(c)
     zMin::T, zMax::T = get_z_limits(c)
-    surfaces = _get_decomposed_surfaces_cone(c, rbotMax, rtopMax, zMin, zMax)
+    surfaces = _get_decomposed_surfaces_cone(c, rbotMin, rbotMax, rtopMin, rtopMax, zMin, zMax)
     push!(surfaces, ConeMantle(c, rbot = rbotMin, rtop = rtopMin))
     unique(surfaces)
 end
@@ -135,7 +135,7 @@ function get_decomposed_surfaces(c::Cone{T, <:Union{T, Tuple{T,T}}, <:AbstractIn
     rbotMin::T, rbotMax::T, rtopMin::T, rtopMax::T = get_r_limits(c)
     zMin::T, zMax::T = get_z_limits(c)
     φMin::T, φMax::T, _ = get_φ_limits(c)
-    surfaces = _get_decomposed_surfaces_cone(c, rbotMax, rtopMax, zMin, zMax)
+    surfaces = _get_decomposed_surfaces_cone(c, rbotMin, rbotMax, rtopMin, rtopMax, zMin, zMax)
     for φ in [φMin, φMax]
         push!(surfaces, ConalPlane(c, φ = φ))
     end
@@ -146,7 +146,7 @@ function get_decomposed_surfaces(c::Cone{T, <:Union{<:AbstractInterval{T}, Tuple
     rbotMin::T, rbotMax::T, rtopMin::T, rtopMax::T = get_r_limits(c)
     zMin::T, zMax::T = get_z_limits(c)
     φMin::T, φMax::T, _ = get_φ_limits(c)
-    surfaces = _get_decomposed_surfaces_cone(c, rbotMax, rtopMax, zMin, zMax)
+    surfaces = _get_decomposed_surfaces_cone(c, rbotMin, rbotMax, rtopMin, rtopMax, zMin, zMax)
     for φ in [φMin, φMax]
         push!(surfaces, ConalPlane(c, φ = φ))
     end

--- a/src/ConstructiveSolidGeometry/plotting/SurfacePrimitives/ConalPlane.jl
+++ b/src/ConstructiveSolidGeometry/plotting/SurfacePrimitives/ConalPlane.jl
@@ -1,10 +1,6 @@
 function get_plot_points(c::ConalPlane{T}; n = 30) where {T <: AbstractFloat}
-    plot_points = Vector{CartesianPoint{T}}[]
     v = get_vertices(c)
-    push!(plot_points, Vector{CartesianPoint{T}}([v[1], v[2]]))
-    push!(plot_points, Vector{CartesianPoint{T}}([v[2], v[3]]))
-    push!(plot_points, Vector{CartesianPoint{T}}([v[3], v[4]]))
-    push!(plot_points, Vector{CartesianPoint{T}}([v[4], v[1]]))
+    [Vector{CartesianPoint{T}}([v[1], v[2]]), Vector{CartesianPoint{T}}([v[2], v[3]]), Vector{CartesianPoint{T}}([v[3], v[4]]), Vector{CartesianPoint{T}}([v[4], v[1]])]
 end
 
 function mesh(c::ConalPlane{T}; n = 30) where {T <: AbstractFloat}

--- a/src/ConstructiveSolidGeometry/plotting/SurfacePrimitives/ConalPlane.jl
+++ b/src/ConstructiveSolidGeometry/plotting/SurfacePrimitives/ConalPlane.jl
@@ -8,5 +8,5 @@ function mesh(c::ConalPlane{T}; n = 30) where {T <: AbstractFloat}
     while length(v) < 3
         push!(v,v[1])
     end
-    mesh(Plane(v...))
+    mesh(Plane(v..., p4_on_plane_check = false))
  end


### PR DESCRIPTION
I have added the distance_to_surface function for all the conal surfaces (ConeMantle, CylindricalAnnulus, ConalPlane) and made small corrections to their dependency in SurfacePrimitives/Plane.jl. An example follows
`cone = CSG.Cone(0, 1, 1, 3, π/6, 3π/2, -3, 3)`
`plot(cone, SSD_style = :surface, color = color, camera = (30,30))`
`plot!(cone, SSD_style = :wireframe, color = :black)`
![distance_to_cone](https://user-images.githubusercontent.com/41748838/108245407-89505e00-7150-11eb-990a-561aed22470f.png)
We can scan the cone along z to explore the distance to surface of the cone for each point in the world
`D[i,j] = CSG.distance_to_surface(CSG.CylindricalPoint{T}(r,φ,z),cone)`
`heatmap(Φ,R,D, c = cgrad(:inferno, scale =:exp), clims = (0,3), projection = :polar, title = string("z = ",z))`
![zcuts](https://user-images.githubusercontent.com/41748838/108247787-65dae280-7153-11eb-81e7-dfe1d403217a.gif)
Lest take a closer look at z = 2. I have also used the `in` function as a further check
`point = CSG.CylindricalPoint{T}(r,φ,2)`
 `D[i,j] = point in a ? CSG.distance_to_surface(point,cone) : NaN`
`heatmap(Φ,R,D, c = cgrad(:inferno, scale =:exp), projection = :polar, title = "z = 2")`
![z2cut](https://user-images.githubusercontent.com/41748838/108247803-6b382d00-7153-11eb-9eec-909d2ca31b35.png)
We can also scan the cone along φ 
`D[j,i] = CSG.distance_to_surface(CSG.CylindricalPoint{T}(r,φ*π/180,z),cone) `
`heatmap(R,Z,D, c = cgrad(:inferno, scale =:exp), clims = (0,3), title = string("φ = ", φ, "°"), aspect_ratio = 1)`
![phicuts](https://user-images.githubusercontent.com/41748838/108246133-5fe40200-7151-11eb-9de4-f62b7b22f19d.gif)
Lest take a closer look at φ = 90°
`point = CSG.CylindricalPoint{T}(r,π/2,z)`
`D[j,i] = point in a ? CSG.distance_to_surface(point,cone) : NaN`
`heatmap(R,Z,D, c = cgrad(:inferno, scale =:exp), title = string("φ = 90°"), aspect_ratio = 1)`
![phi90cut](https://user-images.githubusercontent.com/41748838/108246157-65414c80-7151-11eb-9b82-e19c9e2e33da.png)
