### PR TITLE
Add tests for CSG sampling

### DIFF
--- a/src/ConstructiveSolidGeometry/PointsAndVectors.jl
+++ b/src/ConstructiveSolidGeometry/PointsAndVectors.jl
@@ -108,18 +108,18 @@ end
 
 @inline _isapprox_x(p::CylindricalPoint{T}, x::Real) where {T} = isapprox(p.r * cos(p.φ), x, atol = geom_atol_zero(T))
 
-@inline _in_x(p::CylindricalPoint, x::Real) = abs(p.r * cos(p.φ)) <= x
-@inline _in_x(p::CylindricalPoint, x::AbstractInterval) = p.r * cos(p.φ) in x
+@inline _in_x(p::CylindricalPoint{T}, x::Real) where {T} = abs(p.r * cos(p.φ)) <= x + geom_atol_zero(T)
+@inline _in_x(p::CylindricalPoint, x::AbstractInterval) = p.r * cos(p.φ) in x || _isapprox_x(p, x.left) || _isapprox_x(p, x.right)
 
 @inline _isapprox_y(p::CylindricalPoint{T}, y::Real) where {T} = isapprox(p.r * sin(p.φ), y, atol = geom_atol_zero(T))
 
-@inline _in_y(p::CylindricalPoint, y::Real) = abs(p.r * sin(p.φ)) <= y
-@inline _in_y(p::CylindricalPoint, y::AbstractInterval) = p.r * sin(p.φ) in y
+@inline _in_y(p::CylindricalPoint{T}, y::Real) where {T} = abs(p.r * sin(p.φ)) <= y + geom_atol_zero(T)
+@inline _in_y(p::CylindricalPoint, y::AbstractInterval) = p.r * sin(p.φ) in y || _isapprox_y(p, y.left) || _isapprox_y(p, y.right)
 
 @inline _isapprox_z(p::CylindricalPoint{T}, z::Real) where {T} = isapprox(p.z, z, atol = geom_atol_zero(T))
 
-@inline _in_z(p::CylindricalPoint, z::Real) = abs(p.z) <= z
-@inline _in_z(p::CylindricalPoint, z::AbstractInterval) = p.z in z
+@inline _in_z(p::CylindricalPoint{T}, z::Real) where {T} = abs(p.z) <= z + geom_atol_zero(T)
+@inline _in_z(p::CylindricalPoint, z::AbstractInterval) = p.z in z || _isapprox_z(p, z.left) || _isapprox_z(p, z.right)
 
 @inline _isapprox_sph_r(p::CylindricalPoint{T}, radius::Real) where {T} = isapprox(hypot(p.r, p.z), radius, atol = geom_atol_zero(T))
 

--- a/src/ConstructiveSolidGeometry/PointsAndVectors.jl
+++ b/src/ConstructiveSolidGeometry/PointsAndVectors.jl
@@ -22,7 +22,7 @@ struct CartesianPoint{T} <: AbstractCoordinatePoint{T, Cartesian}
     z::T
 end
 
-@inline _eq_cyl_r(p::CartesianPoint{T}, r::Real) where {T} = hypot(p.x, p.y) == T(r)
+@inline _isapprox_cyl_r(p::CartesianPoint{T}, r::Real) where {T} = isapprox(hypot(p.x, p.y), r, atol = geom_atol_zero(T))
 
 @inline _in_planar_r(p::PlanarPoint, r::Real) = hypot(p.u, p.v) <= r
 @inline _in_planar_r(p::PlanarPoint, r::AbstractInterval) = hypot(p.u, p.v) in r
@@ -97,7 +97,7 @@ end
 @inline _convert_point(pt::AbstractCoordinatePoint, ::Type{Cylindrical}) = CylindricalPoint(pt)
 @inline _convert_point(pt::AbstractCoordinatePoint, ::Type{Cartesian}) = CartesianPoint(pt)
 
-@inline _eq_cyl_r(p::CylindricalPoint{T}, r::Real) where {T} = p.r == T(r)
+@inline _isapprox_cyl_r(p::CylindricalPoint{T}, r::Real) where {T} = isapprox(p.r, r, atol = geom_atol_zero(T))
 
 @inline _in_cyl_r(p::CylindricalPoint, r::Real) = p.r <= r
 @inline _in_cyl_r(p::CylindricalPoint, r::AbstractInterval) = p.r in r

--- a/src/ConstructiveSolidGeometry/PointsAndVectors.jl
+++ b/src/ConstructiveSolidGeometry/PointsAndVectors.jl
@@ -108,18 +108,18 @@ end
 
 @inline _isapprox_x(p::CylindricalPoint{T}, x::Real) where {T} = isapprox(p.r * cos(p.φ), x, atol = geom_atol_zero(T))
 
-@inline _in_x(p::CylindricalPoint{T}, x::Real) where {T} = abs(p.r * cos(p.φ)) <= x + geom_atol_zero(T)
-@inline _in_x(p::CylindricalPoint, x::AbstractInterval) = p.r * cos(p.φ) in x || _isapprox_x(p, x.left) || _isapprox_x(p, x.right)
+@inline _in_x(p::CylindricalPoint{T}, x::Real) where {T} = abs(p.r * cos(p.φ)) <= nextfloat(x,2)
+@inline _in_x(p::CylindricalPoint, x::AbstractInterval) = p.r * cos(p.φ) in x || p.x == prevfloat(x.left) || p.x == nextfloat(x.right)
 
 @inline _isapprox_y(p::CylindricalPoint{T}, y::Real) where {T} = isapprox(p.r * sin(p.φ), y, atol = geom_atol_zero(T))
 
-@inline _in_y(p::CylindricalPoint{T}, y::Real) where {T} = abs(p.r * sin(p.φ)) <= y + geom_atol_zero(T)
-@inline _in_y(p::CylindricalPoint, y::AbstractInterval) = p.r * sin(p.φ) in y || _isapprox_y(p, y.left) || _isapprox_y(p, y.right)
+@inline _in_y(p::CylindricalPoint{T}, y::Real) where {T} = abs(p.r * sin(p.φ)) <= nextfloat(y,2)
+@inline _in_y(p::CylindricalPoint, y::AbstractInterval) = p.r * sin(p.φ) in y || p.y == prevfloat(y.left) || p.y == nextfloat(y.right)
 
 @inline _isapprox_z(p::CylindricalPoint{T}, z::Real) where {T} = isapprox(p.z, z, atol = geom_atol_zero(T))
 
-@inline _in_z(p::CylindricalPoint{T}, z::Real) where {T} = abs(p.z) <= z + geom_atol_zero(T)
-@inline _in_z(p::CylindricalPoint, z::AbstractInterval) = p.z in z || _isapprox_z(p, z.left) || _isapprox_z(p, z.right)
+@inline _in_z(p::CylindricalPoint{T}, z::Real) where {T} = abs(p.z) <= nextfloat(z,2)
+@inline _in_z(p::CylindricalPoint, z::AbstractInterval) = p.z in z || p.z == prevfloat(z.left,2) || p.z == nextfloat(z.right,2)
 
 @inline _isapprox_sph_r(p::CylindricalPoint{T}, radius::Real) where {T} = isapprox(hypot(p.r, p.z), radius, atol = geom_atol_zero(T))
 

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/ConeMantle.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/ConeMantle.jl
@@ -65,10 +65,10 @@ get_φ_limits(c::ConeMantle{T, <:Any, <:AbstractInterval, <:Any}) where {T} = (c
 get_z_limits(c::ConeMantle{T}) where {T} = (_left_linear_interval(c.z), _right_linear_interval(c.z))
 
 in(p::AbstractCoordinatePoint, c::ConeMantle{<:Any, <:Any, Nothing, <:Any}) =
-    _in_z(p, c.z) && _eq_cyl_r(p, get_r_at_z(c, p.z))
+    _in_z(p, c.z) && _isapprox_cyl_r(p, get_r_at_z(c, p.z))
 
 in(p::AbstractCoordinatePoint, c::ConeMantle{<:Any, <:Any, <:AbstractInterval, <:Any}) =
-    _in_z(p, c.z) && _in_φ(p, c.φ) && _eq_cyl_r(p, get_r_at_z(c, p.z))
+    _in_z(p, c.z) && _in_φ(p, c.φ) && _isapprox_cyl_r(p, get_r_at_z(c, p.z))
 
 #=
 function sample(c::ConeMantle{T}, step::Real)::Vector{CylindricalPoint{T}} where {T}

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/Rectangle.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/Rectangle.jl
@@ -25,14 +25,14 @@ RectangleX(b::Box{T}, x::Real) where {T} = RectangleX(T, b.y, b.z, T(x))
 RectangleY(b::Box{T}, y::Real) where {T} = RectangleY(T, b.x, b.z, T(y))
 RectangleZ(b::Box{T}, z::Real) where {T} = RectangleZ(T, b.x, b.y, T(z))
 
-function Rectangle(;normal = Val(:z), lMin = -1, lMax = 1, wMin = -1, wMax = 1, loc = 0)
+function Rectangle(normal = Val(:z); lMin = -1, lMax = 1, wMin = -1, wMax = 1, loc = 0)
     T = float(promote_type(typeof.((lMin, lMax, wMin, wMax, loc))...))
     l = lMax == -lMin ? T(lMax) : T(lMin)..T(lMax)
     w = wMax == -wMin ? T(wMax) : T(wMin)..T(wMax)
     Rectangle(normal, T, l, w, T(loc))
 end
 
-Rectangle(normal, lMin, lMax, wMin, wMax, loc) = Rectangle(; normal = normal, lMin = lMin, lMax = lMax, wMin = wMin, wMax = wMax, loc = loc)
+Rectangle(normal, lMin, lMax, wMin, wMax, loc) = Rectangle(normal; lMin = lMin, lMax = lMax, wMin = wMin, wMax = wMax, loc = loc)
 
 function Rectangle(normal::Union{Val{:x}, Val{:y}, Val{:z}}, l::L, w::W, loc::C) where {L<:Real, W<:Real, C<:Real}
     T = float(promote_type(L,W,C))

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/Rectangle.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/Rectangle.jl
@@ -86,23 +86,21 @@ end
 
 
 function get_r(r::RectangleX{T}, φ::T) where {T}
-    atol = geom_atol_zero(T)
     x::T = r.loc
     yMin::T, yMax::T = get_l_limits(r)
     sφ::T, cφ::T = sincos(φ)
     if x * cφ < 0 return () end
     tanφ::T = tan(φ)
-    yMin - atol ≤ x * tanφ ≤ yMax + atol ? (x / cφ,) : ()
+    prevfloat(yMin,2) ≤ x * tanφ ≤ nextfloat(yMax,2) ? (x / cφ,) : ()
 end
 
 function get_r(r::RectangleY{T}, φ::T) where {T}
-    atol = geom_atol_zero(T)
     y::T = r.loc
     xMin::T, xMax::T = get_l_limits(r)
     sφ::T, cφ::T = sincos(φ)
     if y * sφ < 0 return () end
     cotφ::T = cot(φ)
-    xMin - atol ≤ y * cotφ ≤ xMax + atol ? (y / sφ,) : ()
+    prevfloat(xMin,2) ≤ y * cotφ ≤ nextfloat(xMax,2) ? (y / sφ,) : ()
 end
 
 function get_φ_at_loc(r::RectangleX{T}, R::T) where {T}

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/RegularPolygon.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/RegularPolygon.jl
@@ -39,16 +39,18 @@ end
 
 
 @inline in(p::CylindricalPoint, rp::RegularPolygon{N, T, <:Real}) where {N,T} = begin
-    _isapprox_z(p, rp.z) && p.r * cos(T(π/N) - mod(p.φ, T(2π/N))) / cos(T(π/N)) <= rp.r
+    _isapprox_z(p, rp.z) && p.r * cos(T(π/N) - mod(p.φ, T(2π/N))) / cos(T(π/N)) <= rp.r +  geom_atol_zero(T)
 end
 
 @inline in(p::CylindricalPoint, rp::RegularPolygon{N, T, <:AbstractInterval}) where {N,T} = begin
-    _isapprox_z(p, rp.z) && p.r * cos(T(π/N) - mod(p.φ, T(2π/N))) / cos(T(π/N)) in rp.r
+    _isapprox_z(p, rp.z) && let rr = p.r * cos(T(π/N) - mod(p.φ, T(2π/N))) / cos(T(π/N))
+         rr in rp.r || isapprox(rr, rp.r.left, tol = geom_atol_zero(T)) || isapprox(rr, rp.r.left, tol = geom_atol_zero(T))
+     end
 end
 
 @inline in(p::CartesianPoint, rp::RegularPolygon) = in(CylindricalPoint(p), rp)
 
-# Special case: CartesianPoint in RegularHexagon: use analytical formulas
+#= Special case: CartesianPoint in RegularHexagon: use analytical formulas
 @inline in(p::CartesianPoint, hp::RegularHexagon{T, <:Real}) where {T} =
     _isapprox_z(p, hp.z) && _in_y(p, hp.r * sqrt(T(3))/2) && _in_x(p, hp.r - abs(p.y)/sqrt(T(3)))
 
@@ -58,6 +60,7 @@ end
         abs(p.y) >= hp.r.left * sqrt(T(3))/2 && _in_x(p, hp.r.right * T(0.5)) ||
         abs(p.x) in (hp.r.left - abs(p.y) /sqrt(T(3)))..(hp.r.right - abs(p.y)/sqrt(T(3)))
     )
+=#
 
 get_r_limits(rp::RegularPolygon) = (_left_radial_interval(rp.r), _right_radial_interval(rp.r))
 get_r_at_φ(rp::RegularPolygon{N,T}, φ::T) where {N,T} = get_r_limits(rp) .* T(cos(π/N)/cos(π/N - mod(φ, 2π/N)))

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/RegularPrismMantle.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/RegularPrismMantle.jl
@@ -77,14 +77,16 @@ function sample(rp::RegularPrismMantle{N,T}, g::CartesianTicksTuple{T})::Vector{
     corners = SVector{N+1,Tuple{T,T}}(sincos.(T(2π/N) .* (0:N)))
     samples = vcat(
     [   # sample all points on the x-grid lines
-        CartesianPoint{T}(x,y,rp.z)
+        CartesianPoint{T}(x,y,z)
         for x in _get_ticks(g.x, rp.r * minimum(broadcast(p -> p[2], corners)), rp.r * maximum(broadcast(p -> p[2], corners)))
         for y in (-get_y_at_x(rp.r, corners, g, x), get_y_at_x(rp.r, corners, g, x))
+        for z in get_z_ticks(rp, g)
     ] , 
     [   # sample the missing points on y-grid lines
-        CartesianPoint{T}(x,y,rp.z)
+        CartesianPoint{T}(x,y,z)
         for y in _get_ticks(g.y, rp.r * minimum(broadcast(p -> p[1], corners)), rp.r * maximum(broadcast(p -> p[1], corners)))
         for x in get_missing_x_at_y(rp.r, corners, g, y)
+        for z in get_z_ticks(rp, g)
     ]
     )
 end

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/RegularPrismMantle.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/RegularPrismMantle.jl
@@ -43,6 +43,7 @@ end
 
 @inline in(p::CartesianPoint, rp::RegularPrismMantle) = in(CylindricalPoint(p), rp)
 
+#=
 @inline in(p::CartesianPoint, hp::HexagonalPrismMantle{T}) where {T} = begin
     tol = geom_atol_zero(T)
     _in_z(p, hp.z) && abs(p.y) ≤ hp.r * sqrt(T(3))/2 &&
@@ -51,6 +52,7 @@ end
         ( isapprox(abs(p.x), hp.r - abs(p.y)/sqrt(T(3)), atol = tol) &&  T(0.5) ≤ abs(p.x) ≤ hp.r )
     )
 end
+=#
 
 get_z_limits(rp::RegularPrismMantle) = (_left_linear_interval(rp.z), _right_linear_interval(rp.z))
 get_r_at_φ(rp::RegularPrismMantle{N,T}, φ::T) where {N,T} = rp.r * T(cos(π/N)/cos(π/N - mod(φ, 2π/N)))

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/SphereMantle.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/SphereMantle.jl
@@ -2,6 +2,11 @@ struct SphereMantle{T} <: AbstractSurfacePrimitive{T}
     r::T
 end
 
+function SphereMantle(r::R = 1) where {R <: Real}
+    T = float(R)
+    SphereMantle{T}(T(r))
+end
+
 get_r_limits(s::SphereMantle{T}) where {T} = (_left_radial_interval(s.r), _right_radial_interval(s.r))
 get_φ_limits(s::SphereMantle{T}) where {T} = (T(0), T(2π), true)
 get_z_limits(s::SphereMantle{T}) where {T} = (-_right_linear_interval(s.r), _right_linear_interval(s.r))

--- a/test/ConstructiveSolidGeometry/CSG_sampling.jl
+++ b/test/ConstructiveSolidGeometry/CSG_sampling.jl
@@ -1,0 +1,54 @@
+using Test
+
+using SolidStateDetectors.ConstructiveSolidGeometry: sample,
+    ConalPlane, ConeMantle, CylindricalAnnulus, 
+    RectangleX, RectangleY, RectangleZ, 
+    RegularHexagon, HexagonalPrismMantle, RegularPolygon, RegularPrismMantle,
+    SphereMantle, ToroidalAnnulus, TorusMantle,
+    Tube, Cone, Torus, Box, Sphere, HexagonalPrism
+
+@testset "Test sampling" begin
+
+    @testset "VolumePrimitives" begin
+        
+        volume_primitives = [Tube, Cone, Torus, Box, Sphere, HexagonalPrism]
+        
+        for P in volume_primitives
+            @testset "$P" begin
+                p = P(); @test all(broadcast(pt -> pt in p, sample(p)))
+                p = P(); @test all(broadcast(pt -> pt in p, sample(p, (10,10,10))))
+            end
+        end
+    end
+    
+    @testset "SurfacePrimitives" begin
+        
+        surface_primitives = [ConalPlane, CylindricalAnnulus,
+                    #ConeMantle, RegularHexagon, HexagonalPrismMantle,
+                    RectangleX, RectangleY, RectangleZ, 
+                    SphereMantle, ToroidalAnnulus, TorusMantle]
+        
+        @testset "Cartesian Grid" begin
+            cart = (x = collect(-2:0.01:2), y = collect(-2:0.01:2),   z = collect(-2:0.01:2))
+            for P in surface_primitives
+                @testset "$P" begin
+                    p = P(); @test all(broadcast(pt -> pt in p, sample(p, cart)))
+                end
+            end
+        end
+        
+        surface_primitives = [ConalPlane, CylindricalAnnulus,
+                    ConeMantle, RegularHexagon, HexagonalPrismMantle,
+                    #RectangleX, RectangleY, RectangleZ, 
+                    SphereMantle, ToroidalAnnulus, TorusMantle]
+        
+        @testset "Cylindrical Grid" begin
+            cylt = (r = collect(0:0.01:2),  φ = collect(0:pi/8:2pi), z = collect(-2:0.01:2))
+            for P in surface_primitives
+                @testset "$P" begin
+                    p = P(); @test all(broadcast(pt -> pt in p, sample(p, cylt)))
+                end
+            end
+        end
+    end
+end

--- a/test/ConstructiveSolidGeometry/CSG_sampling.jl
+++ b/test/ConstructiveSolidGeometry/CSG_sampling.jl
@@ -47,7 +47,7 @@ using SolidStateDetectors.ConstructiveSolidGeometry: sample,
         end
         
         surface_primitives = [ConalPlane, CylindricalAnnulus, ConeMantle,
-                    # RectangleX, RectangleY, RectangleZ, # Rounding errors at the edges
+                    RectangleX, RectangleY, RectangleZ,
                     SphereMantle, ToroidalAnnulus, TorusMantle]
         
         @testset "Cylindrical Grid" begin

--- a/test/ConstructiveSolidGeometry/CSG_sampling.jl
+++ b/test/ConstructiveSolidGeometry/CSG_sampling.jl
@@ -3,7 +3,7 @@ using Test
 using SolidStateDetectors.ConstructiveSolidGeometry: sample,
     ConalPlane, ConeMantle, CylindricalAnnulus, 
     RectangleX, RectangleY, RectangleZ, 
-    RegularHexagon, HexagonalPrismMantle, RegularPolygon, RegularPrismMantle,
+    RegularPolygon, RegularPrismMantle,
     SphereMantle, ToroidalAnnulus, TorusMantle,
     Tube, Cone, Torus, Box, Sphere, HexagonalPrism
 
@@ -23,8 +23,7 @@ using SolidStateDetectors.ConstructiveSolidGeometry: sample,
     
     @testset "SurfacePrimitives" begin
         
-        surface_primitives = [ConalPlane, CylindricalAnnulus,
-                    #ConeMantle, RegularHexagon, HexagonalPrismMantle,
+        surface_primitives = [ConalPlane, CylindricalAnnulus, ConeMantle,
                     RectangleX, RectangleY, RectangleZ, 
                     SphereMantle, ToroidalAnnulus, TorusMantle]
         
@@ -35,11 +34,23 @@ using SolidStateDetectors.ConstructiveSolidGeometry: sample,
                     p = P(); @test all(broadcast(pt -> pt in p, sample(p, cart)))
                 end
             end
+            
+            for N in 4:8
+                #= 
+                # There are still rounding errors if r is slightly outside of the r-interval of RegularPolygon
+                @testset "RegularPolygon{$N}" begin
+                    p = RegularPolygon(N); @test all(broadcast(pt -> pt in p, sample(p, cart)))
+                end
+                =#
+                @testset "RegularPrismMantle{$N}" begin
+                    p = RegularPrismMantle(N); @test all(broadcast(pt -> pt in p, sample(p, cart)))
+                end
+            end
+            
         end
         
-        surface_primitives = [ConalPlane, CylindricalAnnulus,
-                    ConeMantle, RegularHexagon, HexagonalPrismMantle,
-                    #RectangleX, RectangleY, RectangleZ, 
+        surface_primitives = [ConalPlane, CylindricalAnnulus, ConeMantle,
+                    # RectangleX, RectangleY, RectangleZ, # Rounding errors at the edges
                     SphereMantle, ToroidalAnnulus, TorusMantle]
         
         @testset "Cylindrical Grid" begin
@@ -47,6 +58,14 @@ using SolidStateDetectors.ConstructiveSolidGeometry: sample,
             for P in surface_primitives
                 @testset "$P" begin
                     p = P(); @test all(broadcast(pt -> pt in p, sample(p, cylt)))
+                end
+            end
+            for N in 4:8
+                @testset "RegularPolygon{$N}" begin
+                    p = RegularPolygon(N); @test all(broadcast(pt -> pt in p, sample(p, cylt)))
+                end
+                @testset "RegularPrismMantle{$N}" begin
+                    p = RegularPrismMantle(N); @test all(broadcast(pt -> pt in p, sample(p, cylt)))
                 end
             end
         end

--- a/test/ConstructiveSolidGeometry/CSG_sampling.jl
+++ b/test/ConstructiveSolidGeometry/CSG_sampling.jl
@@ -36,12 +36,9 @@ using SolidStateDetectors.ConstructiveSolidGeometry: sample,
             end
             
             for N in 4:8
-                #= 
-                # There are still rounding errors if r is slightly outside of the r-interval of RegularPolygon
                 @testset "RegularPolygon{$N}" begin
                     p = RegularPolygon(N); @test all(broadcast(pt -> pt in p, sample(p, cart)))
                 end
-                =#
                 @testset "RegularPrismMantle{$N}" begin
                     p = RegularPrismMantle(N); @test all(broadcast(pt -> pt in p, sample(p, cart)))
                 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -123,3 +123,4 @@ end
 include("ConstructiveSolidGeometry/CSG_test.jl")
 include("ConstructiveSolidGeometry/CSG_IO.jl")
 include("ConstructiveSolidGeometry/CSG_decomposition.jl")
+include("ConstructiveSolidGeometry/CSG_sampling.jl")


### PR DESCRIPTION
In order to extend the CSG sampling with `CSGUnion`, `CSGIntersection` and `CSGDifference` using `in()`,
tests are provided to see that all sampled points are "in" the primitive they were sampled from.

For most primitives, the sampled points are "in" the geometry they were sampled from. The only (mostly rounding) errors occur for:
- [x] `ConeMantle` with `CartesianTicksTuple`
- [x] `RegularPolygon` with `CartesianTicksTuple`
- [x] `RegularPrismMantle` with `CartesianTicksTuple`
- [x] `RectangleZ` with `CylindricalTicksTuple`

which, for now, are excluded from the tests. I will check if the `sample` / `in` methods can be changed such that these tests pass.