### PR TITLE
Enhance initialization of `Grid`

### DIFF
--- a/src/Axes/DiscreteAxis.jl
+++ b/src/Axes/DiscreteAxis.jl
@@ -363,3 +363,32 @@ end
 
 Base.convert(T::Type{NamedTuple}, x::DiscreteAxis; unit = u"m/m") = T(x)
 
+function merge_closest_ticks!(v::AbstractVector{T}, n::Int = length(v); min_diff::T = T(1e-6)) where {T}
+    Δv = diff(v[1:n])
+    Δ_min, Δv_min_indx = findmin(Δv)
+    vFirst = v[1]
+    vLast  = v[n]
+    if Δ_min < min_diff
+        v[Δv_min_indx] = (v[Δv_min_indx]+v[Δv_min_indx+1]) / 2
+        v[Δv_min_indx+1:end-1] = v[Δv_min_indx+2:end]
+        v[1] = vFirst
+        n -= 1
+        v[n] = vLast
+        n
+    else
+        n
+    end
+end
+function merge_close_ticks(v::AbstractVector{T}; min_diff::T = T(1e-6)) where {T}
+    l = length(v)
+    if l == 1 return v end
+    n = merge_closest_ticks!(v, min_diff = min_diff)
+    reduced = n < l
+    l = n
+    while reduced
+        n = merge_closest_ticks!(v, n, min_diff = min_diff)
+        reduced = n < l
+        l = n
+    end
+    v[1:n]
+end

--- a/src/Axes/DiscreteAxis.jl
+++ b/src/Axes/DiscreteAxis.jl
@@ -485,3 +485,23 @@ function initialize_axis_ticks(t::AbstractVector{T}; max_ratio = T(2)) where {T}
     @assert isunique(ticks)
     ticks
 end
+
+function fill_up_ticks(v::AbstractVector{T}, max_diff::T) where {T}
+    if length(v) == 1 return v end
+    Δv = diff(v)
+    add_n_points = Int.(round.(Δv ./ max_diff, RoundUp)) .- 1
+    r = Vector{T}(undef, length(v) + sum(add_n_points))
+    r[:] .= 0
+    i = 0
+    for j in eachindex(Δv)
+        x0 = v[j]
+        n = add_n_points[j]
+        Δ = Δv[j] / (n + 1) 
+        for l in 0:n
+            i += 1
+            r[i] = x0 + Δ * l
+        end
+    end
+    r[end] = v[end]
+    r
+end

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -296,35 +296,6 @@ function Grid(  sim::Simulation{T, Cylindrical};
     return CylindricalGrid{T}( (ax_r, ax_φ, ax_z) )
 end
 
-function merge_closest_ticks!(v::AbstractVector{T}, n::Int = length(v); max_diff::T = T(1e-6)) where {T}
-    Δv = diff(v[1:n])
-    Δ_min, Δv_min_indx = findmin(Δv)
-    vFirst = v[1]
-    vLast  = v[n]
-    if Δ_min < max_diff
-        v[Δv_min_indx] = (v[Δv_min_indx]+v[Δv_min_indx+1]) / 2
-        v[Δv_min_indx+1:end-1] = v[Δv_min_indx+2:end]
-        v[1] = vFirst
-        n -= 1
-        v[n] = vLast
-        n
-    else
-        n
-    end
-end
-function merge_close_ticks(v::AbstractVector{T}; max_diff::T = T(1e-6)) where {T}
-    l = length(v)
-    if l == 1 return v end
-    n = merge_closest_ticks!(v, max_diff = max_diff)
-    reduced = n < l
-    l = n
-    while reduced
-        n = merge_closest_ticks!(v, n, max_diff = max_diff)
-        reduced = n < l
-        l = n
-    end
-    v[1:n]
-end
 
 function Grid(  sim::Simulation{T, Cartesian};
                 init_grid_size::Union{Missing, NTuple{3, Int}} = missing,

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -180,6 +180,7 @@ function Grid(  sim::Simulation{T, Cylindrical};
                 init_grid_spacing::Union{Missing, Tuple{<:Real,<:Real,<:Real}} = missing,
                 for_weighting_potential::Bool = false,
                 min_n_ticks::Int = 10,
+                max_tick_distance::Real = 1e-2,
                 full_2π::Bool = false)::CylindricalGrid{T} where {T}
     if ismissing(init_grid_size)
         world_diffs = [(getproperty.(sim.world.intervals, :right) .- getproperty.(sim.world.intervals, :left))...]
@@ -214,18 +215,40 @@ function Grid(  sim::Simulation{T, Cylindrical};
 
     push!(important_r_points, sim.world.intervals[1].left)
     push!(important_r_points, sim.world.intervals[1].right)
-    important_r_points = unique!(sort!(csg_round_lin.(important_r_points)))
+    important_r_points = unique!(sort!(important_r_points))
+    iL = searchsortedfirst(important_r_points, sim.world.intervals[1].left)
+    iR = searchsortedfirst(important_r_points, sim.world.intervals[1].right)
+    important_r_points = unique(map(t -> isapprox(t, 0, atol = 1e-12) ? zero(T) : t, important_r_points[iL:iR]))
+    important_r_points = merge_close_ticks(important_r_points)
+    important_r_points = initialize_axis_ticks(important_r_points; max_ratio = 2.0)
+    if max_tick_distance isa Real
+        important_r_points = fill_up_ticks(important_r_points, T(max_tick_distance))
+    end
+
     push!(important_z_points, sim.world.intervals[3].left)
     push!(important_z_points, sim.world.intervals[3].right)
-    important_z_points = unique!(sort!(csg_round_lin.(important_z_points)))
+    important_z_points = unique!(sort!(important_z_points))
+    iL = searchsortedfirst(important_z_points, sim.world.intervals[3].left)
+    iR = searchsortedfirst(important_z_points, sim.world.intervals[3].right)
+    important_z_points = unique(map(t -> isapprox(t, 0, atol = 1e-12) ? zero(T) : t, important_z_points[iL:iR]))
+    important_z_points = merge_close_ticks(important_z_points)
+    important_z_points = initialize_axis_ticks(important_z_points; max_ratio = 2.0)
+    if max_tick_distance isa Real
+        important_z_points = fill_up_ticks(important_z_points, T(max_tick_distance))
+    end
+
     push!(important_φ_points, sim.world.intervals[2].left)
     push!(important_φ_points, sim.world.intervals[2].right)
-    important_φ_points = unique!(sort!(csg_round_rad.(important_φ_points)))
-
-    important_r_points = merge_close_ticks(important_r_points)
-    important_φ_points = merge_close_ticks(important_φ_points, max_diff = T(1e-4))
-    important_z_points = merge_close_ticks(important_z_points)
-
+    important_φ_points = unique!(sort!(important_φ_points))
+    iL = searchsortedfirst(important_φ_points, sim.world.intervals[2].left)
+    iR = searchsortedfirst(important_φ_points, sim.world.intervals[2].right)
+    important_φ_points = unique(map(t -> isapprox(t, 0, atol = 1e-3) ? zero(T) : t, important_φ_points[iL:iR]))
+    important_φ_points = merge_close_ticks(important_φ_points, min_diff = T(1e-3))
+    important_φ_points = initialize_axis_ticks(important_φ_points; max_ratio = 2.0)
+    if max_tick_distance isa Real
+        important_φ_points = fill_up_ticks(important_φ_points, 2*T(max_tick_distance) / (sim.world.intervals[1].right - sim.world.intervals[1].left))
+    end
+    
     # r
     L, R, BL, BR = get_boundary_types(sim.world.intervals[1])
     int_r = Interval{L, R, T}(sim.world.intervals[1].left, sim.world.intervals[1].right)
@@ -234,8 +257,9 @@ function Grid(  sim::Simulation{T, Cylindrical};
     else
         DiscreteAxis{BL, BR}(int_r, length = init_grid_size[1])
     end
-    rticks::Vector{T} = merge_axis_ticks_with_important_ticks(ax_r, important_r_points, atol = minimum(diff(ax_r.ticks))/4)
-    rticks = merge_close_ticks(rticks)
+    # rticks::Vector{T} = merge_axis_ticks_with_important_ticks(ax_r, important_r_points, atol = minimum(diff(ax_r.ticks))/4)
+    # rticks = merge_close_ticks(rticks)
+    rticks = important_r_points
     ax_r = DiscreteAxis{T, BL, BR}(int_r, rticks)
 
 
@@ -256,12 +280,17 @@ function Grid(  sim::Simulation{T, Cylindrical};
         end
     end
     if length(ax_φ) > 1
-        φticks::Vector{T} = merge_axis_ticks_with_important_ticks(ax_φ, important_φ_points, atol = minimum(diff(ax_φ.ticks))/4)
-        φticks = merge_close_ticks(φticks)
+        # φticks::Vector{T} = merge_axis_ticks_with_important_ticks(ax_φ, important_φ_points, atol = minimum(diff(ax_φ.ticks))/4)
+        # φticks = merge_close_ticks(φticks)
+        φticks = if R == :open 
+            important_φ_points[1:end-1]
+        else
+            important_φ_points
+        end
         ax_φ = typeof(ax_φ)(int_φ, φticks)
     end
     int_φ = ax_φ.interval
-    φticks = merge_close_ticks(ax_φ.ticks)
+    # φticks = merge_close_ticks(ax_φ.ticks)
     if isodd(length(ax_φ)) && length(ax_φ) > 1 # must be even
         imax = findmax(diff(φticks))[2]
         push!(φticks, (φticks[imax] + φticks[imax+1]) / 2)
@@ -280,8 +309,9 @@ function Grid(  sim::Simulation{T, Cylindrical};
     else
         DiscreteAxis{BL, BR}(int_z, length = init_grid_size[3])
     end
-    zticks::Vector{T} = merge_axis_ticks_with_important_ticks(ax_z, important_z_points, atol=minimum(diff(ax_z.ticks))/2)
-    zticks = merge_close_ticks(zticks)
+    # zticks::Vector{T} = merge_axis_ticks_with_important_ticks(ax_z, important_z_points, atol=minimum(diff(ax_z.ticks))/2)
+    # zticks = merge_close_ticks(zticks)
+    zticks = important_z_points
     ax_z = typeof(ax_z)(int_z, zticks)
     if isodd(length(ax_z)) # must be even
         int_z = ax_z.interval
@@ -301,6 +331,7 @@ function Grid(  sim::Simulation{T, Cartesian};
                 init_grid_size::Union{Missing, NTuple{3, Int}} = missing,
                 init_grid_spacing::Union{Missing, Tuple{<:Real,<:Real,<:Real,}} = missing,
                 min_n_ticks::Int = 10,
+                max_tick_distance::Real = 1e-2,
                 for_weighting_potential::Bool = false)::CartesianGrid3D{T} where {T}
 
     if ismissing(init_grid_size)
@@ -323,10 +354,45 @@ function Grid(  sim::Simulation{T, Cartesian};
 
     samples::Vector{CartesianPoint{T}} = sample(sim.detector, Cartesian)
     
-    important_x_points::Vector{T} = merge_close_ticks(sort(unique(map(p -> p.x, samples))))
-    important_y_points::Vector{T} = merge_close_ticks(sort(unique(map(p -> p.y, samples))))
-    important_z_points::Vector{T} = merge_close_ticks(sort(unique(map(p -> p.z, samples))))
+    important_x_points::Vector{T} = map(p -> p.x, samples)
+    important_y_points::Vector{T} = map(p -> p.y, samples)
+    important_z_points::Vector{T} = map(p -> p.z, samples)
 
+    push!(important_x_points, sim.world.intervals[1].left)
+    push!(important_x_points, sim.world.intervals[1].right)
+    important_x_points = unique!(sort!(important_x_points))
+    iL = searchsortedfirst(important_x_points, sim.world.intervals[1].left)
+    iR = searchsortedfirst(important_x_points, sim.world.intervals[1].right)
+    important_x_points = unique(map(t -> isapprox(t, 0, atol = 1e-12) ? zero(T) : t, important_x_points[iL:iR]))
+    important_x_points = merge_close_ticks(important_x_points)
+    important_x_points = initialize_axis_ticks(important_x_points; max_ratio = 2.0)
+    if max_tick_distance isa Real
+        important_x_points = fill_up_ticks(important_x_points, T(max_tick_distance))
+    end
+
+    push!(important_y_points, sim.world.intervals[2].left)
+    push!(important_y_points, sim.world.intervals[2].right)
+    important_y_points = unique!(sort!(important_y_points))
+    iL = searchsortedfirst(important_y_points, sim.world.intervals[2].left)
+    iR = searchsortedfirst(important_y_points, sim.world.intervals[2].right)
+    important_y_points = unique(map(t -> isapprox(t, 0, atol = 1e-12) ? zero(T) : t, important_y_points[iL:iR]))
+    important_y_points = merge_close_ticks(important_y_points)
+    important_y_points = initialize_axis_ticks(important_y_points; max_ratio = 2.0)
+    if max_tick_distance isa Real
+        important_y_points = fill_up_ticks(important_y_points, T(max_tick_distance))
+    end
+
+    push!(important_z_points, sim.world.intervals[3].left)
+    push!(important_z_points, sim.world.intervals[3].right)
+    important_z_points = unique!(sort!(important_z_points))
+    iL = searchsortedfirst(important_z_points, sim.world.intervals[3].left)
+    iR = searchsortedfirst(important_z_points, sim.world.intervals[3].right)
+    important_z_points = unique(map(t -> isapprox(t, 0, atol = 1e-12) ? zero(T) : t, important_z_points[iL:iR]))
+    important_z_points = merge_close_ticks(important_z_points)
+    important_z_points = initialize_axis_ticks(important_z_points; max_ratio = 2.0)
+    if max_tick_distance isa Real
+        important_z_points = fill_up_ticks(important_z_points, T(max_tick_distance))
+    end
 
     init_grid_spacing, use_spacing::Bool = if !ismissing(init_grid_spacing)
         T.(init_grid_spacing), true
@@ -342,8 +408,9 @@ function Grid(  sim::Simulation{T, Cartesian};
     else
         DiscreteAxis{BL, BR}(int_x, length = init_grid_size[1])
     end
-    xticks::Vector{T} = merge_axis_ticks_with_important_ticks(ax_x, important_x_points, atol = minimum(diff(ax_x.ticks)) / 2)
-    xticks = merge_close_ticks(xticks)
+    # xticks::Vector{T} = merge_axis_ticks_with_important_ticks(ax_x, important_x_points, atol = minimum(diff(ax_x.ticks)) / 2)
+    # xticks = merge_close_ticks(xticks)
+    xticks = important_x_points
     ax_x = typeof(ax_x)(int_x, xticks)
     if isodd(length(ax_x)) # RedBlack dimension must be of even length
         xticks = ax_x.ticks
@@ -361,8 +428,9 @@ function Grid(  sim::Simulation{T, Cartesian};
     else
         DiscreteAxis{BL, BR}(int_y, length = init_grid_size[2])
     end
-    yticks::Vector{T} = merge_axis_ticks_with_important_ticks(ax_y, important_y_points, atol = minimum(diff(ax_y.ticks)) / 2)
-    yticks = merge_close_ticks(yticks)
+    # yticks::Vector{T} = merge_axis_ticks_with_important_ticks(ax_y, important_y_points, atol = minimum(diff(ax_y.ticks)) / 2)
+    # yticks = merge_close_ticks(yticks)
+    yticks = important_y_points
     ax_y = typeof(ax_y)(int_y, yticks)
 
     # z
@@ -373,8 +441,9 @@ function Grid(  sim::Simulation{T, Cartesian};
     else
         DiscreteAxis{BL, BR}(int_z, length = init_grid_size[3])
     end
-    zticks::Vector{T} = merge_axis_ticks_with_important_ticks(ax_z, important_z_points, atol = minimum(diff(ax_z.ticks)) / 2)
-    zticks = merge_close_ticks(zticks)
+    # zticks::Vector{T} = merge_axis_ticks_with_important_ticks(ax_z, important_z_points, atol = minimum(diff(ax_z.ticks)) / 2)
+    # zticks = merge_close_ticks(zticks)
+    zticks = important_z_points
     ax_z = typeof(ax_z)(int_z, zticks)
 
     return CartesianGrid3D{T}( (ax_x, ax_y, ax_z) )

--- a/test/comparison_to_analytic_solutions.jl
+++ b/test/comparison_to_analytic_solutions.jl
@@ -44,12 +44,10 @@ struct DummyImpurityDensity{T} <: SolidStateDetectors.AbstractImpurityDensity{T}
     intV = (R2^2 - R1^2) * π * L
 
     calculate_electric_potential!(sim_cyl, 
-        init_grid_size = (40, 2, 2), 
-        max_refinements = 1,
+        max_refinements = 6,
     )
     calculate_electric_potential!(sim_car, 
-        init_grid_size = (40, 40, 2), 
-        max_refinements = 1
+        max_refinements = 2
     )
     calculate_electric_field!(sim_cyl)
     calculate_electric_field!(sim_car)
@@ -100,11 +98,9 @@ struct DummyImpurityDensity{T} <: SolidStateDetectors.AbstractImpurityDensity{T}
     sim_car.detector = SolidStateDetector(sim_car.detector, DummyImpurityDensity{T}());
 
     calculate_electric_potential!(sim_cyl, 
-        init_grid_size = (40, 2, 2), 
-        max_refinements = 1
+        max_refinements = 4
     )
     calculate_electric_potential!(sim_car, 
-        init_grid_size = (40, 40, 2), 
         max_refinements = 1
     )
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,7 +47,7 @@ end
             signalsum += abs(evt.waveforms[i].value[end])
         end
         @info signalsum
-        @test isapprox( signalsum, T(2), atol = 4e-3 )
+        @test isapprox( signalsum, T(2), atol = 0.02 )
     end
     @testset "Simulate example detector: BEGe" begin
         sim = Simulation{T}(SSD_examples[:BEGe])
@@ -59,7 +59,7 @@ end
             signalsum += abs(evt.waveforms[i].value[end])
         end
         @info signalsum
-        @test isapprox( signalsum, T(2), atol = 3e-3 )
+        @test isapprox( signalsum, T(2), atol = 3e-2 )
     end
     @testset "Simulate example detector: HexagonalPrism" begin
         sim = Simulation{T}(SSD_examples[:Hexagon])
@@ -120,7 +120,7 @@ end
             signalsum += abs(evt.waveforms[i].value[end])
         end
         @info signalsum
-        @test isapprox( signalsum, T(2), atol = 2e-3 )
+        @test isapprox( signalsum, T(2), atol = 2e-2 )
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -112,7 +112,7 @@ end
     end
     @testset "Simulate example detector: SigGen PPC" begin
         sim = Simulation{T}(SSD_examples[:SigGen])
-        simulate!(sim, max_refinements = 0, verbose = true)
+        simulate!(sim, max_refinements = 1, verbose = true)
         evt = Event(CartesianPoint.([CylindricalPoint{T}(20e-3, deg2rad(10), 40e-3 )]))
         simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
         signalsum = T(0)


### PR DESCRIPTION
This PR addresses the initialization of the Grid. 

In order to have a fast convergence towards equilibrium it is good when the widths of the voxels
are not too different compared to the widths of the neighbor voxels.  

In extreme cases this can lead to the effect of shadowing (blocking the spreading of the electric potential in the SOR).
See comment: https://github.com/JuliaPhysics/SolidStateDetectors.jl/pull/163#issuecomment-866699288

![shadowing](https://user-images.githubusercontent.com/16963906/124783721-91fdd100-df45-11eb-96c9-dddbed0e0c56.png)

To avoid this I implemented the function `initialize_axis_ticks` in 4e3c5fb
which add axis ticks next to existing axis ticks (generated by the geometry of objects) where the ratio of the distances to the neighboring ticks (left and right) exceeds a certain limit. The limit ratio can be tuned via a keyword. Default is `2`.

Here an example:
The black lines are the existing ticks and the red lines are all ticks after `initialize_axis_ticks`:

![gridspacing](https://user-images.githubusercontent.com/16963906/124783951-c1acd900-df45-11eb-8435-b8003fa01216.png)
