### PR TITLE
Hotfix in I/O of Simulation and MCEventsProcessing

### DIFF
--- a/src/MCEventsProcessing/MCEventsProcessing.jl
+++ b/src/MCEventsProcessing/MCEventsProcessing.jl
@@ -7,7 +7,7 @@ function simulate_waveforms( mcevents::TypedTables.Table, s::Simulation{T};
     n_total_physics_events = length(mcevents)
     Δtime = T(to_internal_units(internal_time_unit, Δt)) 
     n_contacts = length(s.detector.contacts)
-    S = Val(get_coordinate_system(s.electron_drift_field.grid))
+    S = get_coordinate_system(s)
     contacts = s.detector.contacts;
     contact_ids = Int[]
     for contact in contacts if !ismissing(s.weighting_potentials[contact.id]) push!(contact_ids, contact.id) end end

--- a/src/MCEventsProcessing/MCEventsProcessing_hdf5.jl
+++ b/src/MCEventsProcessing/MCEventsProcessing_hdf5.jl
@@ -8,7 +8,6 @@ function simulate_waveforms( mcevents::TypedTables.Table, s::Simulation{T},
     n_total_physics_events = length(mcevents)
     Δtime = T(to_internal_units(internal_time_unit, Δt)) 
     n_contacts = length(s.detector.contacts)
-    S = Val(get_coordinate_system(s.electric_potential.grid))
     @info "Detector has $(n_contacts) contact(s)"
     contacts = s.detector.contacts;
     # wps_interpolated = [interpolated_scalarfield(s.weighting_potentials[contact.id]) for contact in contacts ];

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -53,7 +53,7 @@ function NamedTuple(sim::Simulation{T}) where {T <: SSDFloat}
     end
     wps_syms = Symbol.(wps_strings)
     nt = (
-        detector_json_string = NamedTuple(sim.detector.config_dict),
+        detector_json_string = NamedTuple(sim.config_dict),
         electric_potential = NamedTuple(sim.electric_potential),
         q_eff_imp = NamedTuple(sim.q_eff_imp),
         q_eff_fix = NamedTuple(sim.q_eff_fix),
@@ -73,8 +73,7 @@ Base.convert(T::Type{NamedTuple}, x::Simulation) = T(x)
 function Simulation(nt::NamedTuple)
     ep = ElectricPotential(nt.electric_potential)
     T = eltype(ep.data)
-    det = SolidStateDetector{T}( Dict(nt.detector_json_string) )
-    sim = Simulation( det )
+    sim = Simulation{T}( Dict(nt.detector_json_string) )
     if !ismissing(nt.electric_potential) sim.electric_potential = ep end
     if !ismissing(nt.q_eff_imp) sim.q_eff_imp = EffectiveChargeDensity(nt.q_eff_imp) end
     if !ismissing(nt.q_eff_fix) sim.q_eff_fix = EffectiveChargeDensity(nt.q_eff_fix) end


### PR DESCRIPTION
When trying to run the [legend-julia-tutorial](https://github.com/legend-exp/legend-julia-tutorial), I encountered some bugs in the I/O.

- fbc9c23: The `json_string` is now stored in `Simulation` and not in `SolidStateDetector` (see #162)
- 024fe44: Replacing `:cartesian` and `:cylindrical` with actual types made the use of `Val(S)` obsolte.