### PR TITLE
Update configuration file conversion script

### DIFF
--- a/examples/example_primitive_files/Torus.yaml
+++ b/examples/example_primitive_files/Torus.yaml
@@ -7,4 +7,3 @@ torus:
   theta: 
       from: 0.0°
       to: 360.0°
-  z: 0.0

--- a/src/ConstructiveSolidGeometry/IO.jl
+++ b/src/ConstructiveSolidGeometry/IO.jl
@@ -146,7 +146,7 @@ function parse_r_of_primitive(::Type{T}, dict::AbstractDict, unit::Unitful.Units
         if r_bot_out == r_top_out
             return r_bot_out # Cylinder
         else
-            return (r_bot_out, r_top_out) # VaryingCylinder
+            return ((r_bot_out,), (r_top_out,)) # VaryingCylinder
         end
     elseif r_top_in == r_top_out && r_bot_in != r_bot_out
         if r_top_in == 0

--- a/src/ConstructiveSolidGeometry/Transformations.jl
+++ b/src/ConstructiveSolidGeometry/Transformations.jl
@@ -25,3 +25,17 @@ function combine_transformations(current::Transformations, new::Transformations)
     (rotation = r, translation = t)
 end
 
+
+function Dictionary(m::SMatrix{3,3,T,9}) where {T}
+    dict = OrderedDict{String, Any}()
+    mat = RotXYZ(m)
+    if mat.theta1 == 0 && mat.theta2 == 0
+        if mat.theta3 != 0
+            dict["Z"] = string(mat.theta3)*"rad"
+        end
+    else
+        dict["M"] = m[:]
+    end
+    dict
+end
+

--- a/src/ConstructiveSolidGeometry/VolumePrimitives/Box.jl
+++ b/src/ConstructiveSolidGeometry/VolumePrimitives/Box.jl
@@ -69,6 +69,14 @@ function Geometry(::Type{T}, ::Type{Box}, dict::AbstractDict, input_units::Named
     transform(box, transformations)
 end
 
+function Dictionary(b::Box{T})::OrderedDict{String, Any} where {T}
+    dict = OrderedDict{String,Any}()
+    dict["widths"] = [2*b.hX, 2*b.hY, 2*b.hZ]
+    if b.origin != zero(CartesianVector{T}) dict["origin"] = b.origin end
+    if b.rotation != one(SMatrix{3,3,T,9}) dict["rotation"] = Dictionary(b.rotation) end
+    OrderedDict{String,Any}("box" => dict)
+end
+
 function vertices(b::Box{T}) where {T}
     return (
         b.rotation * SVector{3,T}(-b.hX, -b.hY, -b.hZ) .+ b.origin,

--- a/src/ConstructiveSolidGeometry/VolumePrimitives/Cone.jl
+++ b/src/ConstructiveSolidGeometry/VolumePrimitives/Cone.jl
@@ -120,28 +120,28 @@ ___
 _____\
 
 =#
-const VaryingCylinder{T,CO} = Cone{T,CO,Tuple{T,T},Nothing} # Full in φ
-const PartialVaryingCylinder{T,CO} = Cone{T,CO,Tuple{T,T},Tuple{T,T}}
+const VaryingCylinder{T,CO} = Cone{T,CO,Tuple{Tuple{T},Tuple{T}},Nothing} # Full in φ
+const PartialVaryingCylinder{T,CO} = Cone{T,CO,Tuple{Tuple{T},Tuple{T}},Tuple{T,T}}
 
 function _in(pt::CartesianPoint, c::VaryingCylinder{T,ClosedPrimitive}; csgtol::T = csg_default_tol(T)) where {T} 
     az = abs(pt.z) 
     az <= c.hZ + csgtol && begin
         r = hypot(pt.x, pt.y) 
-        rz = radius_at_z(c.hZ, c.r[1], c.r[2], pt.z)
+        rz = radius_at_z(c.hZ, c.r[1][1], c.r[2][1], pt.z)
         r <= rz + csgtol
     end
 end
 function _in(pt::CartesianPoint, c::VaryingCylinder{T,OpenPrimitive}; csgtol::T = csg_default_tol(T)) where {T} 
     abs(pt.z) + csgtol < c.hZ &&
-    csgtol + hypot(pt.x, pt.y) < radius_at_z(c.hZ, c.r[1], c.r[2], pt.z)
+    csgtol + hypot(pt.x, pt.y) < radius_at_z(c.hZ, c.r[1][1], c.r[2][1], pt.z)
 end
 
 function surfaces(t::VaryingCylinder{T}) where {T}
     bot_center_pt = _transform_into_global_coordinate_system(CartesianPoint{T}(zero(T), zero(T), -t.hZ), t) 
     top_center_pt = _transform_into_global_coordinate_system(CartesianPoint{T}(zero(T), zero(T), +t.hZ), t) 
-    mantle = ConeMantle{T,Tuple{T,T},Nothing,:inwards}((t.r[1], t.r[2]), t.φ, t.hZ, t.origin, t.rotation)
-    e_bot = CircularArea{T}(r = t.r[1], φ = t.φ, origin = bot_center_pt, rotation = t.rotation)
-    e_top = CircularArea{T}(r = t.r[2], φ = t.φ, origin = top_center_pt, rotation = -t.rotation * RotZ{T}(π))
+    mantle = ConeMantle{T,Tuple{T,T},Nothing,:inwards}((t.r[1][1], t.r[2][1]), t.φ, t.hZ, t.origin, t.rotation)
+    e_bot = CircularArea{T}(r = t.r[1][1], φ = t.φ, origin = bot_center_pt, rotation = t.rotation)
+    e_top = CircularArea{T}(r = t.r[2][1], φ = t.φ, origin = top_center_pt, rotation = -t.rotation * RotZ{T}(π))
     # normals of the surfaces show inside the volume primitives. 
     e_top, e_bot, mantle
 end
@@ -150,7 +150,7 @@ function _in(pt::CartesianPoint, c::PartialVaryingCylinder{T,ClosedPrimitive}; c
     az = abs(pt.z) 
     az <= c.hZ + csgtol && begin
         r = hypot(pt.x, pt.y) 
-        rz = radius_at_z(c.hZ, c.r[1], c.r[2], pt.z)
+        rz = radius_at_z(c.hZ, c.r[1][1], c.r[2][1], pt.z)
         r <= rz + csgtol &&
         _in_angular_interval_closed(atan(pt.y, pt.x), c.φ, csgtol = csgtol / r)
     end
@@ -158,7 +158,7 @@ end
 function _in(pt::CartesianPoint, c::PartialVaryingCylinder{T,OpenPrimitive}; csgtol::T = csg_default_tol(T)) where {T} 
     abs(pt.z) + csgtol < c.hZ && begin
         r = hypot(pt.x, pt.y) 
-        csgtol + r < radius_at_z(c.hZ, c.r[1], c.r[2], pt.z) &&
+        csgtol + r < radius_at_z(c.hZ, c.r[1][1], c.r[2][1], pt.z) &&
         _in_angular_interval_open(atan(pt.y, pt.x), c.φ, csgtol = csgtol / r)
     end
 end
@@ -166,19 +166,19 @@ end
 function surfaces(t::PartialVaryingCylinder{T}) where {T}
     bot_center_pt = _transform_into_global_coordinate_system(CartesianPoint{T}(zero(T), zero(T), -t.hZ), t) 
     top_center_pt = _transform_into_global_coordinate_system(CartesianPoint{T}(zero(T), zero(T), +t.hZ), t) 
-    mantle = ConeMantle{T,Tuple{T,T},Tuple{T,T},:inwards}((t.r[1], t.r[2]), t.φ, t.hZ, t.origin, t.rotation)
-    e_bot = PartialCircularArea{T}(r = t.r[1], φ = t.φ, origin = bot_center_pt, rotation = t.rotation)
-    e_top = PartialCircularArea{T}(r = t.r[2], φ = t.φ, origin = top_center_pt, rotation = -t.rotation * RotZ{T}(π))
+    mantle = ConeMantle{T,Tuple{T,T},Tuple{T,T},:inwards}((t.r[1][1], t.r[2][1]), t.φ, t.hZ, t.origin, t.rotation)
+    e_bot = PartialCircularArea{T}(r = t.r[1][1], φ = t.φ, origin = bot_center_pt, rotation = t.rotation)
+    e_top = PartialCircularArea{T}(r = t.r[2][1], φ = t.φ, origin = top_center_pt, rotation = -t.rotation * RotZ{T}(π))
     poly_l = _transform_into_global_coordinate_system(Quadrangle{T}((
-        CartesianPoint(CylindricalPoint{T}(zero(T),  t.φ[1], -t.hZ)),
-        CartesianPoint(CylindricalPoint{T}(zero(T),  t.φ[1], +t.hZ)),
-        CartesianPoint(CylindricalPoint{T}( t.r[2],  t.φ[1], +t.hZ)),
-        CartesianPoint(CylindricalPoint{T}( t.r[1],  t.φ[1], -t.hZ)) )), t)
+        CartesianPoint(CylindricalPoint{T}(zero(T),    t.φ[1], -t.hZ)),
+        CartesianPoint(CylindricalPoint{T}(zero(T),    t.φ[1], +t.hZ)),
+        CartesianPoint(CylindricalPoint{T}( t.r[2][1], t.φ[1], +t.hZ)),
+        CartesianPoint(CylindricalPoint{T}( t.r[1][1], t.φ[1], -t.hZ)) )), t)
     poly_r = _transform_into_global_coordinate_system(Quadrangle{T}((
-        CartesianPoint(CylindricalPoint{T}(zero(T),  t.φ[2], -t.hZ)),
-        CartesianPoint(CylindricalPoint{T}( t.r[1],  t.φ[2], -t.hZ)),
-        CartesianPoint(CylindricalPoint{T}( t.r[2],  t.φ[2], +t.hZ)),
-        CartesianPoint(CylindricalPoint{T}(zero(T),  t.φ[2], +t.hZ)) )), t)
+        CartesianPoint(CylindricalPoint{T}(zero(T),    t.φ[2], -t.hZ)),
+        CartesianPoint(CylindricalPoint{T}( t.r[1][1], t.φ[2], -t.hZ)),
+        CartesianPoint(CylindricalPoint{T}( t.r[2][1], t.φ[2], +t.hZ)),
+        CartesianPoint(CylindricalPoint{T}(zero(T),    t.φ[2], +t.hZ)) )), t)
     # normals of the surfaces show inside the volume primitives. 
     e_top, e_bot, mantle, poly_l, poly_r
 end

--- a/src/ConstructiveSolidGeometry/VolumePrimitives/Ellipsoid.jl
+++ b/src/ConstructiveSolidGeometry/VolumePrimitives/Ellipsoid.jl
@@ -57,6 +57,16 @@ function Geometry(::Type{T}, ::Type{Ellipsoid}, dict::AbstractDict, input_units:
     transform(e, transformations)
 end
 
+function Dictionary(e::Ellipsoid{T})::OrderedDict{String, Any} where {T}
+    dict = OrderedDict{String, Any}()
+    dict["r"] = e.r # always a Real 
+    if !isnothing(e.φ) error("Partial Ellipsoid (`φ = φ`) is not yet supported.") end
+    if !isnothing(e.θ) error("Partial Ellipsoid (`θ = θ`) is not yet supported.") end
+    if e.origin != zero(CartesianVector{T}) dict["origin"] = e.origin end
+    if e.rotation != one(SMatrix{3,3,T,9}) dict["rotation"] = Dictionary(e.rotation) end
+    OrderedDict{String, Any}("sphere" => dict)
+end
+
 _in(pt::CartesianPoint{T}, s::FullSphere{<:Any, ClosedPrimitive}; csgtol::T = csg_default_tol(T)) where {T} =
     hypot(pt.x, pt.y, pt.z) <= s.r + csgtol
 

--- a/src/ConstructiveSolidGeometry/VolumePrimitives/RegularPrism.jl
+++ b/src/ConstructiveSolidGeometry/VolumePrimitives/RegularPrism.jl
@@ -51,6 +51,22 @@ function Geometry(::Type{T}, ::Type{P}, dict::AbstractDict, input_units::NamedTu
     transform(g, transformations)
 end
 
+const PrismAliases = Dict{Int, String}(
+    3 => "TriangularPrism", 
+    4 => "QuadranglePrism", 
+    5 => "PentagonalPrism", 
+    6 => "HexagonalPrism"
+)
+
+function Dictionary(rp::RegularPrism{T, <:Any, N})::OrderedDict{String, Any} where {T, N}
+    dict = OrderedDict{String, Any}()
+    dict["r"] = rp.r # always a Real 
+    dict["h"] = rp.hZ*2
+    if rp.origin != zero(CartesianVector{T}) dict["origin"] = rp.origin end
+    if rp.rotation != one(SMatrix{3,3,T,9}) dict["rotation"] = Dictionary(rp.rotation) end
+    OrderedDict{String, Any}(PrismAliases[N] => dict)
+end
+
 function vertices(rp::RegularPrism{T,ClosedPrimitive,N,T}) where {T,N}
     xys = [rp.r .* sincos(T(2π)*(n-1)/N) for n in 1:N]
     pts = [CartesianPoint{T}(xy[2], xy[1], z) for z in (-rp.hZ, rp.hZ) for xy in xys]
@@ -95,13 +111,6 @@ function _in(pt::CartesianPoint{T}, rp::RegularPrism{T,OpenPrimitive,N,T}; csgto
         _r < rp.r - csgtol
     end
 end
-
-# const PrismAliases = Dict{Int, String}(
-#     3 => "TriangularPrism", 
-#     4 => "SquarePrism", 
-#     5 => "PentagonalPrism", 
-#     6 => "HexagonalPrism"
-# )
 
 # # Convenience functions
 # const TriangularPrism{T,TR,TZ} = RegularPrism{3,T,TR,TZ}

--- a/src/ConstructiveSolidGeometry/VolumePrimitives/Torus.jl
+++ b/src/ConstructiveSolidGeometry/VolumePrimitives/Torus.jl
@@ -55,6 +55,17 @@ function Geometry(::Type{T}, ::Type{Torus}, dict::AbstractDict, input_units::Nam
     transform(t, transformations)
 end
 
+function Dictionary(t::Torus{T})::OrderedDict{String, Any} where {T}
+    dict = OrderedDict{String, Any}()
+    dict["r_torus"] = t.r_torus
+    dict["r_tube"] = t.r_tube # always a Real
+    if !isnothing(t.φ) error("Partial Torus (`φ = φ`) is not yet supported.") end
+    if !isnothing(t.θ) error("Partial Torus (`θ = θ`) is not yet supported.") end
+    if t.origin != zero(CartesianVector{T}) dict["origin"] = t.origin end
+    if t.rotation != one(SMatrix{3,3,T,9}) dict["rotation"] = Dictionary(t.rotation) end
+    OrderedDict{String, Any}("torus" => dict)
+end
+
 function surfaces(t::FullTorus{T,ClosedPrimitive}) where {T}
     tm = FullTorusMantle{T,:inwards}(t.r_torus, t.r_tube, t.φ, t.θ, t.origin, t.rotation)
     (tm, )

--- a/test/update_config_file.jl
+++ b/test/update_config_file.jl
@@ -3,7 +3,7 @@ using SolidStateDetectors.ConstructiveSolidGeometry: CSGUnion, CSGIntersection, 
         parse_r_of_primitive, parse_height_of_primitive, parse_translate_vector, parse_rotation_matrix
 using SolidStateDetectors: construct_units
 import SolidStateDetectors.ConstructiveSolidGeometry: Geometry, Dictionary
-using SolidStateDetectors.ConstructiveSolidGeometry: AbstractGeometry, TranslatedGeometry, ScaledGeometry, RotatedGeometry, 
+using SolidStateDetectors.ConstructiveSolidGeometry: AbstractGeometry,
     CSGUnion, CSGDifference, CSGIntersection, Cone, CartesianVector, HexagonalPrism
 using DataStructures: OrderedDict
 using IntervalSets
@@ -96,9 +96,9 @@ function Geometry(::Type{T}, ::Type{HexagonalPrism}, dict::AbstractDict, input_u
     r = parse_r_of_primitive(T, dict, length_unit)
     z = parse_height_of_primitive(T, dict, length_unit)
     rot = haskey(dict, "rotate") ? parse_rotation_matrix(T, dict["rotate"], u"rad") : one(RotMatrix{3,T})
-    return RotatedGeometry(HexagonalPrism(T, r, z), rot)
+    return HexagonalPrism(T, r, z, rotation = rot)
 end
-
+#=
 function Dictionary(g::RotatedGeometry{T}) where {T}
     dict = Dictionary(g.p)
     mat = RotXYZ(inv(g.inv_r))
@@ -111,7 +111,7 @@ function Dictionary(g::RotatedGeometry{T}) where {T}
     end
     OrderedDict{String,Any}("rotate" => dict)
 end
-
+=#
 
 function restructure_config_file_dict!(config_file_dict::AbstractDict, T::DataType = Float64)
 

--- a/test/update_config_file.jl
+++ b/test/update_config_file.jl
@@ -1,5 +1,5 @@
 using SolidStateDetectors.ConstructiveSolidGeometry: CSGUnion, CSGIntersection, CSGDifference,
-        internal_unit_length, internal_unit_angle, CSG_dict, geom_round,
+        internal_unit_length, internal_unit_angle, CSG_dict,
         parse_r_of_primitive, parse_height_of_primitive, parse_translate_vector, parse_rotation_matrix
 using SolidStateDetectors: construct_units
 import SolidStateDetectors.ConstructiveSolidGeometry: Geometry, Dictionary
@@ -67,7 +67,7 @@ function update_primitives!(dict::AbstractDict, input_units::NamedTuple)
     elseif "type" in dict_keys && dict["type"] in ["tube", "cone"] && "h" in dict_keys && dict["h"] != 0
         #add translate vector with z=0 if it does not exist
         if !("translate" in dict_keys) dict["translate"] = Dict{String,Any}("z" => 0) end
-        dict["translate"]["z"] = geom_round(dict["translate"]["z"] + Float64(dict["h"] / 2))
+        dict["translate"]["z"] = dict["translate"]["z"] + Float64(dict["h"] / 2)
         if dict["translate"]["z"] == 0 delete!(dict["translate"], "z") end
         if length(keys(dict["translate"])) == 0 delete!(dict, "translate") end
     end
@@ -104,7 +104,7 @@ function Dictionary(g::RotatedGeometry{T}) where {T}
     mat = RotXYZ(inv(g.inv_r))
     if mat.theta1 == 0 && mat.theta2 == 0
         if mat.theta3 != 0 
-            dict["Z"] = geom_round(HexagonalPrismAngleUnit == u"°" ? rad2deg(mat.theta3) : mat.theta3)
+            dict["Z"] = HexagonalPrismAngleUnit == u"°" ? rad2deg(mat.theta3) : mat.theta3
         end
     else
         dict["M"] = inv(g.inv_r)[:]


### PR DESCRIPTION
Following the changes in #168, the configuration conversion script had to be updated.
While testing it, I found a bug in the `Cone` read-in (90806ee) that would lead to misinterpretations of`VaryingCylinder`.

To update config files, the user has to load `<SSD>/test/update_config_file.jl` 
(which defines a function `update_config_file()`) 
and pass the filename to that function `update_config_file` to update it to v0.6.0.