### PR TITLE
Update TagBot.yml

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,9 +1,11 @@
 name: TagBot
 on:
-  schedule:
-    - cron: 0 * * * *
+  issue_comment:
+    types:
+      - created
 jobs:
   TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1


### PR DESCRIPTION
GitHub has started automatically disabling Actions workflows that run on a schedule for repositories that have not seen any activity for 60 days. This happened both to our TagBot and our CompatHelper.

Following [this thread](https://discourse.julialang.org/t/ann-required-updates-to-tagbot-yml/49249) on Julia discourse, "inactive" repositories will not trigger the TagBot on schedule, but whenever the TagBot commits on issue #105. However, this requires the changes in `TagBot.yml` found in this PR are required.

I do not know whether there is already a user-friendly and easy option to keep our CompatHelper alive.