### PR TITLE
CSG: distance_to_surface for most surface primitives

### DIFF
--- a/src/ConstructiveSolidGeometry/ConstructiveSolidGeometry.jl
+++ b/src/ConstructiveSolidGeometry/ConstructiveSolidGeometry.jl
@@ -19,13 +19,13 @@ module ConstructiveSolidGeometry
     abstract type Cartesian <: AbstractCoordinateSystem end
     abstract type Cylindrical <: AbstractCoordinateSystem end
     const CoordinateSystemType = Union{Type{Cartesian}, Type{Cylindrical}}
-    
+
     # import Base: print, show
     # print(io::IO, ::Type{Cartesian}) = print(io, "Cartesian")
     # print(io::IO, ::Type{Cylindrical}) = print(io, "Cylindrical")
-    # show(io::IO, CS::CoordinateSystemType) = print(io, CS) 
+    # show(io::IO, CS::CoordinateSystemType) = print(io, CS)
     # show(io::IO,::MIME"text/plain", CS::CoordinateSystemType) = show(io, CS)
-    
+
     # Tuples with ticks to sample with differently spaced ticks
     const CartesianTicksTuple{T} = NamedTuple{(:x,:y,:z), NTuple{3,Vector{T}}}
     const CylindricalTicksTuple{T} = NamedTuple{(:r,:φ,:z), NTuple{3,Vector{T}}}
@@ -43,6 +43,7 @@ module ConstructiveSolidGeometry
     include("PointsAndVectors.jl")
     include("GeometryRounding.jl")
     include("VolumePrimitives/VolumePrimitives.jl")
+    include("LinePrimitives/LinePrimitives.jl")
     include("SurfacePrimitives/SurfacePrimitives.jl")
     include("Transformations.jl")
     include("Intervals.jl")

--- a/src/ConstructiveSolidGeometry/LinePrimitives/Arc.jl
+++ b/src/ConstructiveSolidGeometry/LinePrimitives/Arc.jl
@@ -1,0 +1,58 @@
+struct Arc{T,TP,TH} <: AbstractLinePrimitive{T}
+    r::T
+    center::TP
+    α::TH
+    function Arc( ::Type{T},
+                   r::T,
+                   center::PlanarPoint{T},
+                   α::Union{Nothing, <:AbstractInterval{T}}) where {T}
+        new{T,typeof(center),typeof(α)}(r, center, α)
+    end
+end
+
+function Arc(; r = 0, center = PlanarPoint(0,0), αMin = 0, αMax = 2π)
+    T = float(promote_type(typeof.((r, αMin, αMax))..., eltype(center)))
+    α = mod(T(αMax) - T(αMin), T(2π)) == 0 ? nothing : T(αMin)..T(αMax)
+    Arc(T, T(r), PlanarPoint{T}(center), α)
+end
+
+Arc(r, center, αMin, αMax) = Arc(; r = r, center = center, αMin = αMin, αMax = αMax)
+
+Circle(r::T, center::PlanarPoint{T}) where {T} = Arc(T, r, center, nothing)
+Circle(a::Arc{T}) where {T} = Arc(T, a.r, a.center, nothing)
+
+get_α_at_u_v(a::Arc{T}, u::Real, v::Real) where {T} = mod(atan(v - a.center.v, u - a.center.u), 2π) #u,v are planar coordinates
+
+get_α_limits(a::Arc{T, <:Any, Nothing}) where {T} = (T(0), T(2π), true)
+get_α_limits(a::Arc{T, <:Any, <:AbstractInterval}) where {T} = (a.α.left, a.α.right, false)
+
+
+function sample(a::Arc{T}, step::AbstractFloat) where {T}
+    αMin::T, αMax::T, _ = get_α_limits(a)
+    samples = [PlanarPoint{T}(a.r*cos(α)+a.center.u,a.r*sin(α)+a.center.v) for α in (a.r == 0 ? αMin : αMin:step/a.r:αMax)]
+end
+
+function sample(a::Arc{T}, Nsamps::Int) where {T}
+    αMin::T, αMax::T, _ = get_α_limits(a)
+    samples = [PlanarPoint{T}(a.r*cos(α)+a.center.u,a.r*sin(α)+a.center.v) for α in range(αMin, αMax, length = Nsamps)]
+end
+
+function distance_to_line(point::PlanarPoint{T}, a::Arc{T, <:Any, Nothing}) where {T}
+    p_t = point - a.center
+    r = hypot(p_t.u, p_t.v)
+    abs(a.r - r)
+end
+
+function distance_to_line(point::PlanarPoint{T}, a::Arc{T, <:Any, <:AbstractInterval}) where {T}
+    αMin::T, αMax::T, _ = get_α_limits(a)
+    p_t = point - a.center
+    r = hypot(p_t.u, p_t.v)
+    α = atan(p_t.v, p_t.u)
+    if _in_angular_interval_closed(α, a.α)
+        return abs(a.r - r)
+    else
+        αNear = Δ_φ(T(α),αMin) ≤ Δ_φ(T(α),αMax) ? αMin : αMax
+        sαNear, cαNear = sincos(αNear)
+        return norm(p_t - PlanarPoint{T}(a.r*cαNear, a.r*sαNear))
+    end
+end

--- a/src/ConstructiveSolidGeometry/LinePrimitives/Line.jl
+++ b/src/ConstructiveSolidGeometry/LinePrimitives/Line.jl
@@ -11,18 +11,6 @@ struct Line{T,TP,TL} <: AbstractLinePrimitive{T}
     end
 end
 
-function Line( ::Type{T},
-               p1::PT,
-               p2::PT) where {T, PT <: Union{CartesianPoint{T}, PlanarPoint{T}}} #if (inf)Line there are no endpoints
-    Line(T, p1, p2, Val(:inf))
-end
-
-function Ray( ::Type{T},
-               p1::PT,
-               p2::PT) where {T, PT <: Union{CartesianPoint{T}, PlanarPoint{T}}} #if Ray endpoint is p1
-    Line(T, p1, p2, Val(:ray))
-end
-
 function LineSegment( ::Type{T},
                p1::PT,
                p2::PT) where {T, PT <: Union{CartesianPoint{T}, PlanarPoint{T}}} #if LineSegment endpoints are p1, and p2

--- a/src/ConstructiveSolidGeometry/LinePrimitives/Line.jl
+++ b/src/ConstructiveSolidGeometry/LinePrimitives/Line.jl
@@ -3,48 +3,49 @@ struct Line{T,TP,TL} <: AbstractLinePrimitive{T}
     p2::TP
     linetype::TL
     function Line( ::Type{T},
-                   p1::Union{CartesianPoint{T}, PlanarPoint{T}},
-                   p2::Union{CartesianPoint{T}, PlanarPoint{T}},
-                   linetype::Union{Val{:inf}, Val{:ray}, Val{:seg}}) where {T}
+                   p1::PT,
+                   p2::PT,
+                   linetype::Union{Val{:inf}, Val{:ray}, Val{:seg}}
+                 ) where {T, PT <: Union{CartesianPoint{T}, PlanarPoint{T}}}
         new{T,typeof(p1),typeof(linetype)}(p1, p2)
     end
 end
 
 function Line( ::Type{T},
-               p1::Union{CartesianPoint{T}, PlanarPoint{T}},
-               p2::Union{CartesianPoint{T}, PlanarPoint{T}}) where {T} #if (inf)Line there are no endpoints
+               p1::PT,
+               p2::PT) where {T, PT <: Union{CartesianPoint{T}, PlanarPoint{T}}} #if (inf)Line there are no endpoints
     Line(T, p1, p2, Val(:inf))
 end
 
 function Ray( ::Type{T},
-               p1::Union{CartesianPoint{T}, PlanarPoint{T}},
-               p2::Union{CartesianPoint{T}, PlanarPoint{T}}) where {T} #if Ray endpoint is p1
+               p1::PT,
+               p2::PT) where {T, PT <: Union{CartesianPoint{T}, PlanarPoint{T}}} #if Ray endpoint is p1
     Line(T, p1, p2, Val(:ray))
 end
 
 function LineSegment( ::Type{T},
-               p1::Union{CartesianPoint{T}, PlanarPoint{T}},
-               p2::Union{CartesianPoint{T}, PlanarPoint{T}}) where {T} #if LineSegment endpoints are p1, and p2
+               p1::PT,
+               p2::PT) where {T, PT <: Union{CartesianPoint{T}, PlanarPoint{T}}} #if LineSegment endpoints are p1, and p2
     Line(T, p1, p2, Val(:seg))
 end
-
-Line(l::Line{T}) where {T} = Line(T, l.p1, l.p2)
 
 get_line_vector(l::Line{T,PlanarPoint{T}}) where {T} = normalize(PlanarVector{T}(l.p2 - l.p1))
 get_line_vector(l::Line{T,CartesianPoint{T}}) where {T} = normalize(CartesianVector{T}(l.p2 - l.p1))
 
-
-function distance_to_line(point::Union{PlanarPoint{T}, CartesianPoint{T}}, l::Line{T, <:Any, Val{:inf}})::T where {T}
-    v12 = normalize(l.p2 - l.p1)
-    v_point_1 = point - l.p1
-    proj_on_v12 = dot(v12,v_point_1)
-    return sqrt(abs(dot(v_point_1,v_point_1) - proj_on_v12^2))
-end
-
-function distance_to_line(point::Union{PlanarPoint{T}, CartesianPoint{T}}, l::Line{T, <:Any, Val{:ray}})::T where {T}
+function _distance_to_line(point::TP, l::Line{T, TP}) where {T, TP <: Union{PlanarPoint{T}, CartesianPoint{T}}}
     v12 = get_line_vector(l)
     v_point_1 = point - l.p1
     proj_on_v12 = dot(v12,v_point_1)
+    return v12, v_point_1, proj_on_v12
+end
+
+function distance_to_line(point::TP, l::Line{T, TP, Val{:inf}})::T where {T, TP <: Union{PlanarPoint{T}, CartesianPoint{T}}}
+    v12, v_point_1, proj_on_v12 = _distance_to_line(point, l)
+    return sqrt(abs(dot(v_point_1,v_point_1) - proj_on_v12^2))
+end
+
+function distance_to_line(point::TP, l::Line{T, TP, Val{:ray}})::T where {T, TP <: Union{PlanarPoint{T}, CartesianPoint{T}}}
+    v12, v_point_1, proj_on_v12 = _distance_to_line(point, l)
     if proj_on_v12 ≤ T(0)
         return norm(l.p1 - point)
     else
@@ -57,10 +58,8 @@ function distance_to_line(point::Union{PlanarPoint{T}, CartesianPoint{T}}, l::Li
     end
 end
 
-function distance_to_line(point::Union{PlanarPoint{T}, CartesianPoint{T}}, l::Line{T, <:Any, Val{:seg}})::T where {T}
-    v12 = get_line_vector(l)
-    v_point_1 = point - l.p1
-    proj_on_v12 = dot(v12,v_point_1)
+function distance_to_line(point::TP, l::Line{T, TP, Val{:seg}})::T where {T, TP <: Union{PlanarPoint{T}, CartesianPoint{T}}}
+    v12, v_point_1, proj_on_v12 = _distance_to_line(point, l)
     if proj_on_v12 ≤ T(0)
         return norm(l.p1 - point)
     else

--- a/src/ConstructiveSolidGeometry/LinePrimitives/Line.jl
+++ b/src/ConstructiveSolidGeometry/LinePrimitives/Line.jl
@@ -1,0 +1,74 @@
+struct Line{T,TP,TL} <: AbstractLinePrimitive{T}
+    p1::TP
+    p2::TP
+    linetype::TL
+    function Line( ::Type{T},
+                   p1::Union{CartesianPoint{T}, PlanarPoint{T}},
+                   p2::Union{CartesianPoint{T}, PlanarPoint{T}},
+                   linetype::Union{Val{:inf}, Val{:ray}, Val{:seg}}) where {T}
+        new{T,typeof(p1),typeof(linetype)}(p1, p2)
+    end
+end
+
+function Line( ::Type{T},
+               p1::Union{CartesianPoint{T}, PlanarPoint{T}},
+               p2::Union{CartesianPoint{T}, PlanarPoint{T}}) where {T} #if (inf)Line there are no endpoints
+    Line(T, p1, p2, Val(:inf))
+end
+
+function Ray( ::Type{T},
+               p1::Union{CartesianPoint{T}, PlanarPoint{T}},
+               p2::Union{CartesianPoint{T}, PlanarPoint{T}}) where {T} #if Ray endpoint is p1
+    Line(T, p1, p2, Val(:ray))
+end
+
+function LineSegment( ::Type{T},
+               p1::Union{CartesianPoint{T}, PlanarPoint{T}},
+               p2::Union{CartesianPoint{T}, PlanarPoint{T}}) where {T} #if LineSegment endpoints are p1, and p2
+    Line(T, p1, p2, Val(:seg))
+end
+
+Line(l::Line{T}) where {T} = Line(T, l.p1, l.p2)
+
+get_line_vector(l::Line{T,PlanarPoint{T}}) where {T} = normalize(PlanarVector{T}(l.p2 - l.p1))
+get_line_vector(l::Line{T,CartesianPoint{T}}) where {T} = normalize(CartesianVector{T}(l.p2 - l.p1))
+
+
+function distance_to_line(point::Union{PlanarPoint{T}, CartesianPoint{T}}, l::Line{T, <:Any, Val{:inf}})::T where {T}
+    v12 = normalize(l.p2 - l.p1)
+    v_point_1 = point - l.p1
+    proj_on_v12 = dot(v12,v_point_1)
+    return sqrt(abs(dot(v_point_1,v_point_1) - proj_on_v12^2))
+end
+
+function distance_to_line(point::Union{PlanarPoint{T}, CartesianPoint{T}}, l::Line{T, <:Any, Val{:ray}})::T where {T}
+    v12 = get_line_vector(l)
+    v_point_1 = point - l.p1
+    proj_on_v12 = dot(v12,v_point_1)
+    if proj_on_v12 ≤ T(0)
+        return norm(l.p1 - point)
+    else
+        v_point_2 = point - l.p2
+        if dot(v12,v_point_2) ≥ T(0)
+            return norm(l.p2 - point)
+        else
+            return sqrt(abs(dot(v_point_1,v_point_1) - proj_on_v12^2))
+        end
+    end
+end
+
+function distance_to_line(point::Union{PlanarPoint{T}, CartesianPoint{T}}, l::Line{T, <:Any, Val{:seg}})::T where {T}
+    v12 = get_line_vector(l)
+    v_point_1 = point - l.p1
+    proj_on_v12 = dot(v12,v_point_1)
+    if proj_on_v12 ≤ T(0)
+        return norm(l.p1 - point)
+    else
+        v_point_2 = point - l.p2
+        if dot(v12,v_point_2) ≥ T(0)
+            return norm(l.p2 - point)
+        else
+            return sqrt(abs(dot(v_point_1,v_point_1) - proj_on_v12^2))
+        end
+    end
+end

--- a/src/ConstructiveSolidGeometry/LinePrimitives/LinePrimitives.jl
+++ b/src/ConstructiveSolidGeometry/LinePrimitives/LinePrimitives.jl
@@ -1,0 +1,2 @@
+include("Line.jl")
+include("Arc.jl")

--- a/src/ConstructiveSolidGeometry/PointsAndVectors.jl
+++ b/src/ConstructiveSolidGeometry/PointsAndVectors.jl
@@ -129,6 +129,8 @@ function Δ_φ(φ1::T, φ2::T)::T where {T}
     min(δφ, T(2π) - δφ)
 end
 
+_φNear(φ::Real, φMin::T, φMax::T) where {T} = Δ_φ(T(φ),φMin) ≤ Δ_φ(T(φ),φMax) ? φMin : φMax
+
 struct PlanarVector{T} <: AbstractPlanarVector{T}
     u::T
     v::T

--- a/src/ConstructiveSolidGeometry/PointsAndVectors.jl
+++ b/src/ConstructiveSolidGeometry/PointsAndVectors.jl
@@ -1,6 +1,13 @@
 abstract type AbstractCoordinatePoint{T, S} <: StaticArrays.FieldVector{3, T} end
 abstract type AbstractCoordinateVector{T, S} <: StaticArrays.FieldVector{3, T} end
 
+abstract type AbstractPlanarPoint{T} <: StaticArrays.FieldVector{2, T} end
+abstract type AbstractPlanarVector{T} <: StaticArrays.FieldVector{2, T} end
+
+struct PlanarPoint{T} <: AbstractPlanarPoint{T}
+    u::T
+    v::T
+end
 
 """
     struct CartesianPoint{T} <: AbstractCoordinatePoint{T, Cartesian}
@@ -17,6 +24,9 @@ end
 
 @inline _eq_cyl_r(p::CartesianPoint{T}, r::Real) where {T} = hypot(p.x, p.y) == T(r)
 
+@inline _in_planar_r(p::PlanarPoint, r::Real) = hypot(p.u, p.v) <= r
+@inline _in_planar_r(p::PlanarPoint, r::AbstractInterval) = hypot(p.u, p.v) in r
+
 @inline _in_cyl_r(p::CartesianPoint, r::Real) = hypot(p.x, p.y) <= r
 @inline _in_cyl_r(p::CartesianPoint, r::AbstractInterval) = hypot(p.x, p.y) in r
 
@@ -24,11 +34,17 @@ end
 
 @inline _in_φ(p::CartesianPoint{T}, φ::AbstractInterval) where {T} = _in_angular_interval_closed(mod(atan(p.y, p.x), T(2π)), φ)
 
+@inline _in_planar_α(p::PlanarPoint{T}, α::AbstractInterval) where {T} = _in_angular_interval_closed(mod(atan(p.v, p.u), T(2π)), α)
+
 @inline _in_x(p::CartesianPoint, x::Real) = abs(p.x) <= x
 @inline _in_x(p::CartesianPoint, x::AbstractInterval) = p.x in x
 
+@inline _in_planar_u(p::PlanarPoint, u::AbstractInterval) = p.u in u
+
 @inline _in_y(p::CartesianPoint, y::Real) = abs(p.y) <= y
 @inline _in_y(p::CartesianPoint, y::AbstractInterval) = p.y in y
+
+@inline _in_planar_v(p::PlanarPoint, v::AbstractInterval) = p.v in v
 
 @inline _eq_z(p::CartesianPoint{T}, z::Real) where {T} = p.z == T(z)
 
@@ -113,6 +129,10 @@ function Δ_φ(φ1::T, φ2::T)::T where {T}
     min(δφ, T(2π) - δφ)
 end
 
+struct PlanarVector{T} <: AbstractPlanarVector{T}
+    u::T
+    v::T
+end
 
 """
     struct CartesianVector{T} <: AbstractCoordinateVector{T, Cartesian}

--- a/src/ConstructiveSolidGeometry/PointsAndVectors.jl
+++ b/src/ConstructiveSolidGeometry/PointsAndVectors.jl
@@ -124,12 +124,12 @@ end
 
 @inline _in_torr_θ(p::CylindricalPoint{T}, r_torus::Real, θ::AbstractInterval, z_torus::Real) where {T} = _in_angular_interval_closed(mod(atan(p.z - z_torus, p.r - r_torus), T(2π)), θ)
 
-function Δ_φ(φ1::T, φ2::T)::T where {T}
+function _Δφ(φ1::T, φ2::T)::T where {T}
     δφ = mod(φ2 - φ1, T(2π))
     min(δφ, T(2π) - δφ)
 end
 
-_φNear(φ::Real, φMin::T, φMax::T) where {T} = Δ_φ(T(φ),φMin) ≤ Δ_φ(T(φ),φMax) ? φMin : φMax
+_φNear(φ::Real, φMin::T, φMax::T) where {T} = _Δφ(T(φ),φMin) ≤ _Δφ(T(φ),φMax) ? φMin : φMax
 
 struct PlanarVector{T} <: AbstractPlanarVector{T}
     u::T

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/ConalPlane.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/ConalPlane.jl
@@ -103,19 +103,23 @@ function distance_to_surface(point::AbstractCoordinatePoint{T}, c::ConalPlane{T}
     d, r_on_plane = pcy.r .* sincos(Δφ)
     if point.z ≥ zMax
         if r_on_plane ≥ rtopMax
-            return hypot(d, point.z-zMax, r_on_plane-rtopMax)
+            line = LineSegment(T, PlanarPoint{T}(rbotMax,zMin), PlanarPoint{T}(rtopMax,zMax))
+            return hypot(d, distance_to_line(PlanarPoint{T}(r_on_plane,point.z), line))
         elseif r_on_plane ≤ rtopMin
-            return hypot(d, point.z-zMax, rtopMin - r_on_plane)
+            line = LineSegment(T, PlanarPoint{T}(rbotMin,zMin), PlanarPoint{T}(rtopMin,zMax))
+            return hypot(d, distance_to_line(PlanarPoint{T}(r_on_plane,point.z), line))
         else
             return hypot(d, point.z-zMax)
         end
     elseif point.z ≤ zMin
         if r_on_plane ≥ rbotMax
-            return hypot(d, zMin-point.z, r_on_plane-rbotMax)
-        elseif r_on_plane ≤ rtopMin
-            return hypot(d, zMin-point.z, rbotMin - r_on_plane)
+            line = LineSegment(T, PlanarPoint{T}(rbotMax,zMin), PlanarPoint{T}(rtopMax,zMax))
+            return hypot(d, distance_to_line(PlanarPoint{T}(r_on_plane,point.z), line))
+        elseif r_on_plane ≤ rbotMin
+            line = LineSegment(T, PlanarPoint{T}(rbotMin,zMin), PlanarPoint{T}(rtopMin,zMax))
+            return hypot(d, distance_to_line(PlanarPoint{T}(r_on_plane,point.z), line))
         else
-            return hypot(d, zMax-point.z)
+            return hypot(d, zMin-point.z)
         end
     else
         r_at_z = get_r_at_z(c, point.z)
@@ -124,9 +128,8 @@ function distance_to_surface(point::AbstractCoordinatePoint{T}, c::ConalPlane{T}
         if rMin ≤ r_on_plane ≤ rMax
             return abs(d)
         else
-            line = r_on_plane ≥ rMax ? Line(T, PlanarPoint{T}(rbotMax,zMin), PlanarPoint{T}(rtopMax,zMax)) : Line(T, PlanarPoint{T}(rbotMin,zMin), PlanarPoint{T}(rtopMin,zMax))
-            point = PlanarPoint{T}(r_on_plane,point.z)
-            return sqrt(d^2 + distance_to_line(point, line)^2)
+            line = r_on_plane ≥ rMax ? LineSegment(T, PlanarPoint{T}(rbotMax,zMin), PlanarPoint{T}(rtopMax,zMax)) : LineSegment(T, PlanarPoint{T}(rbotMin,zMin), PlanarPoint{T}(rtopMin,zMax))
+            return hypot(d, distance_to_line(PlanarPoint{T}(r_on_plane,point.z), line))
         end
     end
 end

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/ConeMantle.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/ConeMantle.jl
@@ -145,7 +145,6 @@ function distance_to_surface(point::AbstractCoordinatePoint{T}, c::ConeMantle{T,
     if _in_φ(pcy, c.φ)
         return distance_to_line(PlanarPoint{T}(pcy.r,pcy.z), LineSegment(c))
     else
-        φNear = Δ_φ(T(pcy.φ),φMin) ≤ Δ_φ(T(pcy.φ),φMax) ? φMin : φMax
-        return distance_to_line(CartesianPoint(point), LineSegment(c, φNear))
+        return distance_to_line(CartesianPoint(point), LineSegment(c, _φNear(pcy.φ, φMin, φMax)))
     end
 end

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/ConeMantle.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/ConeMantle.jl
@@ -70,19 +70,6 @@ in(p::AbstractCoordinatePoint, c::ConeMantle{<:Any, <:Any, Nothing, <:Any}) =
 in(p::AbstractCoordinatePoint, c::ConeMantle{<:Any, <:Any, <:AbstractInterval, <:Any}) =
     _in_z(p, c.z) && _in_φ(p, c.φ) && _eq_cyl_r(p, get_r_at_z(c, p.z))
 
-function LineSegment(c::ConeMantle{T}) where {T}
-    rbot::T, rtop::T = get_r_limits(c)
-    zMin::T, zMax::T = get_z_limits(c)
-    LineSegment(T, PlanarPoint{T}(rbot,zMin), PlanarPoint{T}(rtop,zMax))
-end
-
-function LineSegment(c::ConeMantle{T}, φ::Real) where {T}
-    rbot::T, rtop::T = get_r_limits(c)
-    zMin::T, zMax::T = get_z_limits(c)
-    sφ::T, cφ::T = sincos(φ)
-    LineSegment(T, CartesianPoint{T}(rbot*cφ,rbot*sφ,zMin), CartesianPoint{T}(rtop*cφ,rtop*sφ,zMax))
-end
-
 #=
 function sample(c::ConeMantle{T}, step::Real)::Vector{CylindricalPoint{T}} where {T}
     φMin::T, φMax::T, _ = get_φ_limits(c)
@@ -132,6 +119,19 @@ function sample(c::ConeMantle{T}, g::CartesianTicksTuple{T})::Vector{CartesianPo
         for y in _get_y_at_z(c, x, z)
         if c.φ === nothing || mod(atan(y, x), T(2π)) in c.φ
     ]
+end
+
+function LineSegment(c::ConeMantle{T}) where {T}
+    rbot::T, rtop::T = get_r_limits(c)
+    zMin::T, zMax::T = get_z_limits(c)
+    LineSegment(T, PlanarPoint{T}(rbot,zMin), PlanarPoint{T}(rtop,zMax))
+end
+
+function LineSegment(c::ConeMantle{T}, φ::Real) where {T}
+    rbot::T, rtop::T = get_r_limits(c)
+    zMin::T, zMax::T = get_z_limits(c)
+    sφ::T, cφ::T = sincos(φ)
+    LineSegment(T, CartesianPoint{T}(rbot*cφ,rbot*sφ,zMin), CartesianPoint{T}(rtop*cφ,rtop*sφ,zMax))
 end
 
 function distance_to_surface(point::AbstractCoordinatePoint{T}, c::ConeMantle{T, <:Any, Nothing, <:Any})::T where {T}

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/CylindricalAnnulus.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/CylindricalAnnulus.jl
@@ -109,7 +109,7 @@ function distance_to_surface(point::AbstractCoordinatePoint{T}, a::CylindricalAn
         Δz = abs(pcy.z - a.z)
         return _in_cyl_r(pcy, a.r) ? Δz : hypot(Δz, min(abs(pcy.r - rMin), abs(pcy.r - rMax)))
     else
-        φNear = Δ_φ(T(pcy.φ),φMin) ≤ Δ_φ(T(pcy.φ),φMax) ? φMin : φMax
+        φNear = _φNear(pcy.φ, φMin, φMax)
         if rMin == rMax
             return norm(CartesianPoint(point)-CartesianPoint(CylindricalPoint{T}(rMin,φNear,a.z)))
         else

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/SphereMantle.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/SphereMantle.jl
@@ -55,3 +55,8 @@ function sample(s::SphereMantle{T}, g::CartesianTicksTuple{T})::Vector{Cartesian
         for y in _get_y_at_z(s, z, x)
     ]
 end
+
+function distance_to_surface(point::AbstractCoordinatePoint{T}, s::SphereMantle{T})::T where {T}
+    pcy = CylindricalPoint(point)
+    return abs(hypot(pcy.r, pcy.z) - s.r)
+end

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/SphereMantle.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/SphereMantle.jl
@@ -56,7 +56,6 @@ function sample(s::SphereMantle{T}, g::CartesianTicksTuple{T})::Vector{Cartesian
     ]
 end
 
-function distance_to_surface(point::AbstractCoordinatePoint{T}, s::SphereMantle{T})::T where {T}
-    pcy = CylindricalPoint(point)
-    return abs(hypot(pcy.r, pcy.z) - s.r)
-end
+distance_to_surface(point::CylindricalPoint{T}, s::SphereMantle{T}) where {T} = abs(hypot(point.r, point.z) - s.r)
+
+distance_to_surface(point::CartesianPoint{T}, s::SphereMantle{T}) where {T} = abs(norm(point) - s.r)

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/ToroidalAnnulus.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/ToroidalAnnulus.jl
@@ -103,7 +103,6 @@ function distance_to_surface(point::AbstractCoordinatePoint{T}, t::ToroidalAnnul
     pcy = CylindricalPoint(point)
     Δφ = pcy.φ - t.φ
     z, r_on_plane = pcy.r .* sincos(Δφ)
-    pp = PlanarPoint{T}(r_on_plane, pcy.z) - PlanarVector{T}(t.r_torus, t.z)
-    pct_transformed = CartesianPoint{T}(pp.u, pp.v, z)
+    pct_transformed = CartesianPoint{T}(r_on_plane - t.r_torus, pcy.z - t.z, z)
     distance_to_surface(pct_transformed, CylindricalAnnulus(T, t.r_tube, t.θ, T(0)))
 end

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/ToroidalAnnulus.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/ToroidalAnnulus.jl
@@ -60,20 +60,20 @@ function sample(t::ToroidalAnnulus{T}, Nsamps::NTuple{3,Int}) where {T}
 end
 
 function _get_z_at_r(t::ToroidalAnnulus{T,T}, g::CylindricalTicksTuple{T}, r::T) where {T}
-    tmp::T = t.r_tube^2 - (r - t.r_torus)^2 
+    tmp::T = t.r_tube^2 - (r - t.r_torus)^2
     if tmp < 0 return (t.z,) end
     _get_ticks(g.z, t.z - sqrt(tmp), t.z + sqrt(tmp))
 end
 
 function _get_z_at_r(t::ToroidalAnnulus{T,<:AbstractInterval{T}}, g::CylindricalTicksTuple{T}, r::T) where {T}
     r_tubeMin::T, r_tubeMax::T = get_r_tube_limits(t)
-    tmp::T = r_tubeMax^2 - (r - t.r_torus)^2 
+    tmp::T = r_tubeMax^2 - (r - t.r_torus)^2
     if tmp < 0 return (t.z,) end
-    tmp2::T = r_tubeMin^2 - (r - t.r_torus)^2 
+    tmp2::T = r_tubeMin^2 - (r - t.r_torus)^2
     if tmp2 < 0 return _get_ticks(g.z, t.z - sqrt(tmp), t.z + sqrt(tmp)) end
     vcat(_get_ticks(g.z, t.z - sqrt(tmp), t.z - sqrt(tmp2)),_get_ticks(g.z, t.z + sqrt(tmp2), t.z + sqrt(tmp)))
 end
-    
+
 
 function sample(t::ToroidalAnnulus{T}, g::CylindricalTicksTuple{T})::Vector{CylindricalPoint{T}} where {T}
     r_tubeMin::T, r_tubeMax::T = get_r_tube_limits(t)
@@ -97,4 +97,13 @@ function sample(t::ToroidalAnnulus{T}, g::CartesianTicksTuple{T})::Vector{Cartes
         if (r_tubeMin <= hypot(r - t.r_torus, z - t.z) <= r_tubeMax) &&
            (t.θ === nothing || _in_angular_interval_closed(mod(atan(z - t.z, r - t.r_torus), T(2π)), t.θ))
     ]
+end
+
+function distance_to_surface(point::AbstractCoordinatePoint{T}, t::ToroidalAnnulus{T})::T where {T}
+    pcy = CylindricalPoint(point)
+    Δφ = pcy.φ - t.φ
+    z, r_on_plane = pcy.r .* sincos(Δφ)
+    pp = PlanarPoint{T}(r_on_plane, pcy.z) - PlanarVector{T}(t.r_torus, t.z)
+    pct_transformed = CartesianPoint{T}(pp.u, pp.v, z)
+    distance_to_surface(pct_transformed, CylindricalAnnulus(T, t.r_tube, t.θ, T(0)))
 end

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/TorusMantle.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/TorusMantle.jl
@@ -138,8 +138,7 @@ function distance_to_surface(point::AbstractCoordinatePoint{T}, t::TorusMantle{T
         return distance_to_line(PlanarPoint{T}(pcy.r,pcy.z), Arc(t))
     else
         φMin::T, φMax::T, _ = get_φ_limits(t)
-        φNear::T = Δ_φ(T(pcy.φ),φMin) ≤ Δ_φ(T(pcy.φ),φMax) ? φMin : φMax
-        Δφ = pcy.φ - φNear
+        Δφ = pcy.φ - _φNear(pcy.φ, φMin, φMax)
         d, r_on_plane = pcy.r .* sincos(Δφ)
         return hypot(d, distance_to_line(PlanarPoint{T}(r_on_plane, pcy.z), Arc(t)))
     end

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/TorusMantle.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/TorusMantle.jl
@@ -44,7 +44,6 @@ in(p::AbstractCoordinatePoint, t::TorusMantle{<:Any, Nothing, <:AbstractInterval
 in(p::AbstractCoordinatePoint, t::TorusMantle{<:Any, <:AbstractInterval, <:AbstractInterval}) =
     _isapprox_torr_r_tube(p, t.r_torus, t.r_tube, t.z) && _in_φ(p, t.φ) && _in_torr_θ(p, t.r_torus, t.θ, t.z)
 
-
 get_φ_limits(t::TorusMantle{T, Nothing}) where {T} = (T(0), T(2π), true)
 get_φ_limits(t::TorusMantle{T, <:AbstractInterval}) where {T} = (t.φ.left, t.φ.right, false)
 
@@ -106,11 +105,11 @@ function _get_y_at_z(t::TorusMantle{T}, x::T, z::T) where {T}
     R::T = sqrt(t.r_tube^2 - (z - t.z)^2)
     tmp::T = (t.r_torus + R)^2 - x^2
     tmp2::T = (t.r_torus - R)^2 - x^2
-    if tmp < 0 
+    if tmp < 0
         ()
-    elseif tmp2 < 0 
+    elseif tmp2 < 0
         (-sqrt(tmp), sqrt(tmp))
-    else 
+    else
         (-sqrt(tmp), -sqrt(tmp2), sqrt(tmp2), sqrt(tmp))
     end
 end
@@ -121,8 +120,27 @@ function sample(t::TorusMantle{T}, g::CartesianTicksTuple{T})::Vector{CartesianP
             for z in _get_z_ticks(t, g)
             for x in _get_x_at_z(t, g, z)
             for y in _get_y_at_z(t, x, z)
-            if (t.φ === nothing || mod(atan(y, x), T(2π)) in t.φ) && 
+            if (t.φ === nothing || mod(atan(y, x), T(2π)) in t.φ) &&
                (t.θ === nothing || _in_angular_interval_closed(mod(atan(z - t.z, hypot(x, y) - t.r_torus), T(2π)), t.θ))
         ]
 end
 
+Arc(t::TorusMantle{T}) where {T} = Arc(T, t.r_tube, PlanarPoint{T}(t.r_torus,t.z), t.θ)
+
+function distance_to_surface(point::AbstractCoordinatePoint{T}, t::TorusMantle{T, Nothing})::T where {T}
+    pcy = CylindricalPoint(point)
+    return distance_to_line(PlanarPoint{T}(pcy.r,pcy.z), Arc(t))
+end
+
+function distance_to_surface(point::AbstractCoordinatePoint{T}, t::TorusMantle{T, <:AbstractInterval})::T where {T}
+    pcy = CylindricalPoint(point)
+    if _in_φ(point, t.φ)
+        return distance_to_line(PlanarPoint{T}(pcy.r,pcy.z), Arc(t))
+    else
+        φMin::T, φMax::T, _ = get_φ_limits(t)
+        φNear::T = Δ_φ(T(pcy.φ),φMin) ≤ Δ_φ(T(pcy.φ),φMax) ? φMin : φMax
+        Δφ = pcy.φ - φNear
+        d, r_on_plane = pcy.r .* sincos(Δφ)
+        return hypot(d, distance_to_line(PlanarPoint{T}(r_on_plane, pcy.z), Arc(t)))
+    end
+end

--- a/src/ConstructiveSolidGeometry/plotting/SurfacePrimitives/ConalPlane.jl
+++ b/src/ConstructiveSolidGeometry/plotting/SurfacePrimitives/ConalPlane.jl
@@ -1,6 +1,6 @@
 function get_plot_points(c::ConalPlane{T}; n = 30) where {T <: AbstractFloat}
     v = get_vertices(c)
-    [Vector{CartesianPoint{T}}([v[1], v[2]]), Vector{CartesianPoint{T}}([v[2], v[3]]), Vector{CartesianPoint{T}}([v[3], v[4]]), Vector{CartesianPoint{T}}([v[4], v[1]])]
+    [Vector{CartesianPoint{T}}([v[1], v[2]]), Vector{CartesianPoint{T}}([v[2], v[4]]), Vector{CartesianPoint{T}}([v[3], v[4]]), Vector{CartesianPoint{T}}([v[3], v[1]])]
 end
 
 function mesh(c::ConalPlane{T}; n = 30) where {T <: AbstractFloat}


### PR DESCRIPTION
Added `distance_to_surface()` to the following surface primitives

- ConalPlane (Allocation free, worst case btime ~ 45ns)
- ConeMantle (Allocation free, worst case btime ~ 35ns)
- CylindricalAnnulus (Allocation free, worst case btime ~ 85ns)
- ToroidalAnnulus(Allocation free, worst case btime ~ 120ns)
- TorusMantle (Allocation free, worst case btime ~ 85ns)
- SphereMantle (Allocation free, worst case btime ~ 10ns)

Note that quoted btimes are worst case geometric scenarios, with the right conditions btime can be up to 100 times faster. These faster scenarios occur most often when close to a surface. 

`distance_to_surface()` is pending for the following surface primitives

- RegularPolygon
- RegularPrismMantle

This will wait until we have a decision on `φ_0` for these primitives.

Dependencies added for `distance_to_surface()`

- PlanarPoint (Problem is often reduced to 2D)
- LinePrimitives (`Arc` and `Line`. Problem is often reduced to 2D)
- Line constructors from surface primitives. Eg. `Arc(::TorusMantle)`, `LineSegment(::ConeMantle)`
- `distance_to_line()`

Various `φ` and `z` scans are shown below with the colorbar indicating distance to surface:

`cp = CSG.ConalPlane(1, 3, 3, 4, π/4, 0, 2)`
<img width="300" alt="Screen Shot 2021-05-06 at 9 31 43 PM" src="https://user-images.githubusercontent.com/41748838/117355370-c7892e00-aeb2-11eb-91de-0e5b1aab3d38.png">
![distance_to_conal_plane](https://user-images.githubusercontent.com/41748838/117355396-d079ff80-aeb2-11eb-8ebd-d9d6bfb8d27f.gif)

`cm = CSG.ConeMantle(3, 1, 0, 3π/2, 0 ,2)`
<img width="300" alt="Screen Shot 2021-05-06 at 9 35 31 PM" src="https://user-images.githubusercontent.com/41748838/117355552-05865200-aeb3-11eb-9ddd-58e7c260522e.png">
![distance_to_cone_mantle](https://user-images.githubusercontent.com/41748838/117355569-0d45f680-aeb3-11eb-817c-2cb3cfa2311c.gif)
![distance_to_cone_mantle2](https://user-images.githubusercontent.com/41748838/117355668-2cdd1f00-aeb3-11eb-8b63-c8d2c0ba6ff7.gif)

`ca = CSG.CylindricalAnnulus(1, 2, -π/4, 3π/2, 1)`
<img width="300" alt="Screen Shot 2021-05-06 at 9 37 40 PM" src="https://user-images.githubusercontent.com/41748838/117355811-4e3e0b00-aeb3-11eb-96ed-4d779c9a1a7d.png">
![distance_to_cylindrical_annulus](https://user-images.githubusercontent.com/41748838/117355838-572edc80-aeb3-11eb-84c8-faa37d43b6eb.gif)

`ta = CSG.ToroidalAnnulus(3,1,2,π/3,-π/6,π,-1)`
<img width="300" alt="Screen Shot 2021-05-06 at 9 38 37 PM" src="https://user-images.githubusercontent.com/41748838/117355923-72015100-aeb3-11eb-8074-9c3605192a88.png">
![distance_to_toroidal_annulus](https://user-images.githubusercontent.com/41748838/117355957-7cbbe600-aeb3-11eb-8682-06dbe4771721.gif)

`tm = CSG.TorusMantle(3,2,0,π,0,3π/2,-1)`
<img width="300" alt="Screen Shot 2021-05-06 at 9 39 32 PM" src="https://user-images.githubusercontent.com/41748838/117356004-8fceb600-aeb3-11eb-9f3e-4d1a8d432a32.png">
![distance_to_torus_mantle](https://user-images.githubusercontent.com/41748838/117356012-93623d00-aeb3-11eb-9f90-9fab5b8a47c1.gif)
![distance_to_torus_mantle2](https://user-images.githubusercontent.com/41748838/117356018-95c49700-aeb3-11eb-80e9-9b0895e76421.gif)

`sm = CSG.SphereMantle{T}(2)`
<img width="300" alt="Screen Shot 2021-05-06 at 9 40 19 PM" src="https://user-images.githubusercontent.com/41748838/117356209-c86e8f80-aeb3-11eb-990b-45a98422a443.png">
![distance_to_sphere_mantle](https://user-images.githubusercontent.com/41748838/117356240-cdcbda00-aeb3-11eb-8ab3-149f3626f2a8.gif)







