### PR TITLE
Distance to Surface for Remaining Surface Primitives

### DIFF
--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/Rectangle.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/Rectangle.jl
@@ -238,7 +238,7 @@ function distance_to_surface(point::AbstractCoordinatePoint{T}, r::Rectangle{<:A
     l, w, d = _get_rectangle_coordinates(point, r)
     lMin::T, lMax::T = get_l_limits(r)
     wMin::T, wMax::T = get_w_limits(r)
-    if l in lMin..lMax && w in wMin..wMax
+    if lMin ≤ l ≤ lMax && wMin ≤ w ≤ wMax
         return abs(d - r.loc)
     else 
         if lMin ≤ l ≤ lMax

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/Rectangle.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/Rectangle.jl
@@ -227,3 +227,31 @@ function get_vertices(r::RectangleZ{T}) where {T}
     CartesianPoint{T}(lMin, wMax, r.loc),
     CartesianPoint{T}(lMax, wMax, r.loc))
 end
+
+_get_rectangle_coordinates(point::CartesianPoint, r::RectangleX) = (point.y, point.z, point.x)
+_get_rectangle_coordinates(point::CartesianPoint, r::RectangleY) = (point.x, point.z, point.y)
+_get_rectangle_coordinates(point::CartesianPoint, r::RectangleZ) = (point.x, point.y, point.z)
+
+_get_rectangle_coordinates(point::CylindricalPoint, r::Rectangle) = _get_rectangle_coordinates(CartesianPoint(point), r)
+
+function distance_to_surface(point::AbstractCoordinatePoint{T}, r::Rectangle{<:Any, T})::T where {T}
+    l, w, d = _get_rectangle_coordinates(point, r)
+    lMin::T, lMax::T = get_l_limits(r)
+    wMin::T, wMax::T = get_w_limits(r)
+    if l in lMin..lMax && w in wMin..wMax
+        return abs(d - r.loc)
+    else 
+        if lMin ≤ l ≤ lMax
+            y = w < wMin ? wMin : wMax
+            return hypot(w - y, d - r.loc)
+        elseif wMin ≤ w ≤ wMax
+            x = l < lMin ? lMin : lMax
+            return hypot(l - x, d - r.loc)
+        else
+            lnear = l < lMin ? lMin : lMax
+            wnear = w < wMin ? wMin : wMax
+            return hypot(l - lnear, w - wnear, d - r.loc)
+        end
+    end
+            
+end

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/RegularPrismMantle.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/RegularPrismMantle.jl
@@ -89,3 +89,18 @@ function sample(rp::RegularPrismMantle{N,T}, g::CartesianTicksTuple{T})::Vector{
     )
 end
 
+function distance_to_surface(point::AbstractCoordinatePoint{T}, rp::RegularPrismMantle{N,T})::T where {N,T}
+    pcy = CylindricalPoint(point)
+    zMin::T, zMax::T = get_z_limits(rp)
+    φ = mod(pcy.φ, T(2π/N))
+    sn, cn = sincos(2π/N)
+    line = LineSegment(T, PlanarPoint{T}(rp.r, 0), PlanarPoint{T}(rp.r*cn, rp.r*sn))
+    sφ, cφ = sincos(φ)
+    d = distance_to_line(PlanarPoint{T}(pcy.r*cφ, pcy.r*sφ), line)
+    if zMin ≤ pcy.z ≤ zMax
+        return d
+    else
+        z = pcy.z < zMin ? zMin : zMax
+        return hypot(d, pcy.z - z)
+    end
+end


### PR DESCRIPTION
`distance_to_surface()` added to RegularPolygon, RegularPrismMantle, and Rectangle
All are type stable, allocation free and have a worst case btime of ~50ns
`rp = CSG.RegularPolygon(7,0.8,1.3,0)`
<img width="300" alt="Screen Shot 2021-05-17 at 8 30 51 PM" src="https://user-images.githubusercontent.com/41748838/118538672-ca0b4380-b74e-11eb-8ec2-f297a6756c54.png">
![distance_to_regular_polygon](https://user-images.githubusercontent.com/41748838/118538718-dabbb980-b74e-11eb-8cb2-217128403b2d.gif)

`rpm = CSG.RegularPrismMantle(3,1.3,1)`
<img width="300" alt="Screen Shot 2021-05-17 at 8 31 54 PM" src="https://user-images.githubusercontent.com/41748838/118538878-076fd100-b74f-11eb-9641-2fd379ae6f24.png">
![distance_to_regular_prism_mantle](https://user-images.githubusercontent.com/41748838/118538884-08a0fe00-b74f-11eb-8669-b6a9b1c2fb42.gif)
![distance_to_regular_prism_mantle2](https://user-images.githubusercontent.com/41748838/118538892-0ccd1b80-b74f-11eb-87e0-c073e4348ae1.gif)

`rec = CSG.RectangleX(0.5, 1, -1.2, 0.6, 0)`
<img width="300" alt="Screen Shot 2021-05-17 at 8 33 53 PM" src="https://user-images.githubusercontent.com/41748838/118539034-38500600-b74f-11eb-8833-7aa056852ff1.png">
![distance_to_rectangle](https://user-images.githubusercontent.com/41748838/118539073-43a33180-b74f-11eb-95c9-08c77169d2e5.gif)
![distance_to_rectangle2](https://user-images.githubusercontent.com/41748838/118539078-469e2200-b74f-11eb-8c46-ff242c5def83.gif)

`rec = CSG.RectangleZ(0.5, 1, -1.2, 0.6, 0.5)`
<img width="677" alt="Screen Shot 2021-05-17 at 8 35 23 PM" src="https://user-images.githubusercontent.com/41748838/118539215-72b9a300-b74f-11eb-9f2b-b6b6c09e8767.png">
![distance_to_rectangle3](https://user-images.githubusercontent.com/41748838/118539224-777e5700-b74f-11eb-950d-90b6a08288fe.gif)

