### PR TITLE
Require Julia v1.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -56,7 +56,7 @@ Tables = "0.2, 1"
 TypedTables = "1.2"
 Unitful = "0.18, 1"
 YAML = "0.3, 0.4"
-julia = "1"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Julia v1.0 starts making trouble from time to time. 

Julia v1.7 is already in the beta phase and I believe 1.6 should become the new LTS version of Julia once v1.7 is released. 

So, I would suggest to require Julia v1.6 from now on. 
Since we will have this v0.6-branch on our master branch for some time for testing,
Julia v1.7 will probably be released once we want to make a new release of SSD.