### PR TITLE
Remove uniq() function from SSD

### DIFF
--- a/src/Axes/DiscreteAxis.jl
+++ b/src/Axes/DiscreteAxis.jl
@@ -65,28 +65,11 @@ function get_boundary_types(ax::DiscreteAxis{T,LB,RB})::NTuple{4, Symbol} where 
     return LB, RB, get_boundary_types(ax.interval)...
 end
 
-
-function uniq(v::Vector{T})::Vector{T} where {T <: Real}
-    v1::Vector{T} = Vector{T}()
-    if length(v) > 0
-        laste::T = v[1]
-        push!(v1, laste)
-        for e in v
-            if e != laste
-                laste = e
-                push!(v1, laste)
-            end
-        end
-    end
-    return v1
-end
-
 function merge_axis_ticks_with_important_ticks(ax::DiscreteAxis{T}, impticks::Vector{T}; atol::Real = 0.0001 )::Vector{T} where {T}
     v::Vector{T} = T[]
     for r in impticks if in(r, ax.interval) push!(v, r) end end
     for r in ax push!(v, r) end
-    sort!(v)
-    v = uniq(v)
+    unique!(sort!(v))
     delete_idcs::Vector{Int} = Int[]
     for i in 1:(length(v) - 1)
         if (v[i + 1] - v[i]) < atol
@@ -94,7 +77,7 @@ function merge_axis_ticks_with_important_ticks(ax::DiscreteAxis{T}, impticks::Ve
             if !in(v[i + 1], impticks) push!(delete_idcs, i + 1) end
         end
     end
-    delete_idcs = sort(uniq(delete_idcs))
+    unique!(sort!(delete_idcs))
     deleteat!(v, delete_idcs) 
     for impv in impticks
         if !in(impv, v) && in(impv, ax.interval)

--- a/src/PotentialSimulation/ConvergenceAndRefinement.jl
+++ b/src/PotentialSimulation/ConvergenceAndRefinement.jl
@@ -251,7 +251,7 @@ function _get_refinement_inds( potential::Array{T, 3}, grid::Grid{T, 3, :cylindr
     if isodd(length(inds_z)) inds_z = inds_z[1:end-1] end
     @assert iseven(length(inds_z)) "Refinement would result in uneven grid in z."
 
-    return sort(inds_r), sort(inds_φ), sort(inds_z)
+    return sort!(inds_r), sort!(inds_φ), sort!(inds_z)
 end
 
 
@@ -356,7 +356,7 @@ function _get_refinement_inds(  potential::Array{T, 3}, grid::Grid{T, 3, :cartes
     @assert iseven(length(inds_x)) "Refinement would result in uneven grid in x. This is not allowed since this is the red black dimension."
     
 
-    return sort(inds_x), sort(inds_y), sort(inds_z)
+    return sort!(inds_x), sort!(inds_y), sort!(inds_z)
 end
 
 function refine(p::ScalarPotential, max_diffs::Tuple{<:Real,<:Real,<:Real}, minimum_distances::Tuple{<:Real,<:Real,<:Real})::typeof(p) 

--- a/src/SolidStateDetector/DetectorGeometries.jl
+++ b/src/SolidStateDetector/DetectorGeometries.jl
@@ -156,7 +156,7 @@ function get_important_points(c::SolidStateDetector{T}, s::Symbol)::Vector{T} wh
             append!(imp, get_important_points(g, Val{s}()))
         end
     end
-    return uniq(sort(imp))
+    return unique!(sort!(imp))
 end
 
 
@@ -513,13 +513,13 @@ function Grid(  detector::SolidStateDetector{T, :cylindrical};
 
     push!(important_r_points, detector.world.intervals[1].left)
     push!(important_r_points, detector.world.intervals[1].right)
-    important_r_points = uniq(sort(important_r_points))
+    unique!(sort!(important_r_points))
     push!(important_z_points, detector.world.intervals[3].left)
     push!(important_z_points, detector.world.intervals[3].right)
-    important_z_points = uniq(sort(important_z_points))
+    unique!(sort!(important_z_points))
     push!(important_φ_points, detector.world.intervals[2].left)
     push!(important_φ_points, detector.world.intervals[2].right)
-    important_φ_points = uniq(sort(important_φ_points))
+    unique!(sort!(important_φ_points))
 
     # r
     L, R, BL, BR = get_boundary_types(detector.world.intervals[1])

--- a/src/SolidStateDetector/SolidStateDetector.jl
+++ b/src/SolidStateDetector/SolidStateDetector.jl
@@ -123,8 +123,8 @@ function get_world_limits_from_objects(S::Val{:cylindrical}, s::Vector{Semicondu
             end
         end
     end
-    imps_1 = uniq(sort(imps_1))
-    imps_3 = uniq(sort(imps_3))
+    unique!(sort!(imps_1))
+    unique!(sort!(imps_3))
     if length(imps_1) > 1
         ax1l = minimum(imps_1)
         ax1r = maximum(imps_1)
@@ -155,9 +155,9 @@ function get_world_limits_from_objects(S::Val{:cartesian}, s::Vector{Semiconduct
             end
         end
     end
-    imps_1 = uniq(sort(imps_1))
-    imps_2 = uniq(sort(imps_2))
-    imps_3 = uniq(sort(imps_3))
+    unique!(sort!(imps_1))
+    unique!(sort!(imps_2))
+    unique!(sort!(imps_3))
     if length(imps_1) > 1
         ax1l = minimum(imps_1)
         ax1r = maximum(imps_1)
@@ -230,7 +230,7 @@ end
 function Base.sort!(v::AbstractVector{<:AbstractGeometry})
     hierarchies::Vector{Int} = map(x->x.hierarchy,v)
     v_result::typeof(v) = []
-    for idx in sort!(unique!(hierarchies))
+    for idx in unique!(sort!(hierarchies))
         push!(v_result,filter(x->x.hierarchy == hierarchies[idx],v)...)
     end
     return v_result


### PR DESCRIPTION
This PR addresses the `uniq()` function:
```julia
function uniq(v::Vector{T})::Vector{T} where {T <: Real}
    v1::Vector{T} = Vector{T}()
    if length(v) > 0
        laste::T = v[1]
        push!(v1, laste)
        for e in v
            if e != laste
                laste = e
                push!(v1, laste)
            end
        end
    end
    return v1
end
```

This function, to me, is obsolete (#87) and can be perfectly replaced by `unique!()`.
Also: `unique!()` checks if the array is sorted (see [julia/base/set.jl:360](https://github.com/JuliaLang/julia/blob/a58bdd90101796eb0ec761a7a8e5103bd96c2d13/base/set.jl#L360)) and has different inner functions to discard multiple entries, so `sort!()` should always be called before `unique!()`.