### PR TITLE
Enhancement of the Refinement

### DIFF
--- a/docs/src/tutorial_lit.jl
+++ b/docs/src/tutorial_lit.jl
@@ -32,7 +32,7 @@ plot(
 # Next, calculate the electric potential:
 
 calculate_electric_potential!( simulation,
-                               max_refinements = 3)
+                               refinement_limits = [0.2, 0.1, 0.05, 0.01])
 
 plot(
     plot(simulation.electric_potential, φ = 20), # initial electric potential (boundary conditions)
@@ -63,7 +63,7 @@ simulation_undep.detector = SolidStateDetector(simulation_undep.detector, contac
 calculate_electric_potential!( simulation_undep,
                                depletion_handling = true,
                                convergence_limit=1e-6,
-                               max_refinements = 3,
+                               refinement_limits = [0.2, 0.1, 0.05, 0.01],
                                verbose = false)
 
 
@@ -141,7 +141,7 @@ plot!(event.drift_paths)
 # We need weighting potentials to simulate the detector charge signal induced by drifting charges. We'll calculate the weighting potential for the point contact and the outer shell of the detector:
 
 for contact in simulation.detector.contacts
-    calculate_weighting_potential!(simulation, contact.id, max_refinements = 3, n_points_in_φ = 2, verbose = false)
+    calculate_weighting_potential!(simulation, contact.id, refinement_limits = [0.2, 0.1, 0.05, 0.01], n_points_in_φ = 2, verbose = false)
 end
 
 plot(

--- a/examples/example_config_files/public_CGD_config.yaml
+++ b/examples/example_config_files/public_CGD_config.yaml
@@ -24,7 +24,7 @@ detectors:
   - translate: 
       x: 0
     rotate: 
-      Z: 45
+      Z: 0
     bulk:
       material: HPGe
       temperature: 78

--- a/src/PotentialSimulation/ConvergenceAndRefinement.jl
+++ b/src/PotentialSimulation/ConvergenceAndRefinement.jl
@@ -234,3 +234,10 @@ function _refine_axis(ax::DiscreteAxis{T, <:Any, <:Any, ClosedInterval{T}}, ns::
     ticks[end] = ax.ticks[end]
     typeof(ax)(ax.interval, ticks)
 end
+
+
+function _extend_refinement_limits(rl::Union{<:Real, Vector{<:Real}, Tuple{<:Real,<:Real,<:Real}, Vector{<:Tuple{<:Real, <:Real, <:Real}}})
+    0
+end
+_extend_refinement_limits(rl::Real) = (rl, rl, rl )
+_extend_refinement_limits(rl::Tuple{<:Real,<:Real,<:Real}) = rl

--- a/src/PotentialSimulation/ConvergenceAndRefinement.jl
+++ b/src/PotentialSimulation/ConvergenceAndRefinement.jl
@@ -233,6 +233,13 @@ function _create_refined_grid(p::ScalarPotential{T,3}, max_diffs::NTuple{3, T}, 
             end
         end
     end
+    for i in 1:3 # always add an even number of ticks
+        if isodd(sum(ns[i])) 
+            i_max_width = findmax(sub_widths[i])[2]
+            ns[i][i_max_width] += 1 
+            sub_widths[i][i_max_width] = widths[i][i_max_width] / (ns[i][i_max_width]+1)
+        end
+    end
     new_axes = broadcast(i -> _refine_axis(p.grid.axes[i], ns[i], sub_widths[i]), (1, 2, 3))
     return typeof(p.grid)(new_axes)
 end

--- a/src/PotentialSimulation/ConvergenceAndRefinement.jl
+++ b/src/PotentialSimulation/ConvergenceAndRefinement.jl
@@ -170,10 +170,10 @@ end
 """
     _get_closed_potential(p::ScalarPotential{T,3,CS}) where {T, CS}
 
-Returnes an closed Grid & Potential:
+Returns an closed Grid & Potential:
 E.g. if one of the axis is {:closed,:open} it will turn this into {:closed,:closed}
 and also extend the `data` field of the potential in the respective dimension and fill
-it with the respective values. 
+it with the respective values.
 """
 function _get_closed_potential(p::ScalarPotential{T,3,CS}) where {T, CS}
     g = p.grid
@@ -185,7 +185,6 @@ function _get_closed_potential(p::ScalarPotential{T,3,CS}) where {T, CS}
     closed_grid = Grid{T, 3, CS, AT}(closed_axes)
     ScalarPotential(p, closed_values, closed_grid)
 end
-
 
 """
     _convert_to_original_potential(::Type{P}, data, grid) where {P, T, CS}

--- a/src/PotentialSimulation/ConvergenceAndRefinement.jl
+++ b/src/PotentialSimulation/ConvergenceAndRefinement.jl
@@ -89,281 +89,124 @@ end
 
 
 
-function _get_refinement_inds( potential::Array{T, 3}, grid::Grid{T, 3, Cylindrical}, 
-                max_diffs::NTuple{3, T}, minimum_distances::NTuple{3, T})::NTuple{3, Vector{Int}} where {T <: SSDFloat}
-    inds_r::Vector{Int} = Int[]
-    inds_φ::Vector{Int} = Int[]
-    inds_z::Vector{Int} = Int[]
-
-    ax1::DiscreteAxis{T} = grid[1]
-    ax2::DiscreteAxis{T} = grid[2]
-    ax3::DiscreteAxis{T} = grid[3]
-    int1::Interval = ax1.interval
-    int2::Interval = ax2.interval
-    int3::Interval = ax3.interval
-
-    refinement_value_r::T = max_diffs[1]
-    refinement_value_φ::T = max_diffs[2]
-    refinement_value_z::T = max_diffs[3]
-
-    minimum_distance_r::T = minimum_distances[1]
-    minimum_distance_φ::T = minimum_distances[2]
-    minimum_distance_z::T = minimum_distances[3]
-
-    minimum_distance_φ_deg::T = rad2deg(minimum_distance_φ)
-
-    axr::Vector{T} = collect(grid.axes[1])
-    axφ::Vector{T} = collect(grid.axes[2])
-    axz::Vector{T} = collect(grid.axes[3])
-    cyclic::T = grid.axes[2].interval.right - grid.axes[2].interval.left
-
-    for iz in 1:size(potential, 3)
-        z = axz[iz]
-        for iφ in 1:size(potential, 2)
-            φ = axφ[iφ]
-            isum = iz + iφ
-            for ir in 1:size(potential, 1)
-                r = axr[ir]
-
-                # r
-                if ir != size(potential, 1)
-                    if abs(potential[ir + 1, iφ, iz] - potential[ir, iφ, iz]) >= refinement_value_r
-                        if axr[ir + 1] - axr[ir] > minimum_distance_r
-                            if !in(ir, inds_r) push!(inds_r, ir) end
-                        end
-                    end
-                end
-
-                # φ
-                if iφ == size(potential, 2)
-                    if typeof(int2).parameters[2] == :open # ugly solution for now. should be done over multiple dispatch..
-                        if abs(potential[ir, 1, iz] - potential[ir, iφ, iz]) >= refinement_value_φ
-                            if cyclic - axφ[iφ] > minimum_distance_φ
-                                if !in(iφ, inds_φ) push!(inds_φ, iφ) end
-                            end
-                        end
-                    end
-                else
-                    if abs(potential[ir, iφ + 1, iz] - potential[ir, iφ, iz]) >= refinement_value_φ
-                        if axφ[iφ + 1] - axφ[iφ] > minimum_distance_φ
-                            if !in(iφ, inds_φ) push!(inds_φ, iφ) end
-                        end
-                    end
-                end
-
-                # z
-                if iz != size(potential, 3)
-                    if abs(potential[ir, iφ, iz + 1] - potential[ir, iφ, iz]) >= refinement_value_z
-                        if axz[iz + 1] - axz[iz] > minimum_distance_z
-                            if !in(iz, inds_z) push!(inds_z, iz) end
-                        end
-                    end
-                end
-
+function refine_scalar_potential(p::ScalarPotential{T}, max_diffs::NTuple{3, T}, minimum_distances::NTuple{3, T}) where {T}
+    closed_potential = _get_closed_potential(p)
+    int = interpolate_closed_potential(closed_potential)
+    new_grid = _create_refined_grid(closed_potential, T.(max_diffs), T.(minimum_distances))
+    new_data = Array{T, 3}(undef, size(new_grid))
+    for i3 in axes(new_data, 3)
+        x3 = new_grid.axes[3].ticks[i3]
+        for i2 in axes(new_data, 2)
+            x2 = new_grid.axes[2].ticks[i2]
+            for i1 in axes(new_data, 1)
+                x1 = new_grid.axes[1].ticks[i1]
+                new_data[i1, i2, i3] = int(x1, x2, x3)
             end
         end
     end
+    return _convert_closed_potential(typeof(p), ElectricPotential(new_data, new_grid))
+end             
 
-    if typeof(int2).parameters[2] == :open
-        if isodd(length(inds_φ))
-            for iφ in 1:size(potential, 2)
-                if !in(iφ, inds_φ) 
-                    if iφ != size(potential, 2)
-                        if axφ[iφ + 1] - axφ[iφ] > minimum_distance_φ
-                            append!(inds_φ, iφ)
-                            break
-                        end
-                    else 
-                        if cyclic - axφ[iφ] > minimum_distance_φ
-                            append!(inds_φ, iφ)
-                            break
-                        end
-                    end
-                end
-            end
-        end
-        if isodd(length(inds_φ))
-            b::Bool = true
-            diffs = diff(axφ)
-            while b
-                if length(diffs) > 0
-                    idx = findmax(diffs)[2]
-                    if !in(idx, inds_φ)
-                        append!(inds_φ, idx)
-                        b = false
-                    else
-                        deleteat!(diffs, idx)
-                    end
-                else
-                    for i in eachindex(axφ)
-                        if !in(i, inds_φ) push!(inds_φ, i) end
-                    end
-                    b = false
-                end
-            end
-        end    
-        @assert iseven(length(inds_φ)) "Refinement would result in uneven grid in φ."
-    end
+interpolate_closed_potential(p::ScalarPotential) = interpolate(p.grid.axes, p.data, Gridded(Linear()))
 
-    if isodd(length(inds_z))
-        for iz in 1:size(potential, 3)
-            if !in(iz, inds_z)
-                if iz != size(potential, 3)
-                    if axz[iz + 1] - axz[iz] > minimum_distance_z
-                        append!(inds_z, iz)
-                        break
-                    end
-                end
-            end
-        end
-    end
-    if isodd(length(inds_z)) && ((length(inds_z) + 1) < length(axz))
-        b = true
-        diffs = diff(axz)
-        while b
-            if length(diffs) > 0
-                idx = findmax(diffs)[2]
-                if !in(idx, inds_z)
-                    append!(inds_z, idx)
-                    b = false
-                else
-                    deleteat!(diffs, idx)
-                end
-            else
-                for i in eachindex(axz[1:end-1])
-                    if !in(i, inds_z) push!(inds_z, i) end
-                end
-                b = false
-            end
-        end
-    end
-    if isodd(length(inds_z)) && (length(inds_z) > 1)
-        b = true
-        diffs = diff(axz)
-        while b && length(diffs) > 1
-            idx = findmin(diffs)[2]
-            if in(idx, inds_z)
-                deleteat!(inds_z, findfirst(i -> i == idx, inds_z))
-                b = false
-            else
-                deleteat!(diffs, idx)
-            end
-        end
-    end
-    if isodd(length(inds_z)) inds_z = inds_z[1:end-1] end
-    @assert iseven(length(inds_z)) "Refinement would result in uneven grid in z."
+_get_closed_ticks(ticks::Vector{T}, int::ClosedInterval{T}) where {T} = ticks
+_get_closed_ticks(ticks::Vector{T}, int::Interval{:closed, :open, T}) where {T} = vcat(ticks, [int.right])
 
-    return sort!(inds_r), sort!(inds_φ), sort!(inds_z)
+_get_closed_values(values::Array{T,3}, dim::Int, int::ClosedInterval{T}) where {T} = values
+
+function _get_closed_values(values::Array{T,3}, dim::Int, int::Interval{:closed, :open, T})::Array{T,3} where {T} 
+    if dim == 1
+        cat(values, values[1:1,:,:], dims=dim)
+    elseif dim == 2
+        cat(values, values[:,1:1,:], dims=dim)
+    else # dim == 3
+        cat(values, values[:,:,1:1], dims=dim)
+    end
 end
 
-
-function _get_refinement_inds(  potential::Array{T, 3}, grid::Grid{T, 3, Cartesian}, 
-                                max_diffs::NTuple{3, T}, minimum_distances::NTuple{3, T})::NTuple{3, Vector{Int}} where {T}
-    inds_x::Vector{Int} = Int[]
-    inds_y::Vector{Int} = Int[]
-    inds_z::Vector{Int} = Int[]
-
-    ax1::DiscreteAxis{T} = grid[1]
-    ax2::DiscreteAxis{T} = grid[2]
-    ax3::DiscreteAxis{T} = grid[3]
-    int1::Interval = ax1.interval
-    int2::Interval = ax2.interval
-    int3::Interval = ax3.interval
-
-    refinement_value_x::T = max_diffs[1]
-    refinement_value_y::T = max_diffs[2]
-    refinement_value_z::T = max_diffs[3]
-
-    minimum_distance_x::T = minimum_distances[1]
-    minimum_distance_y::T = minimum_distances[2]
-    minimum_distance_z::T = minimum_distances[3]
-
-    ax_x::Vector{T} = collect(grid.axes[1])
-    ax_y::Vector{T} = collect(grid.axes[2])
-    ax_z::Vector{T} = collect(grid.axes[3])
-
-    
-    for iz in 1:size(potential, 3)
-        z = ax_z[iz]
-        for iy in 1:size(potential, 2)
-            y = ax_y[iy]
-            isum = iz + iy
-            for ix in 1:size(potential, 1)
-                x = ax_x[ix]
-
-                # x
-                if ix != size(potential, 1)
-                    if abs(potential[ix + 1, iy, iz] - potential[ix, iy, iz]) >= refinement_value_x
-                        if ax_x[ix + 1] - ax_x[ix] > minimum_distance_x
-                            if !in(ix, inds_x) push!(inds_x, ix) end
-                        end
-                    end
-                end
-
-                # y
-                if iy != size(potential, 2)
-                    if abs(potential[ix, iy + 1, iz] - potential[ix, iy, iz]) >= refinement_value_y
-                        if ax_y[iy + 1] - ax_y[iy] > minimum_distance_y
-                            if !in(iy, inds_y) push!(inds_y, iy) end
-                        end
-                    end
-                end
-
-                # z
-                if iz != size(potential, 3)
-                    if abs(potential[ix, iy, iz + 1] - potential[ix, iy, iz]) >= refinement_value_z
-                        if ax_z[iz + 1] - ax_z[iz] > minimum_distance_z
-                            if !in(iz, inds_z) push!(inds_z, iz) end
-                        end
-                    end
-                end
-
-            end
-        end
-    end
-
-    if isodd(length(inds_x))
-        for ix in 1:size(potential, 1)
-            if !in(ix, inds_x)
-                if ix != size(potential, 1)
-                    if ax_x[ix + 1] - ax_x[ix] > minimum_distance_x
-                        append!(inds_x, ix)
-                        break
-                    end
-                end
-            end
-        end
-    end
-    if isodd(length(inds_x))
-        b = true
-        diffs = diff(ax_x)
-        while b
-            if length(diffs) > 0
-                idx = findmax(diffs)[2]
-                if !in(idx, inds_x)
-                    append!(inds_x, idx)
-                    b = false
-                else
-                    deleteat!(diffs, idx)
-                end
-            else
-                for i in eachindex(ax_x[1:end-1])
-                    if !in(i, inds_x) push!(inds_x, i) end
-                end
-                b = false
-            end
-        end
-    end
-    if isodd(length(inds_x)) inds_x = inds_x[1:end-1] end
-    @assert iseven(length(inds_x)) "Refinement would result in uneven grid in x. This is not allowed since this is the red black dimension."
-    
-
-    return sort!(inds_x), sort!(inds_y), sort!(inds_z)
+function _get_closed_axis(ax::DiscreteAxis{T, BL, BR}) where {T, BL, BR}
+    ticks = _get_closed_ticks(ax.ticks, ax.interval)
+    return DiscreteAxis{T, BL, BR, ClosedInterval{T}}(ClosedInterval(ax.interval.left, ax.interval.right), ticks)
 end
 
-function refine(p::ScalarPotential, max_diffs::Tuple{<:Real,<:Real,<:Real}, minimum_distances::Tuple{<:Real,<:Real,<:Real})::typeof(p) 
-    T = eltype(p.grid)
-    refine_at_inds = _get_refinement_inds(p.data, p.grid, T.(max_diffs), T.(minimum_distances))
-    potential, grid = add_points_and_interpolate(p.data, p.grid, refine_at_inds...)
-    return typeof(p)(potential, grid)
+"""
+    _get_closed_potential(p::ScalarPotential{T,3,CS}) where {T, CS}
+
+Returnes an closed Grid & Potential:
+E.g. if one of the axis is {:closed,:open} it will turn this into {:closed,:closed}
+and also extend the `data` field of the potential in the respective dimension and fill
+it with the respective values. 
+"""
+function _get_closed_potential(p::ScalarPotential{T,3,CS}) where {T, CS}
+    g = p.grid
+    closed_values = _get_closed_values(p.data, 1, g.axes[1].interval)
+    closed_values = _get_closed_values(closed_values, 2, g.axes[2].interval)
+    closed_values = _get_closed_values(closed_values, 3, g.axes[3].interval)
+    closed_axes = broadcast(i -> _get_closed_axis(g.axes[i]), (1, 2, 3))
+    AT = typeof(closed_axes)
+    closed_grid = Grid{T, 3, CS, AT}(closed_axes)
+    ElectricPotential{T, 3, CS, AT}(closed_values, closed_grid) 
+end
+
+"""
+    _convert_closed_potential(::Type{P}, p::ScalarPotential{T,3,CS}) where {P, T, CS}
+
+Basically the counterpart to `_get_closed_potential`.
+"""
+function _convert_closed_potential(::Type{P}, p::ScalarPotential{T,3,CS}) where {P, T, CS}
+    AT = get_axes_type(P)
+    ATs = get_axes_type(AT)
+    axs = broadcast(i -> _convert_closed_axis(ATs[i], p.grid.axes[i]), (1, 2, 3))
+    values = _reduce_closed_values(ATs, p.data)
+    P(values, Grid{T,3,CS,typeof(axs)}(axs))
+end
+
+_convert_closed_axis(::Type{DiscreteAxis{T, BL, BR, I}}, ax::DiscreteAxis{T, BL, BR, I}) where {T, BL, BR, I} = ax
+
+function _convert_closed_axis(::Type{DiscreteAxis{T, BL, BR, Interval{:closed, :open, T}}}, ax::DiscreteAxis{T, BL, BR, ClosedInterval{T}}) where {T, BL, BR, }
+    DiscreteAxis{T, BL, BR, Interval{:closed, :open, T}}(Interval{:closed, :open, T}(ax.interval.left, ax.interval.right), ax.ticks[1:end-1])
+end
+
+function _reduce_closed_values(axTypes::Tuple, a::Array{T, 3}) where {T} 
+   inds = broadcast(i -> _get_ind_range_of_closed_axis(size(a, i), axTypes[i]), (1, 2, 3))
+   a[inds...]
+end
+
+_get_ind_range_of_closed_axis(l::Int, ::Type{DiscreteAxis{T, BL, BR, ClosedInterval{T}}}) where {T, BL, BR} = 1:l
+_get_ind_range_of_closed_axis(l::Int, ::Type{DiscreteAxis{T, BL, BR, Interval{:closed, :open, T}}}) where {T, BL, BR} = 1:(l-1)
+
+
+function _create_refined_grid(p::ScalarPotential{T,3}, max_diffs::NTuple{3, T}, minimum_distances::NTuple{3, T}) where {T}
+    n_1 = Int.(floor.([maximum(abs.(p.data[i+1,:,:] .- p.data[i,:,:])) for i in 1:size(p.data, 1)-1] ./ max_diffs[1], digits=0)) 
+    n_2 = Int.(floor.([maximum(abs.(p.data[:,i+1,:] .- p.data[:,i,:])) for i in 1:size(p.data, 2)-1] ./ max_diffs[2], digits=0)) 
+    n_3 = Int.(floor.([maximum(abs.(p.data[:,:,i+1] .- p.data[:,:,i])) for i in 1:size(p.data, 3)-1] ./ max_diffs[3], digits=0)) 
+    ns = (n_1, n_2, n_3)
+    widths = diff.((p.grid.axes[1].ticks, p.grid.axes[2].ticks, p.grid.axes[3].ticks))
+    sub_widths = broadcast(ia -> [widths[ia][i] / (ns[ia][i]+1) for i in eachindex(ns[ia])], (1,2,3))
+    for ia in 1:3
+        for i in eachindex(ns[ia])
+            while sub_widths[ia][i] < minimum_distances[ia] && ns[ia][i] > 0
+                ns[ia][i] -= 1
+                sub_widths[ia][i] = widths[ia][i] / (ns[ia][i]+1)
+            end
+        end
+    end
+    new_axes = broadcast(i -> _refine_axis(p.grid.axes[i], ns[i], sub_widths[i]), (1, 2, 3))
+    return typeof(p.grid)(new_axes)
+end
+
+function _refine_axis(ax::DiscreteAxis{T, <:Any, <:Any, ClosedInterval{T}}, ns::Vector{Int}, sub_widths::Vector{T}) where {T, I}
+    @assert length(ns) == length(ax.ticks)-1 # for ClosedInterval axis
+    ticks = Vector{T}(undef, length(ax.ticks) + sum(ns))
+    i = 1 
+    for j in eachindex(ns)
+        ticks[i] = ax.ticks[j]
+        for k in 1:ns[j]
+            i += 1 
+            ticks[i] = ax.ticks[j] + k * sub_widths[j]
+        end
+        i += 1 
+    end
+    ticks[end] = ax.ticks[end]
+    typeof(ax)(ax.interval, ticks)
 end

--- a/src/PotentialSimulation/EffectiveChargeDensity.jl
+++ b/src/PotentialSimulation/EffectiveChargeDensity.jl
@@ -1,6 +1,6 @@
-struct EffectiveChargeDensity{T, N, S} <: AbstractArray{T, N}
+struct EffectiveChargeDensity{T, N, S, AT} <: AbstractArray{T, N}
     data::Array{T, N}
-    grid::Grid{T, N, S}
+    grid::Grid{T, N, S, AT}
 end
 
 @inline size(ρ::EffectiveChargeDensity{T, N, S}) where {T, N, S} = size(ρ.data)

--- a/src/PotentialSimulation/ElectricPotential.jl
+++ b/src/PotentialSimulation/ElectricPotential.jl
@@ -1,6 +1,6 @@
-struct ElectricPotential{T, N, S} <: AbstractArray{T, N}
+struct ElectricPotential{T, N, S, AT} <: AbstractArray{T, N}
     data::Array{T, N}
-    grid::Grid{T, N, S}
+    grid::Grid{T, N, S, AT}
 end
 
 @inline size(ep::ElectricPotential{T, N, S}) where {T, N, S} = size(ep.data)

--- a/src/PotentialSimulation/ScalarPotential.jl
+++ b/src/PotentialSimulation/ScalarPotential.jl
@@ -1,4 +1,8 @@
-const ScalarPotential{T, N, S} = Union{ElectricPotential{T, N, S}, WeightingPotential{T, N, S}, PointTypes{T, N, S}, EffectiveChargeDensity{T, N, S}}
+const ScalarPotential{T, N, S, AT} = Union{ElectricPotential{T, N, S, AT}, WeightingPotential{T, N, S, AT}, PointTypes{T, N, S, AT}, EffectiveChargeDensity{T, N, S, AT}}
+
+get_axes_type(p::ScalarPotential{T, N, S, AT}) where {T, N, S, AT} = AT
+get_axes_type(::Type{<:ScalarPotential{T, N, S, AT}}) where {T, N, S, AT} = AT
+get_axes_type(::Type{Tuple{AT1, AT2, AT3}}) where {AT1, AT2, AT3} = (AT1, AT2, AT3)
 
 function getindex(ep::P, g::Grid{T, N, S}) where {T, N, S, P <: ScalarPotential{T, N, S}}
     gridsize::Tuple = size(g)

--- a/src/PotentialSimulation/ScalarPotential.jl
+++ b/src/PotentialSimulation/ScalarPotential.jl
@@ -5,8 +5,6 @@ ScalarPotential(::WeightingPotential, data, grid) = WeightingPotential(data, gri
 ScalarPotential(::PointTypes, data, grid) = PointTypes(data, grid)
 ScalarPotential(::EffectiveChargeDensity, data, grid) = EffectiveChargeDensity(data, grid)
 
-get_axes_type(p::ScalarPotential{T, N, S, AT}) where {T, N, S, AT} = AT
-get_axes_type(::Type{<:ScalarPotential{T, N, S, AT}}) where {T, N, S, AT} = AT
 get_axes_type(::Type{Tuple{AT1, AT2, AT3}}) where {AT1, AT2, AT3} = (AT1, AT2, AT3)
 
 function getindex(ep::P, g::Grid{T, N, S}) where {T, N, S, P <: ScalarPotential{T, N, S}}

--- a/src/PotentialSimulation/ScalarPotential.jl
+++ b/src/PotentialSimulation/ScalarPotential.jl
@@ -1,5 +1,9 @@
 const ScalarPotential{T, N, S, AT} = Union{ElectricPotential{T, N, S, AT}, WeightingPotential{T, N, S, AT}, PointTypes{T, N, S, AT}, EffectiveChargeDensity{T, N, S, AT}}
 
+ScalarPotential(::ElectricPotential, data, grid) = ElectricPotential(data, grid)
+ScalarPotential(::WeightingPotential, data, grid) = WeightingPotential(data, grid)
+ScalarPotential(::PointTypes, data, grid) = PointTypes(data, grid)
+
 get_axes_type(p::ScalarPotential{T, N, S, AT}) where {T, N, S, AT} = AT
 get_axes_type(::Type{<:ScalarPotential{T, N, S, AT}}) where {T, N, S, AT} = AT
 get_axes_type(::Type{Tuple{AT1, AT2, AT3}}) where {AT1, AT2, AT3} = (AT1, AT2, AT3)
@@ -19,14 +23,13 @@ function getindex(ep::P, g::Grid{T, N, S}) where {T, N, S, P <: ScalarPotential{
     return P(data, g)
 end
 
-
-function get_2π_potential(sp::ScalarPotential{T, 3, Cylindrical}, axφ::DiscreteAxis{T, :periodic, :periodic}, int::Interval{:closed, :open, T}) where {T}
+function get_2π_potential(sp::ScalarPotential{T, 3, Cylindrical}, axφ::DiscreteAxis{AT, :periodic, :periodic}, int::Interval{:closed, :open, AT}) where {T, AT}
     @assert int.right != 0 "Right boundary of φ interval is not allowed to be 0"
     l::Int = length( axφ )
-    Δφ::T = int.right - int.left
-    new_int::Interval{:closed, :open, T} = Interval{:closed, :open, T}(0, 2π)
+    Δφ::AT = int.right - int.left
+    new_int::Interval{:closed, :open, AT} = Interval{:closed, :open, AT}(0, 2π)
     n::Int = Int(round(T(2π) / Δφ, sigdigits = 6))
-    new_ticks::Vector{T} = Vector{T}(undef, l * n)
+    new_ticks::Vector{AT} = Vector{AT}(undef, l * n)
     new_pot = Array{eltype(sp.data), 3}(undef, size(sp, 1), l * n, size(sp, 3))
     for idx_n in 1:n
         for il in 1:l
@@ -35,20 +38,20 @@ function get_2π_potential(sp::ScalarPotential{T, 3, Cylindrical}, axφ::Discret
             new_pot[:, idx, :] = sp[:, il, :]
         end
     end
-    new_axφ = DiscreteAxis{T, :periodic, :periodic}( new_int, new_ticks )
+    new_axφ = DiscreteAxis{AT, :periodic, :periodic}( new_int, new_ticks )
     new_axes = (sp.grid[1], new_axφ, sp.grid[3])
-    new_grid = Grid{T, 3, Cylindrical, typeof(new_axes)}( new_axes )
-    PT = nameof(typeof(sp))
-    new_sp = eval(PT)( new_pot, new_grid )
-    return new_sp
+    new_grid = Grid{AT, 3, Cylindrical, typeof(new_axes)}( new_axes )
+    ScalarPotential(sp, new_pot, new_grid)
 end
 
-function get_2π_potential(sp::ScalarPotential{T, 3, Cylindrical}, axφ::DiscreteAxis{T, :reflecting, :reflecting}, int::Interval{:closed, :closed, T}) where {T}
+
+
+function get_2π_potential(sp::ScalarPotential{T, 3, Cylindrical}, axφ::DiscreteAxis{AT, :reflecting, :reflecting}, int::Interval{:closed, :closed, AT}) where {T, AT}
     @assert int.right != 0 "Right boundary of φ interval is not allowed to be 0"
     l::Int = 2 * length( axφ ) - 2
-    Δφ::T = int.right - int.left
-    new_int::Interval{:closed, :open, T} = Interval{:closed, :open, T}(int.left, int.right + Δφ)
-    new_ticks::Vector{T} = Vector{T}(undef, l)
+    Δφ::AT = int.right - int.left
+    new_int::Interval{:closed, :open, AT} = Interval{:closed, :open, AT}(int.left, int.right + Δφ)
+    new_ticks::Vector{AT} = Vector{AT}(undef, l)
     new_ticks[1:length( axφ )] = collect(axφ.ticks)
     new_pot = Array{eltype(sp.data), 3}(undef, size(sp, 1), l, size(sp, 3))
     new_pot[:, 1:length( axφ ), :] = sp.data[:, :, :]
@@ -56,31 +59,26 @@ function get_2π_potential(sp::ScalarPotential{T, 3, Cylindrical}, axφ::Discret
         new_ticks[length(axφ) + i] = 2 * int.right - axφ.ticks[length(axφ) - i]
         new_pot[:, length(axφ) + i, :] = sp[:, length(axφ) - i, :]
     end
-    new_axφ = DiscreteAxis{T, :periodic, :periodic}( new_int, new_ticks )
+    new_axφ = DiscreteAxis{AT, :periodic, :periodic}( new_int, new_ticks )
     new_axes = (sp.grid[1], new_axφ, sp.grid[3])
-    new_grid = Grid{T, 3, Cylindrical, typeof(new_axes)}( new_axes )
-    PT = nameof(typeof(sp))
-    new_sp = eval(PT)( new_pot, new_grid )
-    return get_2π_potential(new_sp, new_axφ, new_int)
-    # return new_sp
+    new_grid = Grid{AT, 3, Cylindrical, typeof(new_axes)}( new_axes )
+    ScalarPotential(sp, new_pot, new_grid)
 end
 
-function extend_2D_to_3D_by_n_points(sp::ScalarPotential{T, 3, Cylindrical}, axφ::DiscreteAxis{T, :reflecting, :reflecting}, int::Interval{:closed, :closed, T},
-        n_points_in_φ::Int ) where {T}
-    new_int::Interval{:closed, :open, T} = Interval{:closed, :open, T}(0, 2π)
-    new_ticks::Vector{T} = Vector{T}(undef, n_points_in_φ)
+function extend_2D_to_3D_by_n_points(sp::ScalarPotential{T, 3, Cylindrical}, axφ::DiscreteAxis{AT, :reflecting, :reflecting}, int::Interval{:closed, :closed, AT},
+        n_points_in_φ::Int ) where {T, AT}
+    new_int::Interval{:closed, :open, AT} = Interval{:closed, :open, AT}(0, 2π)
+    new_ticks::Vector{AT} = Vector{AT}(undef, n_points_in_φ)
     new_pot = Array{eltype(sp.data), 3}(undef, size(sp, 1), n_points_in_φ, size(sp, 3))
-    Δφ::T = 2π / n_points_in_φ
+    Δφ::AT = 2π / n_points_in_φ
     for i in 1:n_points_in_φ
         new_ticks[i] = (i - 1) * Δφ
         new_pot[:, i, :] = sp[:, 1, :]
     end
-    new_axφ = DiscreteAxis{T, :periodic, :periodic}( new_int, new_ticks )
+    new_axφ = DiscreteAxis{AT, :periodic, :periodic}( new_int, new_ticks )
     new_axes = (sp.grid[1], new_axφ, sp.grid[3])
-    new_grid = Grid{T, 3, Cylindrical, typeof(new_axes)}( new_axes )
-    PT = nameof(typeof(sp))
-    new_sp = eval(PT)( new_pot, new_grid )
-    return new_sp
+    new_grid = Grid{AT, 3, Cylindrical, typeof(new_axes)}( new_axes )
+    ScalarPotential(sp, new_pot, new_grid)
 end
 
 function get_2π_potential(sp::ScalarPotential{T, 3, Cylindrical}; n_points_in_φ::Union{Missing, Int} = missing) where {T}

--- a/src/PotentialSimulation/ScalarPotential.jl
+++ b/src/PotentialSimulation/ScalarPotential.jl
@@ -20,78 +20,79 @@ function getindex(ep::P, g::Grid{T, N, S}) where {T, N, S, P <: ScalarPotential{
 end
 
 
-function get_2π_potential(wp::ScalarPotential{T, 3, Cylindrical}, axφ::DiscreteAxis{T, :periodic, :periodic}, int::Interval{:closed, :open, T}) where {T}
+function get_2π_potential(sp::ScalarPotential{T, 3, Cylindrical}, axφ::DiscreteAxis{T, :periodic, :periodic}, int::Interval{:closed, :open, T}) where {T}
     @assert int.right != 0 "Right boundary of φ interval is not allowed to be 0"
-    Potential::Type = typeof(wp)
     l::Int = length( axφ )
     Δφ::T = int.right - int.left
     new_int::Interval{:closed, :open, T} = Interval{:closed, :open, T}(0, 2π)
     n::Int = Int(round(T(2π) / Δφ, sigdigits = 6))
     new_ticks::Vector{T} = Vector{T}(undef, l * n)
-    new_pot::Array{T, 3} = Array{T, 3}(undef, size(wp, 1), l * n, size(wp, 3))
+    new_pot = Array{eltype(sp.data), 3}(undef, size(sp, 1), l * n, size(sp, 3))
     for idx_n in 1:n
         for il in 1:l
             idx::Int = il + (idx_n - 1) * l
             new_ticks[idx] = (idx_n - 1) * Δφ + axφ.ticks[il]
-            new_pot[:, idx, :] = wp[:, il, :]
+            new_pot[:, idx, :] = sp[:, il, :]
         end
     end
-    new_axφ::DiscreteAxis{T, :periodic, :periodic} = DiscreteAxis{T, :periodic, :periodic}( new_int, new_ticks )
-    new_grid::Grid{T, 3, Cylindrical} = Grid{T, 3, Cylindrical}( (wp.grid[1], new_axφ, wp.grid[3]) )
-    new_wp::Potential = Potential( new_pot, new_grid )
-    return new_wp
+    new_axφ = DiscreteAxis{T, :periodic, :periodic}( new_int, new_ticks )
+    new_axes = (sp.grid[1], new_axφ, sp.grid[3])
+    new_grid = Grid{T, 3, Cylindrical, typeof(new_axes)}( new_axes )
+    PT = typeof(sp).name.name
+    new_sp = eval(PT)( new_pot, new_grid )
+    return new_sp
 end
 
-function get_2π_potential(wp::ScalarPotential{T, 3, Cylindrical}, axφ::DiscreteAxis{T, :reflecting, :reflecting}, int::Interval{:closed, :closed, T}) where {T}
+function get_2π_potential(sp::ScalarPotential{T, 3, Cylindrical}, axφ::DiscreteAxis{T, :reflecting, :reflecting}, int::Interval{:closed, :closed, T}) where {T}
     @assert int.right != 0 "Right boundary of φ interval is not allowed to be 0"
-    Potential::Type = typeof(wp)
     l::Int = 2 * length( axφ ) - 2
     Δφ::T = int.right - int.left
     new_int::Interval{:closed, :open, T} = Interval{:closed, :open, T}(int.left, int.right + Δφ)
     new_ticks::Vector{T} = Vector{T}(undef, l)
     new_ticks[1:length( axφ )] = collect(axφ.ticks)
-    new_pot::Array{T, 3} = Array{T, 3}(undef, size(wp, 1), l, size(wp, 3))
-    new_pot[:, 1:length( axφ ), :] = wp.data[:, :, :]
+    new_pot = Array{eltype(sp.data), 3}(undef, size(sp, 1), l, size(sp, 3))
+    new_pot[:, 1:length( axφ ), :] = sp.data[:, :, :]
     for i in 1:(length(axφ) - 2)
         new_ticks[length(axφ) + i] = 2 * int.right - axφ.ticks[length(axφ) - i]
-        new_pot[:, length(axφ) + i, :] = wp[:, length(axφ) - i, :]
+        new_pot[:, length(axφ) + i, :] = sp[:, length(axφ) - i, :]
     end
-    new_axφ::DiscreteAxis{T, :periodic, :periodic} = DiscreteAxis{T, :periodic, :periodic}( new_int, new_ticks )
-    new_grid::Grid{T, 3, Cylindrical} = Grid{T, 3, Cylindrical}( (wp.grid[1], new_axφ, wp.grid[3]) )
-    new_wp::Potential = Potential( new_pot, new_grid )
-    return get_2π_potential(new_wp, new_axφ, new_int)
-    # return new_wp
+    new_axφ = DiscreteAxis{T, :periodic, :periodic}( new_int, new_ticks )
+    new_axes = (sp.grid[1], new_axφ, sp.grid[3])
+    new_grid = Grid{T, 3, Cylindrical, typeof(new_axes)}( new_axes )
+    PT = typeof(sp).name.name
+    new_sp = eval(PT)( new_pot, new_grid )
+    return get_2π_potential(new_sp, new_axφ, new_int)
+    # return new_sp
 end
 
-function extend_2D_to_3D_by_n_points(wp::ScalarPotential{T, 3, Cylindrical}, axφ::DiscreteAxis{T, :reflecting, :reflecting}, int::Interval{:closed, :closed, T},
+function extend_2D_to_3D_by_n_points(sp::ScalarPotential{T, 3, Cylindrical}, axφ::DiscreteAxis{T, :reflecting, :reflecting}, int::Interval{:closed, :closed, T},
         n_points_in_φ::Int ) where {T}
-    Potential::Type = typeof(wp)
     new_int::Interval{:closed, :open, T} = Interval{:closed, :open, T}(0, 2π)
     new_ticks::Vector{T} = Vector{T}(undef, n_points_in_φ)
-    new_pot::Array{eltype(wp.data), 3} = Array{eltype(wp.data), 3}(undef, size(wp, 1), n_points_in_φ, size(wp, 3))
+    new_pot = Array{eltype(sp.data), 3}(undef, size(sp, 1), n_points_in_φ, size(sp, 3))
     Δφ::T = 2π / n_points_in_φ
     for i in 1:n_points_in_φ
         new_ticks[i] = (i - 1) * Δφ
-        new_pot[:, i, :] = wp[:, 1, :]
+        new_pot[:, i, :] = sp[:, 1, :]
     end
     new_axφ = DiscreteAxis{T, :periodic, :periodic}( new_int, new_ticks )
-    new_axes = (wp.grid[1], new_axφ, wp.grid[3])
+    new_axes = (sp.grid[1], new_axφ, sp.grid[3])
     new_grid = Grid{T, 3, Cylindrical, typeof(new_axes)}( new_axes )
-    PT = typeof(wp).name.name
-    new_wp = eval(PT)( new_pot, new_grid )
-    return new_wp
+    PT = typeof(sp).name.name
+    new_sp = eval(PT)( new_pot, new_grid )
+    return new_sp
 end
 
-function get_2π_potential(wp::ScalarPotential{T, 3, Cylindrical}; n_points_in_φ::Union{Missing, Int} = missing) where {T}
-    axφ::DiscreteAxis{T} = wp.grid[2]
+function get_2π_potential(sp::ScalarPotential{T, 3, Cylindrical}; n_points_in_φ::Union{Missing, Int} = missing) where {T}
+    axφ::DiscreteAxis{T} = sp.grid[2]
     int::Interval = axφ.interval
     if int.right == 0 && length(axφ) == 1 # 2D
         if ismissing(n_points_in_φ)
             error(ArgumentError, ": First Argument is a 2D potential (only 1 point in φ). User has to set the keyword `n_points_in_φ::Int` (e.g. `n_points_in_φ = 18`) in order to get a 3D potential.")
         else
-            return extend_2D_to_3D_by_n_points(wp, axφ, int, n_points_in_φ)
+            return extend_2D_to_3D_by_n_points(sp, axφ, int, n_points_in_φ)
         end
     else
-        return get_2π_potential(wp, axφ, int)
+        return get_2π_potential(sp, axφ, int)
     end
 end

--- a/src/PotentialSimulation/ScalarPotential.jl
+++ b/src/PotentialSimulation/ScalarPotential.jl
@@ -3,6 +3,7 @@ const ScalarPotential{T, N, S, AT} = Union{ElectricPotential{T, N, S, AT}, Weigh
 ScalarPotential(::ElectricPotential, data, grid) = ElectricPotential(data, grid)
 ScalarPotential(::WeightingPotential, data, grid) = WeightingPotential(data, grid)
 ScalarPotential(::PointTypes, data, grid) = PointTypes(data, grid)
+ScalarPotential(::EffectiveChargeDensity, data, grid) = EffectiveChargeDensity(data, grid)
 
 get_axes_type(p::ScalarPotential{T, N, S, AT}) where {T, N, S, AT} = AT
 get_axes_type(::Type{<:ScalarPotential{T, N, S, AT}}) where {T, N, S, AT} = AT

--- a/src/PotentialSimulation/ScalarPotential.jl
+++ b/src/PotentialSimulation/ScalarPotential.jl
@@ -38,7 +38,7 @@ function get_2π_potential(sp::ScalarPotential{T, 3, Cylindrical}, axφ::Discret
     new_axφ = DiscreteAxis{T, :periodic, :periodic}( new_int, new_ticks )
     new_axes = (sp.grid[1], new_axφ, sp.grid[3])
     new_grid = Grid{T, 3, Cylindrical, typeof(new_axes)}( new_axes )
-    PT = typeof(sp).name.name
+    PT = nameof(typeof(sp))
     new_sp = eval(PT)( new_pot, new_grid )
     return new_sp
 end
@@ -59,7 +59,7 @@ function get_2π_potential(sp::ScalarPotential{T, 3, Cylindrical}, axφ::Discret
     new_axφ = DiscreteAxis{T, :periodic, :periodic}( new_int, new_ticks )
     new_axes = (sp.grid[1], new_axφ, sp.grid[3])
     new_grid = Grid{T, 3, Cylindrical, typeof(new_axes)}( new_axes )
-    PT = typeof(sp).name.name
+    PT = nameof(typeof(sp))
     new_sp = eval(PT)( new_pot, new_grid )
     return get_2π_potential(new_sp, new_axφ, new_int)
     # return new_sp
@@ -78,7 +78,7 @@ function extend_2D_to_3D_by_n_points(sp::ScalarPotential{T, 3, Cylindrical}, ax�
     new_axφ = DiscreteAxis{T, :periodic, :periodic}( new_int, new_ticks )
     new_axes = (sp.grid[1], new_axφ, sp.grid[3])
     new_grid = Grid{T, 3, Cylindrical, typeof(new_axes)}( new_axes )
-    PT = typeof(sp).name.name
+    PT = nameof(typeof(sp))
     new_sp = eval(PT)( new_pot, new_grid )
     return new_sp
 end

--- a/src/PotentialSimulation/ScalarPotential.jl
+++ b/src/PotentialSimulation/ScalarPotential.jl
@@ -68,15 +68,17 @@ function extend_2D_to_3D_by_n_points(wp::ScalarPotential{T, 3, Cylindrical}, ax�
     Potential::Type = typeof(wp)
     new_int::Interval{:closed, :open, T} = Interval{:closed, :open, T}(0, 2π)
     new_ticks::Vector{T} = Vector{T}(undef, n_points_in_φ)
-    new_pot::Array{T, 3} = Array{T, 3}(undef, size(wp, 1), n_points_in_φ, size(wp, 3))
+    new_pot::Array{eltype(wp.data), 3} = Array{eltype(wp.data), 3}(undef, size(wp, 1), n_points_in_φ, size(wp, 3))
     Δφ::T = 2π / n_points_in_φ
     for i in 1:n_points_in_φ
         new_ticks[i] = (i - 1) * Δφ
         new_pot[:, i, :] = wp[:, 1, :]
     end
-    new_axφ::DiscreteAxis{T, :periodic, :periodic} = DiscreteAxis{T, :periodic, :periodic}( new_int, new_ticks )
-    new_grid::Grid{T, 3, Cylindrical} = Grid{T, 3, Cylindrical}( (wp.grid[1], new_axφ, wp.grid[3]) )
-    new_wp::Potential = Potential( new_pot, new_grid )
+    new_axφ = DiscreteAxis{T, :periodic, :periodic}( new_int, new_ticks )
+    new_axes = (wp.grid[1], new_axφ, wp.grid[3])
+    new_grid = Grid{T, 3, Cylindrical, typeof(new_axes)}( new_axes )
+    PT = typeof(wp).name.name
+    new_wp = eval(PT)( new_pot, new_grid )
     return new_wp
 end
 

--- a/src/PotentialSimulation/WeightingPotential.jl
+++ b/src/PotentialSimulation/WeightingPotential.jl
@@ -1,6 +1,6 @@
-struct WeightingPotential{T, N, S <: AbstractCoordinateSystem} <: AbstractArray{T, N}
+struct WeightingPotential{T, N, S <: AbstractCoordinateSystem, AT} <: AbstractArray{T, N}
     data::Array{T, N}
-    grid::Grid{T, N, S}
+    grid::Grid{T, N, S, AT}
 end
 
 @inline size(wp::WeightingPotential{T, N, S}) where {T, N, S} = size(wp.data)

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -672,7 +672,7 @@ function _calculate_potential!( sim::Simulation{T, CS}, potential_type::UnionAll
             ref_limits = T.(_extend_refinement_limits(refinement_limits[iref]))
             if isEP
                 max_diffs = abs.(ref_limits .* bias_voltage)
-                sim.electric_potential = refine_scalar_potential(sim.electric_potential, max_diffs, min_grid_spacing)
+                sim.electric_potential = refine_scalar_potential(sim.electric_potential, max_diffs, min_grid_spacing, only2d = Val(only_2d))
                 update_till_convergence!( sim, potential_type, convergence_limit,
                 n_iterations_between_checks = n_iterations_between_checks,
                 max_n_iterations = max_n_iterations,
@@ -681,7 +681,7 @@ function _calculate_potential!( sim::Simulation{T, CS}, potential_type::UnionAll
                 sor_consts = sor_consts )
             else
                 max_diffs = abs.(ref_limits)
-                sim.weighting_potentials[contact_id] = refine_scalar_potential(sim.weighting_potentials[contact_id], max_diffs, min_grid_spacing)
+                sim.weighting_potentials[contact_id] = refine_scalar_potential(sim.weighting_potentials[contact_id], max_diffs, min_grid_spacing, only2d = Val(only_2d))
                 update_till_convergence!( sim, potential_type, contact_id, convergence_limit,
                                     n_iterations_between_checks = n_iterations_between_checks,
                                     max_n_iterations = max_n_iterations,
@@ -839,7 +839,7 @@ end
 ToDo...
 """
 function simulate!( sim::Simulation{T};  
-                    refinement_limits = [0.2, 0.1, 0.05],
+                    refinement_limits = [0.2, 0.1, 0.05 ],
                     verbose::Bool = false,
                     depletion_handling::Bool = false, 
                     convergence_limit::Real = 1e-7 ) where {T <: SSDFloat}

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -709,12 +709,12 @@ There are serveral `<keyword arguments>` which can be used to tune the computati
 - `convergence_limit::Real`: `convergence_limit` times the bias voltage sets the convergence limit of the relaxation.
     The convergence value is the absolute maximum difference of the potential between two iterations of all grid points.
     Default of `convergence_limit` is `2e-6` (times bias voltage).
-- `max_refinements::Int`: Number of maximum refinements. Default is `2`. Set it to `0` to switch off refinement.
-- `refinement_limits::Tuple{<:Real, <:Real, <:Real}`: Tuple of refinement limits for each dimension
-    (in case of cylindrical coordinates the order is `r`, `φ`, `z`).
-    A refinement limit (e.g. `refinement_limits[1]`) times the bias voltage of the detector `det` is the
-    maximum allowed voltage difference between two neighbouring grid points in the respective dimension.
-    When the difference is larger, new points are created inbetween. Default is `[1e-5, 1e-5, 1e-5]`.
+- `refinement_limits: Defines the maximum relative (to applied bias voltage) allowed differences of the potential value of neighboured grid points
+    in each dimension for each refinement.
+        * l::Real -> One refinement with `l` equal in all 3 dimensions
+        * l::Tuple{<:Real,<:Real,<:Real} -> One refinement with `l` set individual for each dimension
+        * l::Vector{<:Real} -> `length(l)` refinements with `l[i]` being the limit for the i-th refinement. 
+        * l::Vector{<:Real,<:Real,<:Real}} `length(l)` refinements with `l[i]` being the limits for the i-th refinement.
 - `min_grid_spacing::Tuple{<:Real, <:Real, <:Real}`: Tuple of the mimimum allowed distance between two grid points for each dimension.
     For normal coordinates the unit is meter. For angular coordinates, the unit is radiance.
     It prevents the refinement to make the grid to fine. Default is [`1e-6`, `1e-6`, `1e-6`].
@@ -750,12 +750,12 @@ There are serveral `<keyword arguments>` which can be used to tune the computati
 - `convergence_limit::Real`: `convergence_limit` times the bias voltage sets the convergence limit of the relaxation.
     The convergence value is the absolute maximum difference of the potential between two iterations of all grid points.
     Default of `convergence_limit` is `2e-6` (times bias voltage).
-- `max_refinements::Int`: Number of maximum refinements. Default is `2`. Set it to `0` to switch off refinement.
-- `refinement_limits::Tuple{<:Real, <:Real, <:Real}`: Tuple of refinement limits for each dimension
-    (in case of cylindrical coordinates the order is `r`, `φ`, `z`).
-    A refinement limit (e.g. `refinement_limits[1]`) times the bias voltage of the detector `det` is the
-    maximum allowed voltage difference between two neighbouring grid points in the respective dimension.
-    When the difference is larger, new points are created inbetween. Default is `[1e-5, 1e-5, 1e-5]`.
+- `refinement_limits: Defines the maximum relative (to applied bias voltage) allowed differences of the potential value of neighboured grid points
+    in each dimension for each refinement.
+        * l::Real -> One refinement with `l` equal in all 3 dimensions
+        * l::Tuple{<:Real,<:Real,<:Real} -> One refinement with `l` set individual for each dimension
+        * l::Vector{<:Real} -> `length(l)` refinements with `l[i]` being the limit for the i-th refinement. 
+        * l::Vector{<:Real,<:Real,<:Real}} `length(l)` refinements with `l[i]` being the limits for the i-th refinement.
 - `grid::Grid{T, N, S}`: Initial grid used to start the simulation. Default is `Grid(sim)`.
 - `depletion_handling::Bool`: Enables the handling of undepleted regions. Default is false.
 - `use_nthreads::Int`: Number of threads to use in the computation. Default is `Base.Threads.nthreads()`.
@@ -834,8 +834,12 @@ function get_signal(sim::Simulation{T, CS}, drift_paths::Vector{EHDriftPath{T}},
 end
 
 """
-    function simulate!(sim::Simulation{T};  max_refinements::Int = 1, verbose::Bool = false,
-                                        depletion_handling::Bool = false, convergence_limit::Real = 1e-5 ) where {T <: SSDFloat}
+    function simulate!(sim::Simulation{T};  refinement_limits = [0.2, 0.1, 0.05],
+                            max_tick_distance::Union{Missing, length_unit, Tuple{length_unit, angle_unit, length_unit}} = missing,
+                            max_distance_ratio::Real = 5,
+                            verbose::Bool = false,
+                            depletion_handling::Bool = false, 
+                            convergence_limit::Real = 1e-5 ) where {T <: SSDFloat}
 
 ToDo...
 """

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -737,17 +737,19 @@ There are several `<keyword arguments>` which can be used to tune the computatio
 - `convergence_limit::Real`: `convergence_limit` times the bias voltage sets the convergence limit of the relaxation.
     The convergence value is the absolute maximum difference of the potential between two iterations of all grid points.
     Default of `convergence_limit` is `2e-6` (times bias voltage).
-- refinement_limits `rl`: Defines the maximum relative (to applied bias voltage) allowed differences 
+- `refinement_limits`: Defines the maximum relative (to applied bias voltage) allowed differences 
     of the potential value of neighbored grid points 
     in each dimension for each refinement.
-    - rl::Real -> One refinement with `rl` equal in all 3 dimensions
-    - rl::Tuple{<:Real,<:Real,<:Real} -> One refinement with `rl` set individual for each dimension
-    - rl::Vector{<:Real} -> `length(l)` refinements with `rl[i]` being the limit for the i-th refinement. 
-    - rl::Vector{<:Real,<:Real,<:Real}} -> `length(rl)` refinements with `rl[i]` being the limits for the i-th refinement.
+    - `rl::Real` -> One refinement with `rl` equal in all 3 dimensions
+    - `rl::Tuple{<:Real,<:Real,<:Real}` -> One refinement with `rl` set individual for each dimension
+    - `rl::Vector{<:Real}` -> `length(l)` refinements with `rl[i]` being the limit for the i-th refinement. 
+    - `rl::Vector{<:Real,<:Real,<:Real}}` -> `length(rl)` refinements with `rl[i]` being the limits for the i-th refinement.
 - `min_tick_distance::Tuple{<:Quantity, <:Quantity, <:Quantity}`: Tuple of the minimum allowed distance between 
     two grid ticks for each dimension. It prevents the refinement to make the grid to fine.
+    Default is 1e-5 for linear axes and `0.25 * r_max` for the polar axis in case of a cylindrical grid.
 - `max_tick_distance::Tuple{<:Quantity, <:Quantity, <:Quantity}`: Tuple of the maximum allowed distance between 
     two grid ticks for each dimension used in the initialization of the grid.
+    Default is 1/4 of size of the world of the respective dimension.
 - `grid::Grid`: Initial grid used to start the simulation. Default is `Grid(sim)`.
 - `max_distance_ratio::Real`: Maximum allowed ratio between the two distances in any dimension to the two neighbouring grid points. 
         If the ratio is too large, additional ticks are generated such that the new ratios are smaller than `max_distance_ratio`.
@@ -783,17 +785,19 @@ There are several `<keyword arguments>` which can be used to tune the computatio
 - `convergence_limit::Real`: `convergence_limit` times the bias voltage sets the convergence limit of the relaxation.
     The convergence value is the absolute maximum difference of the potential between two iterations of all grid points.
     Default of `convergence_limit` is `2e-6` (times bias voltage).
-- `refinement_limits: Defines the maximum relative (to applied bias voltage) allowed differences 
+- `refinement_limits`: Defines the maximum relative (to applied bias voltage) allowed differences 
     of the potential value of neighbored grid points 
     in each dimension for each refinement.
-    - rl::Real -> One refinement with `rl` equal in all 3 dimensions
-    - rl::Tuple{<:Real,<:Real,<:Real} -> One refinement with `rl` set individual for each dimension
-    - rl::Vector{<:Real} -> `length(l)` refinements with `rl[i]` being the limit for the i-th refinement. 
-    - rl::Vector{<:Real,<:Real,<:Real}} -> `length(rl)` refinements with `rl[i]` being the limits for the i-th refinement.
+    - `rl::Real` -> One refinement with `rl` equal in all 3 dimensions
+    - `rl::Tuple{<:Real,<:Real,<:Real}` -> One refinement with `rl` set individual for each dimension
+    - `rl::Vector{<:Real}` -> `length(l)` refinements with `rl[i]` being the limit for the i-th refinement. 
+    - `rl::Vector{<:Real,<:Real,<:Real}}` -> `length(rl)` refinements with `rl[i]` being the limits for the i-th refinement.
 - `min_tick_distance::Tuple{<:Quantity, <:Quantity, <:Quantity}`: Tuple of the minimum allowed distance between 
     two grid ticks for each dimension. It prevents the refinement to make the grid to fine.
+    Default is 1e-5 for linear axes and `0.25 * r_max` for the polar axis in case of a cylindrical grid.
 - `max_tick_distance::Tuple{<:Quantity, <:Quantity, <:Quantity}`: Tuple of the maximum allowed distance between 
     two grid ticks for each dimension used in the initialization of the grid.
+    Default is 1/4 of size of the world of the respective dimension.
 - `grid::Grid`: Initial grid used to start the simulation. Default is `Grid(sim)`.
 - `max_distance_ratio::Real`: Maximum allowed ratio between the two distances in any dimension to the two neighbouring grid points. 
         If the ratio is too large, additional ticks are generated such that the new ratios are smaller than `max_distance_ratio`.
@@ -875,14 +879,50 @@ function get_signal(sim::Simulation{T, CS}, drift_paths::Vector{EHDriftPath{T}},
 end
 
 """
-    function simulate!(sim::Simulation{T};  refinement_limits = [0.2, 0.1, 0.05],
-                            max_tick_distance::Union{Missing, length_unit, Tuple{length_unit, angle_unit, length_unit}} = missing,
-                            max_distance_ratio::Real = 5,
-                            verbose::Bool = false,
-                            depletion_handling::Bool = false, 
-                            convergence_limit::Real = 1e-5 ) where {T <: SSDFloat}
+    function simulate!( sim::Simulation{T};  
+                    refinement_limits = [0.2, 0.1, 0.05],
+                    min_tick_distance::Union{Missing, length_unit, Tuple{length_unit, angle_unit, length_unit}} = missing,
+                    max_tick_distance::Union{Missing, length_unit, Tuple{length_unit, angle_unit, length_unit}} = missing,
+                    max_distance_ratio::Real = 5,
+                    verbose::Bool = false,
+                    use_nthreads::Int = Base.Threads.nthreads(),
+                    sor_consts::Union{Missing, <:Real, Tuple{<:Real,<:Real}} = missing,
+                    max_n_iterations::Int = -1,
+                    depletion_handling::Bool = false, 
+                    convergence_limit::Real = 1e-7 ) where {T <: SSDFloat}
 
-ToDo...
+# Keywords
+- `convergence_limit::Real`: `convergence_limit` times the bias voltage sets the convergence limit of the relaxation.
+    The convergence value is the absolute maximum difference of the potential between two iterations of all grid points.
+    Default of `convergence_limit` is `2e-6` (times bias voltage).
+- `refinement_limits`: Defines the maximum relative (to applied bias voltage) allowed differences 
+    of the potential value of neighbored grid points 
+    in each dimension for each refinement.
+    - `rl::Real` -> One refinement with `rl` equal in all 3 dimensions
+    - `rl::Tuple{<:Real,<:Real,<:Real}` -> One refinement with `rl` set individual for each dimension
+    - `rl::Vector{<:Real}` -> `length(l)` refinements with `rl[i]` being the limit for the i-th refinement. 
+    - `rl::Vector{<:Real,<:Real,<:Real}}` -> `length(rl)` refinements with `rl[i]` being the limits for the i-th refinement.
+- `min_tick_distance::Tuple{<:Quantity, <:Quantity, <:Quantity}`: Tuple of the minimum allowed distance between 
+    two grid ticks for each dimension. It prevents the refinement to make the grid to fine.
+    Default is 1e-5 for linear axes and `0.25 * r_max` for the polar axis in case of a cylindrical grid.
+- `max_tick_distance::Tuple{<:Quantity, <:Quantity, <:Quantity}`: Tuple of the maximum allowed distance between 
+    two grid ticks for each dimension used in the initialization of the grid.
+    Default is 1/4 of size of the world of the respective dimension.
+- `max_distance_ratio::Real`: Maximum allowed ratio between the two distances in any dimension to the two neighbouring grid points. 
+        If the ratio is too large, additional ticks are generated such that the new ratios are smaller than `max_distance_ratio`.
+        Default is `5`.
+- `depletion_handling::Bool`: Enables the handling of undepleted regions. Default is false.
+- `use_nthreads::Int`: Number of threads to use in the computation. Default is `Base.Threads.nthreads()`.
+    The environment variable `JULIA_NUM_THREADS` must be set appropriately before the Julia session was
+    started (e.g. `export JULIA_NUM_THREADS=8` in case of bash).
+- `sor_consts::Union{<:Real, NTuple{2, <:Real}}`: Two element tuple in case of cylindrical coordinates.
+    First element contains the SOR constant for `r` = 0.
+    Second contains the constant at the outer most grid point in `r`. A linear scaling is applied in between.
+    First element should be smaller than the second one and both should be ∈ [1.0, 2.0]. Default is [1.4, 1.85].
+    In case of cartesian coordinates only one value is taken.
+- `max_n_iterations::Int`: Set the maximum number of iterations which are performed after each grid refinement.
+    Default is `-1`. If set to `-1` there will be no limit.
+- `verbose::Bool=true`: Boolean whether info output is produced or not.
 """
 function simulate!( sim::Simulation{T};  
                     refinement_limits = [0.2, 0.1, 0.05],
@@ -890,6 +930,9 @@ function simulate!( sim::Simulation{T};
                     max_tick_distance::Union{Missing, length_unit, Tuple{length_unit, angle_unit, length_unit}} = missing,
                     max_distance_ratio::Real = 5,
                     verbose::Bool = false,
+                    use_nthreads::Int = Base.Threads.nthreads(),
+                    sor_consts::Union{Missing, <:Real, Tuple{<:Real,<:Real}} = missing,
+                    max_n_iterations::Int = -1,
                     depletion_handling::Bool = false, 
                     convergence_limit::Real = 1e-7 ) where {T <: SSDFloat}
     calculate_electric_potential!(  sim,
@@ -897,6 +940,9 @@ function simulate!( sim::Simulation{T};
                                     min_tick_distance = min_tick_distance,
                                     max_tick_distance = max_tick_distance,
                                     max_distance_ratio = max_distance_ratio,
+                                    use_nthreads = use_nthreads,
+                                    sor_consts = sor_consts,
+                                    max_n_iterations = max_n_iterations,
                                     verbose = verbose,
                                     depletion_handling = depletion_handling,
                                     convergence_limit = convergence_limit )

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -947,11 +947,16 @@ function simulate!( sim::Simulation{T};
                                     depletion_handling = depletion_handling,
                                     convergence_limit = convergence_limit )
     for contact in sim.detector.contacts
-        calculate_weighting_potential!(sim, contact.id, refinement_limits = refinement_limits,
+        calculate_weighting_potential!(sim, contact.id, 
+                    refinement_limits = refinement_limits,
                     min_tick_distance = min_tick_distance,
                     max_tick_distance = max_tick_distance,
                     max_distance_ratio = max_distance_ratio,
-                    verbose = verbose, convergence_limit = convergence_limit)
+                    use_nthreads = use_nthreads,
+                    sor_consts = sor_consts,
+                    max_n_iterations = max_n_iterations,
+                    verbose = verbose, 
+                    convergence_limit = convergence_limit)
     end
     calculate_electric_field!(sim)
     calculate_drift_fields!(sim)

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -592,6 +592,7 @@ function _calculate_potential!( sim::Simulation{T, CS}, potential_type::UnionAll
         use_nthreads::Int = Base.Threads.nthreads(),
         sor_consts::Union{Missing, <:Real, Tuple{<:Real,<:Real}} = missing,
         max_n_iterations::Int = 50000,
+        n_iterations_between_checks::Int = 1000,
         verbose::Bool = true,
     )::Nothing where {T <: SSDFloat, CS <: AbstractCoordinateSystem}
 
@@ -638,8 +639,6 @@ function _calculate_potential!( sim::Simulation{T, CS}, potential_type::UnionAll
                 (T(1e-5), T(1e-5), T(1e-5))
             end
         end
-
-        n_iterations_between_checks::Int = 1000
         if use_nthreads > Base.Threads.nthreads()
             use_nthreads = Base.Threads.nthreads();
             @warn "`use_nthreads` was set to `1`. The environment variable `JULIA_NUM_THREADS` must be set appropriately before the julia session is started."

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -728,26 +728,26 @@ end
 Compute the weighting potential for the contact with id `contact_id`
 for the given Simulation `sim` on an adaptive grid through successive over relaxation.
 
-There are serveral `<keyword arguments>` which can be used to tune the computation:
+There are several `<keyword arguments>` which can be used to tune the computation:
 
 # Keywords
 - `convergence_limit::Real`: `convergence_limit` times the bias voltage sets the convergence limit of the relaxation.
     The convergence value is the absolute maximum difference of the potential between two iterations of all grid points.
     Default of `convergence_limit` is `2e-6` (times bias voltage).
 - refinement_limits `rl`: Defines the maximum relative (to applied bias voltage) allowed differences 
-    of the potential value of neighboured grid points 
+    of the potential value of neighbored grid points 
     in each dimension for each refinement.
-    - `rl::Real` -> One refinement with `l` equal in all 3 dimensions
-    - `rl::Tuple{<:Real,<:Real,<:Real}`` -> One refinement with `l` set individual for each dimension
-    - `rl::Vector{<:Real}`` -> `length(l)` refinements with `l[i]` being the limit for the i-th refinement. 
-    - `rl::Vector{<:Real,<:Real,<:Real}}`` -> `length(l)` refinements with `l[i]` being the limits for the i-th refinement.
-- `min_tick_distance::Tuple{<:Quantity, <:Quantity, <:Quantity}`: Tuple of the mimimum allowed distance between 
+    - rl::Real -> One refinement with `rl` equal in all 3 dimensions
+    - rl::Tuple{<:Real,<:Real,<:Real} -> One refinement with `rl` set individual for each dimension
+    - rl::Vector{<:Real} -> `length(l)` refinements with `rl[i]` being the limit for the i-th refinement. 
+    - rl::Vector{<:Real,<:Real,<:Real}} -> `length(rl)` refinements with `rl[i]` being the limits for the i-th refinement.
+- `min_tick_distance::Tuple{<:Quantity, <:Quantity, <:Quantity}`: Tuple of the minimum allowed distance between 
     two grid ticks for each dimension. It prevents the refinement to make the grid to fine.
 - `max_tick_distance::Tuple{<:Quantity, <:Quantity, <:Quantity}`: Tuple of the maximum allowed distance between 
     two grid ticks for each dimension used in the initialization of the grid.
 - `grid::Grid`: Initial grid used to start the simulation. Default is `Grid(sim)`.
-- `max_distance_ratio::Real`: Maxium allowed ratio between the two distances in any dimension to the two neighbouring grid points. 
-        If the ratio is to large, additional ticks are generated such that the new ratios are smaler than `max_distance_ratio`.
+- `max_distance_ratio::Real`: Maximum allowed ratio between the two distances in any dimension to the two neighbouring grid points. 
+        If the ratio is too large, additional ticks are generated such that the new ratios are smaller than `max_distance_ratio`.
         Default is `5`.
 - `depletion_handling::Bool`: Enables the handling of undepleted regions. Default is false.
 - `use_nthreads::Int`: Number of threads to use in the computation. Default is `Base.Threads.nthreads()`.
@@ -774,26 +774,26 @@ end
 Compute the electric potential for the given Simulation `sim` on an adaptive grid
 through successive over relaxation.
 
-There are serveral `<keyword arguments>` which can be used to tune the computation:
+There are several `<keyword arguments>` which can be used to tune the computation:
 
 # Keywords
 - `convergence_limit::Real`: `convergence_limit` times the bias voltage sets the convergence limit of the relaxation.
     The convergence value is the absolute maximum difference of the potential between two iterations of all grid points.
     Default of `convergence_limit` is `2e-6` (times bias voltage).
 - `refinement_limits: Defines the maximum relative (to applied bias voltage) allowed differences 
-    of the potential value of neighboured grid points 
+    of the potential value of neighbored grid points 
     in each dimension for each refinement.
-    - rl::Real -> One refinement with `l` equal in all 3 dimensions
-    - rl::Tuple{<:Real,<:Real,<:Real} -> One refinement with `l` set individual for each dimension
-    - rl::Vector{<:Real} -> `length(l)` refinements with `l[i]` being the limit for the i-th refinement. 
-    - rl::Vector{<:Real,<:Real,<:Real}} -> `length(l)` refinements with `l[i]` being the limits for the i-th refinement.
-- `min_tick_distance::Tuple{<:Quantity, <:Quantity, <:Quantity}`: Tuple of the mimimum allowed distance between 
+    - rl::Real -> One refinement with `rl` equal in all 3 dimensions
+    - rl::Tuple{<:Real,<:Real,<:Real} -> One refinement with `rl` set individual for each dimension
+    - rl::Vector{<:Real} -> `length(l)` refinements with `rl[i]` being the limit for the i-th refinement. 
+    - rl::Vector{<:Real,<:Real,<:Real}} -> `length(rl)` refinements with `rl[i]` being the limits for the i-th refinement.
+- `min_tick_distance::Tuple{<:Quantity, <:Quantity, <:Quantity}`: Tuple of the minimum allowed distance between 
     two grid ticks for each dimension. It prevents the refinement to make the grid to fine.
 - `max_tick_distance::Tuple{<:Quantity, <:Quantity, <:Quantity}`: Tuple of the maximum allowed distance between 
     two grid ticks for each dimension used in the initialization of the grid.
 - `grid::Grid`: Initial grid used to start the simulation. Default is `Grid(sim)`.
-- `max_distance_ratio::Real`: Maxium allowed ratio between the two distances in any dimension to the two neighbouring grid points. 
-        If the ratio is to large, additional ticks are generated such that the new ratios are smaler than `max_distance_ratio`.
+- `max_distance_ratio::Real`: Maximum allowed ratio between the two distances in any dimension to the two neighbouring grid points. 
+        If the ratio is too large, additional ticks are generated such that the new ratios are smaller than `max_distance_ratio`.
         Default is `5`.
 - `depletion_handling::Bool`: Enables the handling of undepleted regions. Default is false.
 - `use_nthreads::Int`: Number of threads to use in the computation. Default is `Base.Threads.nthreads()`.

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -734,16 +734,21 @@ There are serveral `<keyword arguments>` which can be used to tune the computati
 - `convergence_limit::Real`: `convergence_limit` times the bias voltage sets the convergence limit of the relaxation.
     The convergence value is the absolute maximum difference of the potential between two iterations of all grid points.
     Default of `convergence_limit` is `2e-6` (times bias voltage).
-- `refinement_limits: Defines the maximum relative (to applied bias voltage) allowed differences of the potential value of neighboured grid points
+- refinement_limits `rl`: Defines the maximum relative (to applied bias voltage) allowed differences 
+    of the potential value of neighboured grid points 
     in each dimension for each refinement.
-        * l::Real -> One refinement with `l` equal in all 3 dimensions
-        * l::Tuple{<:Real,<:Real,<:Real} -> One refinement with `l` set individual for each dimension
-        * l::Vector{<:Real} -> `length(l)` refinements with `l[i]` being the limit for the i-th refinement. 
-        * l::Vector{<:Real,<:Real,<:Real}} `length(l)` refinements with `l[i]` being the limits for the i-th refinement.
-- `min_tick_distance::Tuple{<:Real, <:Real, <:Real}`: Tuple of the mimimum allowed distance between two grid points for each dimension.
-    For normal coordinates the unit is meter. For angular coordinates, the unit is radiance.
-    It prevents the refinement to make the grid to fine. Default is [`1e-6`, `1e-6`, `1e-6`].
-- `grid::Grid{T, N, S}`: Initial grid used to start the simulation. Default is `Grid(sim)`.
+    - `rl::Real` -> One refinement with `l` equal in all 3 dimensions
+    - `rl::Tuple{<:Real,<:Real,<:Real}`` -> One refinement with `l` set individual for each dimension
+    - `rl::Vector{<:Real}`` -> `length(l)` refinements with `l[i]` being the limit for the i-th refinement. 
+    - `rl::Vector{<:Real,<:Real,<:Real}}`` `length(l)` refinements with `l[i]` being the limits for the i-th refinement.
+- `min_tick_distance::Tuple{<:Quantity, <:Quantity, <:Quantity}`: Tuple of the mimimum allowed distance between 
+    two grid ticks for each dimension. It prevents the refinement to make the grid to fine.
+- `max_tick_distance::Tuple{<:Quantity, <:Quantity, <:Quantity}`: Tuple of the maximum allowed distance between 
+    two grid ticks for each dimension used in the initialization of the grid.
+- `grid::Grid`: Initial grid used to start the simulation. Default is `Grid(sim)`.
+- `max_distance_ratio::Real`: Maxium allowed ratio between the two distances in any dimension to the two neighbouring grid points. 
+        If the ratio is to large, additional ticks are generated such that the new ratios are smaler than `max_distance_ratio`.
+        Default is `5`.
 - `depletion_handling::Bool`: Enables the handling of undepleted regions. Default is false.
 - `use_nthreads::Int`: Number of threads to use in the computation. Default is `Base.Threads.nthreads()`.
     The environment variable `JULIA_NUM_THREADS` must be set appropriately before the Julia session was
@@ -775,13 +780,21 @@ There are serveral `<keyword arguments>` which can be used to tune the computati
 - `convergence_limit::Real`: `convergence_limit` times the bias voltage sets the convergence limit of the relaxation.
     The convergence value is the absolute maximum difference of the potential between two iterations of all grid points.
     Default of `convergence_limit` is `2e-6` (times bias voltage).
-- `refinement_limits: Defines the maximum relative (to applied bias voltage) allowed differences of the potential value of neighboured grid points
+- `refinement_limits: Defines the maximum relative (to applied bias voltage) allowed differences 
+    of the potential value of neighboured grid points 
     in each dimension for each refinement.
-        * l::Real -> One refinement with `l` equal in all 3 dimensions
-        * l::Tuple{<:Real,<:Real,<:Real} -> One refinement with `l` set individual for each dimension
-        * l::Vector{<:Real} -> `length(l)` refinements with `l[i]` being the limit for the i-th refinement. 
-        * l::Vector{<:Real,<:Real,<:Real}} `length(l)` refinements with `l[i]` being the limits for the i-th refinement.
-- `grid::Grid{T, N, S}`: Initial grid used to start the simulation. Default is `Grid(sim)`.
+    - rl::Real -> One refinement with `l` equal in all 3 dimensions
+    - rl::Tuple{<:Real,<:Real,<:Real} -> One refinement with `l` set individual for each dimension
+    - rl::Vector{<:Real} -> `length(l)` refinements with `l[i]` being the limit for the i-th refinement. 
+    - rl::Vector{<:Real,<:Real,<:Real}} `length(l)` refinements with `l[i]` being the limits for the i-th refinement.
+- `min_tick_distance::Tuple{<:Quantity, <:Quantity, <:Quantity}`: Tuple of the mimimum allowed distance between 
+    two grid ticks for each dimension. It prevents the refinement to make the grid to fine.
+- `max_tick_distance::Tuple{<:Quantity, <:Quantity, <:Quantity}`: Tuple of the maximum allowed distance between 
+    two grid ticks for each dimension used in the initialization of the grid.
+- `grid::Grid`: Initial grid used to start the simulation. Default is `Grid(sim)`.
+- `max_distance_ratio::Real`: Maxium allowed ratio between the two distances in any dimension to the two neighbouring grid points. 
+        If the ratio is to large, additional ticks are generated such that the new ratios are smaler than `max_distance_ratio`.
+        Default is `5`.
 - `depletion_handling::Bool`: Enables the handling of undepleted regions. Default is false.
 - `use_nthreads::Int`: Number of threads to use in the computation. Default is `Base.Threads.nthreads()`.
     The environment variable `JULIA_NUM_THREADS` must be set appropriately before the Julia session was

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -197,7 +197,7 @@ function Grid(  sim::Simulation{T, Cylindrical};
     max_distance_φ = T(world_Δφ / 4)
     max_distance_r = T(world_Δr / 4)
     if !ismissing(max_tick_distance)
-        if max_tick_distance isa Quantity{<:Real, Unitful.𝐋}
+        if max_tick_distance isa length_unit
             max_distance_z = max_distance_r = T(to_internal_units(internal_length_unit, max_tick_distance))
             max_distance_φ = max_distance_z / world_r_mid
         else #if max_tick_distance isa Tuple{length_unit, angle_unit, length_unit}
@@ -313,7 +313,7 @@ function Grid(  sim::Simulation{T, Cartesian};
     min_max_distance = min(max_distance_x, max_distance_y, max_distance_z)
     max_distance_x = max_distance_y = max_distance_z = min_max_distance
     if !ismissing(max_tick_distance)
-        if max_tick_distance isa Quantity{<:Real, Unitful.𝐋}
+        if max_tick_distance isa length_unit
             max_distance_x = max_distance_y = max_distance_z = 
                 T(to_internal_units(internal_length_unit, max_tick_distance))
         else
@@ -613,7 +613,7 @@ function _calculate_potential!( sim::Simulation{T, CS}, potential_type::UnionAll
         end
         min_tick_distance::NTuple{3, T} = if CS == Cylindrical
             if !ismissing(min_tick_distance)
-                if min_tick_distance isa Quantity{<:Real, Unitful.𝐋}
+                if min_tick_distance isa length_unit
                     world_r_mid = (sim.world.intervals[1].right + sim.world.intervals[1].left)/2
                     min_distance_z = min_distance_r = T(to_internal_units(internal_length_unit, min_tick_distance))
                     min_distance_r, min_distance_z / world_r_mid, min_distance_z
@@ -627,7 +627,7 @@ function _calculate_potential!( sim::Simulation{T, CS}, potential_type::UnionAll
             end
         else
             if !ismissing(min_tick_distance)
-                if min_tick_distance isa Quantity{<:Real, Unitful.𝐋}
+                if min_tick_distance isa length_unit
                     min_distance = T(to_internal_units(internal_length_unit, min_tick_distance))
                     min_distance, min_distance, min_distance
                 else
@@ -740,7 +740,7 @@ There are serveral `<keyword arguments>` which can be used to tune the computati
     - `rl::Real` -> One refinement with `l` equal in all 3 dimensions
     - `rl::Tuple{<:Real,<:Real,<:Real}`` -> One refinement with `l` set individual for each dimension
     - `rl::Vector{<:Real}`` -> `length(l)` refinements with `l[i]` being the limit for the i-th refinement. 
-    - `rl::Vector{<:Real,<:Real,<:Real}}`` `length(l)` refinements with `l[i]` being the limits for the i-th refinement.
+    - `rl::Vector{<:Real,<:Real,<:Real}}`` -> `length(l)` refinements with `l[i]` being the limits for the i-th refinement.
 - `min_tick_distance::Tuple{<:Quantity, <:Quantity, <:Quantity}`: Tuple of the mimimum allowed distance between 
     two grid ticks for each dimension. It prevents the refinement to make the grid to fine.
 - `max_tick_distance::Tuple{<:Quantity, <:Quantity, <:Quantity}`: Tuple of the maximum allowed distance between 
@@ -786,7 +786,7 @@ There are serveral `<keyword arguments>` which can be used to tune the computati
     - rl::Real -> One refinement with `l` equal in all 3 dimensions
     - rl::Tuple{<:Real,<:Real,<:Real} -> One refinement with `l` set individual for each dimension
     - rl::Vector{<:Real} -> `length(l)` refinements with `l[i]` being the limit for the i-th refinement. 
-    - rl::Vector{<:Real,<:Real,<:Real}} `length(l)` refinements with `l[i]` being the limits for the i-th refinement.
+    - rl::Vector{<:Real,<:Real,<:Real}} -> `length(l)` refinements with `l[i]` being the limits for the i-th refinement.
 - `min_tick_distance::Tuple{<:Quantity, <:Quantity, <:Quantity}`: Tuple of the mimimum allowed distance between 
     two grid ticks for each dimension. It prevents the refinement to make the grid to fine.
 - `max_tick_distance::Tuple{<:Quantity, <:Quantity, <:Quantity}`: Tuple of the maximum allowed distance between 

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -669,7 +669,7 @@ function _calculate_potential!( sim::Simulation{T, CS}, potential_type::UnionAll
         if !(refinement_limits isa Vector) refinement_limits = [refinement_limits] end
         n_refinement_steps = length(refinement_limits)
         for iref in 1:n_refinement_steps
-            ref_limits = _extend_refinement_limits(refinement_limits[iref])
+            ref_limits = T.(_extend_refinement_limits(refinement_limits[iref]))
             if isEP
                 max_diffs = abs.(ref_limits .* bias_voltage)
                 sim.electric_potential = refine_scalar_potential(sim.electric_potential, max_diffs, min_grid_spacing)
@@ -838,15 +838,18 @@ end
 
 ToDo...
 """
-function simulate!(sim::Simulation{T};  max_refinements::Int = 1, verbose::Bool = false,
-                                        depletion_handling::Bool = false, convergence_limit::Real = 1e-7 ) where {T <: SSDFloat}
+function simulate!( sim::Simulation{T};  
+                    refinement_limits = [0.2, 0.1, 0.05],
+                    verbose::Bool = false,
+                    depletion_handling::Bool = false, 
+                    convergence_limit::Real = 1e-7 ) where {T <: SSDFloat}
     calculate_electric_potential!(  sim,
-                                    max_refinements = max_refinements,
+                                    refinement_limits = refinement_limits,
                                     verbose = verbose,
                                     depletion_handling = depletion_handling,
                                     convergence_limit = convergence_limit )
     for contact in sim.detector.contacts
-        calculate_weighting_potential!(sim, contact.id, max_refinements = max_refinements,
+        calculate_weighting_potential!(sim, contact.id, refinement_limits = refinement_limits,
                 verbose = verbose, convergence_limit = convergence_limit)
     end
     calculate_electric_field!(sim)

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -611,8 +611,7 @@ function _calculate_potential!( sim::Simulation{T, CS}, potential_type::UnionAll
         if ismissing(min_grid_spacing)
             min_grid_spacing::NTuple{3, T} = CS == Cylindrical ? (T(1e-5), T(1e-5) / (0.25 * grid.axes[1][end]), T(1e-5)) : (T(1e-5), T(1e-5), T(1e-5))
         end
-        n_iterations_between_checks::Int = div(10^7, length(grid))
-        if n_iterations_between_checks < 20 n_iterations_between_checks = 20 end
+        n_iterations_between_checks::Int = 1000
         if use_nthreads > Base.Threads.nthreads()
             use_nthreads = Base.Threads.nthreads();
             @warn "`use_nthreads` was set to `1`. The environment variable `JULIA_NUM_THREADS` must be set appropriately before the julia session is started."
@@ -633,7 +632,7 @@ function _calculate_potential!( sim::Simulation{T, CS}, potential_type::UnionAll
         if isWP bias_voltage = T(1) end
         if verbose
             println(
-                "$(isEP ? "Electric" : "Weighting") Potential Calculation\n",
+                "$(isEP ? "Electric" : "Weighting") Potential Calculation$(isEP ? "" : " - ID: $contact_id")\n",
                 if isEP "Bias voltage: $(bias_voltage) V\n" else "" end,
                 if CS == Cylindrical "$n_φ_sym_info_txt\n" else "" end,
                 "Precision: $T\n",
@@ -674,20 +673,20 @@ function _calculate_potential!( sim::Simulation{T, CS}, potential_type::UnionAll
                 max_diffs = abs.(ref_limits .* bias_voltage)
                 sim.electric_potential = refine_scalar_potential(sim.electric_potential, max_diffs, min_grid_spacing, only2d = Val(only_2d))
                 update_till_convergence!( sim, potential_type, convergence_limit,
-                n_iterations_between_checks = n_iterations_between_checks,
-                max_n_iterations = max_n_iterations,
-                depletion_handling = depletion_handling,
-                use_nthreads = use_nthreads,
-                sor_consts = sor_consts )
+                                                n_iterations_between_checks = n_iterations_between_checks,
+                                                max_n_iterations = max_n_iterations,
+                                                depletion_handling = depletion_handling,
+                                                use_nthreads = use_nthreads,
+                                                sor_consts = sor_consts )
             else
                 max_diffs = abs.(ref_limits)
                 sim.weighting_potentials[contact_id] = refine_scalar_potential(sim.weighting_potentials[contact_id], max_diffs, min_grid_spacing, only2d = Val(only_2d))
                 update_till_convergence!( sim, potential_type, contact_id, convergence_limit,
-                                    n_iterations_between_checks = n_iterations_between_checks,
-                                    max_n_iterations = max_n_iterations,
-                                    depletion_handling = depletion_handling,
-                                    use_nthreads = use_nthreads,
-                                    sor_consts = sor_consts )
+                                                n_iterations_between_checks = n_iterations_between_checks,
+                                                max_n_iterations = max_n_iterations,
+                                                depletion_handling = depletion_handling,
+                                                use_nthreads = use_nthreads,
+                                                sor_consts = sor_consts )
             end
         end
     end

--- a/src/SolidStateDetectors.jl
+++ b/src/SolidStateDetectors.jl
@@ -38,7 +38,7 @@ using .ConstructiveSolidGeometry:
             csg_round_lin, csg_round_rad, csg_isapprox, 
             parse_rotation_matrix, parse_translate_vector, parse_CSG_transformation,
             transform, CSG_dict, Transformations, combine_transformations,
-            ConfigFileError
+            ConfigFileError, _parse_value
         
 import .ConstructiveSolidGeometry: sample
 export CartesianPoint, CartesianVector, CylindricalPoint

--- a/src/Types/point_types.jl
+++ b/src/Types/point_types.jl
@@ -30,9 +30,9 @@ const max_pointtype_value = update_bit + undepleted_bit + pn_junction_bit #+ bub
 
 PointTypes stores the point type of each grid point.
 """
-struct PointTypes{T, N, S} <: AbstractArray{T, N}
+struct PointTypes{T, N, S, AT} <: AbstractArray{T, N}
     data::Array{PointType, N}
-    grid::Grid{T, N, S}
+    grid::Grid{T, N, S, AT}
 end
 
 @inline size(pts::PointTypes{T, N, S}) where {T, N, S} = size(pts.data)

--- a/src/Units.jl
+++ b/src/Units.jl
@@ -24,6 +24,9 @@ from_internal_units(u_external::Unitful.Units, u_internal::Unitful.Units, x::Rea
 from_internal_units(u_external::typeof(Unitful.NoUnits), u_internal::Unitful.Units, x::AbstractArray{<:Real}) where {T<:Real} = x
 from_internal_units(u_external::Unitful.Units, u_internal::Unitful.Units, x::AbstractArray{<:Real}) where {T<:Quantity} = uconvert.(u_external, x * u_internal)
 
+_get_TDU(x::Quantity{T,D,U}) where {T,D,U} = T, D, U
+const length_unit = Quantity{<:Real, Unitful.𝐋}
+const angle_unit = Quantity{<:Real, NoDims, <:Union{_get_TDU(1u"rad")[3], _get_TDU(1u"°")[3]}}
 
 unit_conversion = Dict{String, Unitful.Units}(
     "nm" => u"nm", "um" => u"μm", "mm" => u"mm", "cm" => u"cm", "m" => u"m", #length

--- a/src/World/World.jl
+++ b/src/World/World.jl
@@ -73,7 +73,7 @@ function get_r_SSDInterval(T, dict, input_units::NamedTuple)
         from::T = 0 
         if "from" in keys(dict) @warn "ConfigFileWarning: \"from\" is not used in r-axis. It is fixed to 0." end
         # to::T = "to" in keys(dict) ? geom_round(ustrip(uconvert(internal_length_unit, T(dict["to"]) * input_units.length))) : throw(ConfigFileError("No \"to\" given for r-axis."))
-        to::T = "to" in keys(dict) ? ustrip(uconvert(internal_length_unit, T(dict["to"]) * input_units.length)) : throw(ConfigFileError("No \"to\" given for r-axis."))
+        to::T = "to" in keys(dict) ? _parse_value(T, dict["to"], input_units.length) : throw(ConfigFileError("No \"to\" given for r-axis."))
         if from < 0 throw(ConfigFileError("left boundary of r-axis cannot be negative.")) end 
         if to < 0 throw(ConfigFileError("right boundary of r-axis cannot be negative.")) end 
         L = :closed
@@ -90,10 +90,8 @@ end
 function get_φ_SSDInterval(T, dict::Dict, input_units::NamedTuple)
     if haskey(dict, "phi")
         dp = dict["phi"]
-        # from::T = "from" in keys(dp) ? geom_round(ustrip(uconvert(internal_angle_unit, T(dp["from"]) * input_units.angle))) : T(0)
-        # to::T = "to" in keys(dp) ? geom_round(ustrip(uconvert(internal_angle_unit, T(dp["to"]) * input_units.angle))) : T(2π)
-        from::T = "from" in keys(dp) ? ustrip(uconvert(internal_angle_unit, T(dp["from"]) * input_units.angle)) : T(0)
-        to::T = "to" in keys(dp) ? ustrip(uconvert(internal_angle_unit, T(dp["to"]) * input_units.angle)) : T(2π)
+        from::T = "from" in keys(dp) ?  _parse_value(T, dp["from"], input_units.angle) : T(0)
+        to::T = "to" in keys(dp) ? _parse_value(T, dp["to"], input_units.angle) : T(2π)
         L = :closed
         R = :open
         BL = :periodic
@@ -115,10 +113,8 @@ function get_φ_SSDInterval(T, dict::Dict, input_units::NamedTuple)
 end
 
 function get_cartesian_SSDInterval(T, dict::Dict, input_units::NamedTuple)
-    # from::T = "from" in keys(dict) ? geom_round(ustrip(uconvert(internal_length_unit, T(dict["from"]) * input_units.length))) : 0
-    # to = "to" in keys(dict) ? geom_round(ustrip(uconvert(internal_length_unit, T(dict["to"]) * input_units.length))) : throw(ConfigFileError("No \"to\" given for z-axis."))
-    from::T = "from" in keys(dict) ? ustrip(uconvert(internal_length_unit, T(dict["from"]) * input_units.length)) : 0
-    to = "to" in keys(dict) ? ustrip(uconvert(internal_length_unit, T(dict["to"]) * input_units.length)) : throw(ConfigFileError("No \"to\" given for z-axis."))
+    from::T = "from" in keys(dict) ? _parse_value(T, dict["from"], input_units.length) : 0
+    to = "to" in keys(dict) ? _parse_value(T, dict["to"], input_units.length) : throw(ConfigFileError("No \"to\" given for z-axis."))
     L = :closed
     R = :closed
     BL, BR = :infinite, :infinite

--- a/test/comparison_to_analytic_solutions.jl
+++ b/test/comparison_to_analytic_solutions.jl
@@ -5,7 +5,6 @@ e = SolidStateDetectors.elementary_charge * u"C"
 @testset "Infinite Parallel Plate Capacitor" begin
     sim = Simulation{T}(SSD_examples[:InfiniteParallelPlateCapacitor])
     calculate_electric_potential!(sim, 
-        init_grid_spacing = T.( (1e-4, 1e-3, 1e-3) ), 
         max_refinements = 1,
     )
     calculate_electric_field!(sim)

--- a/test/comparison_to_analytic_solutions.jl
+++ b/test/comparison_to_analytic_solutions.jl
@@ -95,7 +95,7 @@ struct DummyImpurityDensity{T} <: SolidStateDetectors.AbstractImpurityDensity{T}
     sim_cyl.detector = SolidStateDetector(sim_cyl.detector, DummyImpurityDensity{T}());
     sim_car.detector = SolidStateDetector(sim_car.detector, DummyImpurityDensity{T}());
 
-    calculate_electric_potential!(sim_cyl, grid = Grid(sim_cyl, max_tick_distance = (1u"cm", 15u"°", 1u"mm")),
+    calculate_electric_potential!(sim_cyl, grid = Grid(sim_cyl, max_tick_distance = (1u"cm", 15u"°", 1u"m")),
         convergence_limit = 1e-7, refinement_limits = [0.2, 0.1, 0.05], use_nthreads = 1, verbose = false
     )
     calculate_electric_potential!(sim_car, grid = Grid(sim_car, max_tick_distance = (0.3u"cm", 0.3u"cm", 1u"m")),

--- a/test/comparison_to_analytic_solutions.jl
+++ b/test/comparison_to_analytic_solutions.jl
@@ -5,7 +5,7 @@ e = SolidStateDetectors.elementary_charge * u"C"
 @testset "Infinite Parallel Plate Capacitor" begin
     sim = Simulation{T}(SSD_examples[:InfiniteParallelPlateCapacitor])
     calculate_electric_potential!(sim, 
-        max_refinements = 1,
+        convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false
     )
     calculate_electric_field!(sim)
     BV_true = SolidStateDetectors._get_abs_bias_voltage(sim.detector) 
@@ -42,11 +42,11 @@ struct DummyImpurityDensity{T} <: SolidStateDetectors.AbstractImpurityDensity{T}
     V = π * R2^2 * L
     intV = (R2^2 - R1^2) * π * L
 
-    calculate_electric_potential!(sim_cyl, 
-        max_refinements = 6,
+    calculate_electric_potential!(sim_cyl, grid = Grid(sim_cyl, max_tick_distance = (0.3u"cm", 15u"°", 1u"m")),
+        convergence_limit = 1e-6, refinement_limits = [0.2, 0.1, 0.05, 0.01], use_nthreads = 1, verbose = false
     )
-    calculate_electric_potential!(sim_car, 
-        max_refinements = 2
+    calculate_electric_potential!(sim_car, grid = Grid(sim_car, max_tick_distance = (0.3u"cm", 0.3u"cm", 1u"m")),
+        convergence_limit = 1e-3, refinement_limits = [0.2], use_nthreads = 1, verbose = false
     )
     calculate_electric_field!(sim_cyl)
     calculate_electric_field!(sim_car)
@@ -92,27 +92,26 @@ struct DummyImpurityDensity{T} <: SolidStateDetectors.AbstractImpurityDensity{T}
     function SolidStateDetectors.get_impurity_density(cdm::DummyImpurityDensity{T}, pt::CartesianPoint{T})::T where {T <: SSDFloat}
         SolidStateDetectors.get_impurity_density(cdm, CylindricalPoint(pt))
     end
-
     sim_cyl.detector = SolidStateDetector(sim_cyl.detector, DummyImpurityDensity{T}());
     sim_car.detector = SolidStateDetector(sim_car.detector, DummyImpurityDensity{T}());
 
-    calculate_electric_potential!(sim_cyl, 
-        max_refinements = 4
+    calculate_electric_potential!(sim_cyl, grid = Grid(sim_cyl, max_tick_distance = (1u"cm", 15u"°", 1u"mm")),
+        convergence_limit = 1e-7, refinement_limits = [0.2, 0.1, 0.05], use_nthreads = 1, verbose = false
     )
-    calculate_electric_potential!(sim_car, 
-        max_refinements = 1
+    calculate_electric_potential!(sim_car, grid = Grid(sim_car, max_tick_distance = (0.3u"cm", 0.3u"cm", 1u"m")),
+        convergence_limit = 1e-6, refinement_limits = [0.2, 0.1, 0.05, 0.01], use_nthreads = 1, verbose = false
     )
 
-    idxR1 = searchsortedfirst( sim_cyl.electric_potential.grid.axes[1], ustrip(R1))
-    rs = sim_cyl.electric_potential.grid.axes[1].ticks[idxR1:end]
-    potential_rms_cyl = sqrt(sum((ustrip.(map(r -> potential_analytic(r * u"m"), rs)) .- sim_cyl.electric_potential.data[idxR1:end, 1, 1]).^2))
-    idxR1 = searchsortedfirst( sim_car.electric_potential.grid.axes[1], ustrip(R1))
-    rs = sim_car.electric_potential.grid.axes[1].ticks[idxR1:end]
-    idy0 = searchsortedfirst( sim_car.electric_potential.grid.axes[2], 0)
-    potential_rms_car = sqrt(sum((ustrip.(map(r -> potential_analytic(r * u"m"), rs)) .- sim_car.electric_potential.data[idxR1:end, idy0, 1]).^2))
+    idxR1 = searchsortedfirst( sim_cyl.electric_potential.grid.axes[1], ustrip(R1));
+    rs = sim_cyl.electric_potential.grid.axes[1].ticks[idxR1:end];
+    potential_rms_cyl = sqrt(sum((ustrip.(map(r -> potential_analytic(r * u"m"), rs)) .- sim_cyl.electric_potential.data[idxR1:end, 1, 1]).^2)) / (ustrip(BV_true)*length(rs));
+    idxR1 = searchsortedfirst( sim_car.electric_potential.grid.axes[1], ustrip(R1));
+    rs = sim_car.electric_potential.grid.axes[1].ticks[idxR1:end];
+    idy0 = searchsortedfirst( sim_car.electric_potential.grid.axes[2], 0);
+    potential_rms_car = sqrt(sum((ustrip.(map(r -> potential_analytic(r * u"m"), rs)) .- sim_car.electric_potential.data[idxR1:end, idy0, 1]).^2))/ (ustrip(BV_true)*length(rs));
 
     @testset "Potential RMS" begin
-        @test potential_rms_cyl < 0.01
-        @test potential_rms_car < 1.1
+        @test potential_rms_cyl < 1e-3
+        @test potential_rms_car < 1e-3
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,19 +15,7 @@ end
 @testset "Test real detectors" begin
     @testset "Simulate example detector: Inverted Coax" begin
         sim = Simulation{T}(SSD_examples[:InvertedCoax])
-        simulate!(sim, max_refinements = 1, verbose = true)
-        evt = Event(CartesianPoint.([CylindricalPoint{T}(20e-3, deg2rad(10), 40e-3 )]))
-        simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
-        signalsum = T(0)
-        for i in 1:length(evt.waveforms)
-            signalsum += abs(evt.waveforms[i].value[end])
-        end
-        @info signalsum
-        @test isapprox( signalsum, T(2), atol = 5e-4 )
-    end
-    @testset "Simulate example detector: Inverted Coax (in cryostat)" begin
-        sim = Simulation{T}(SSD_examples[:InvertedCoaxInCryostat])
-        simulate!(sim, max_refinements = 1, verbose = true)
+        simulate!(sim, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
         evt = Event(CartesianPoint.([CylindricalPoint{T}(20e-3, deg2rad(10), 10e-3 )]))
         simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
         signalsum = T(0)
@@ -35,11 +23,23 @@ end
             signalsum += abs(evt.waveforms[i].value[end])
         end
         @info signalsum
-        @test isapprox( signalsum, T(2), atol = 5e-4 )
+        @test isapprox( signalsum, T(2), atol = 1e-3 )
+    end
+    @testset "Simulate example detector: Inverted Coax (in cryostat)" begin
+        sim = Simulation{T}(SSD_examples[:InvertedCoaxInCryostat])
+        simulate!(sim, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
+        evt = Event(CartesianPoint.([CylindricalPoint{T}(20e-3, deg2rad(10), 10e-3 )]))
+        simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
+        signalsum = T(0)
+        for i in 1:length(evt.waveforms)
+            signalsum += abs(evt.waveforms[i].value[end])
+        end
+        @info signalsum
+        @test isapprox( signalsum, T(2), atol = 1e-3 )
     end
     @testset "Simulate example detector: Coax" begin
         sim = Simulation{T}(SSD_examples[:Coax])
-        simulate!(sim, max_refinements = 0, verbose = true)
+        simulate!(sim, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
         evt = Event(CartesianPoint.([CylindricalPoint{T}(20e-3, deg2rad(30), 12e-3 )]))
         simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
         signalsum = T(0)
@@ -47,11 +47,11 @@ end
             signalsum += abs(evt.waveforms[i].value[end])
         end
         @info signalsum
-        @test isapprox( signalsum, T(2), atol = 0.02 )
+        @test isapprox( signalsum, T(2), atol = 1e-3 )
     end
     @testset "Simulate example detector: BEGe" begin
         sim = Simulation{T}(SSD_examples[:BEGe])
-        simulate!(sim, max_refinements = 1, verbose = true)
+        simulate!(sim, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
         evt = Event(CartesianPoint.([CylindricalPoint{T}(20e-3, deg2rad(10), 20e-3 )]))
         simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
         signalsum = T(0)
@@ -59,11 +59,11 @@ end
             signalsum += abs(evt.waveforms[i].value[end])
         end
         @info signalsum
-        @test isapprox( signalsum, T(2), atol = 3e-2 )
+        @test isapprox( signalsum, T(2), atol = 1e-3 )
     end
     @testset "Simulate example detector: HexagonalPrism" begin
         sim = Simulation{T}(SSD_examples[:Hexagon])
-        simulate!(sim, max_refinements = 0, verbose = true)
+        simulate!(sim, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
         evt = Event([CartesianPoint{T}(0, 5e-4, 1e-3)])
         simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
         signalsum = T(0)
@@ -71,23 +71,23 @@ end
             signalsum += abs(evt.waveforms[i].value[end])
         end
         @info signalsum
-        @test isapprox( signalsum, T(2), atol = 5e-4 )
+        @test isapprox( signalsum, T(2), atol = 1e-3 )
     end
     @testset "Simulate example detector: CGD" begin
         sim = Simulation{T}(SSD_examples[:CGD])
-        simulate!(sim, max_refinements = 2, verbose = true)
-        evt = Event([CartesianPoint{T}(5e-3,0,0)])
+        simulate!(sim, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
+        evt = Event([CartesianPoint{T}(0,2e-3,0)])
         simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
         signalsum = T(0)
         for i in 1:length(evt.waveforms)
             signalsum += abs(evt.waveforms[i].value[end])
         end
         @info signalsum
-        @test isapprox( signalsum, T(2), atol = 5e-2 )
+        @test isapprox( signalsum, T(2), atol = 1e-3 )
     end
     @testset "Simulate example detector: Spherical" begin
         sim = Simulation{T}(SSD_examples[:Spherical])
-        simulate!(sim, max_refinements = 1, verbose = true)
+        simulate!(sim, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
         evt = Event([CartesianPoint{T}(0,0,0)])
         simulate!(evt, sim)
         signalsum = T(0)
@@ -95,32 +95,32 @@ end
             signalsum += abs(evt.waveforms[i].value[end])
         end
         @info signalsum
-        @test isapprox( signalsum, T(2), atol = 5e-4 )
+        @test isapprox( signalsum, T(2), atol = 1e-3 )
     end 
     @testset "Simulate example detector: Toroidal" begin
         sim = Simulation{T}(SSD_examples[:CoaxialTorus])
         SolidStateDetectors.apply_initial_state!(sim, ElectricPotential)
-        simulate!(sim, max_refinements = 1, verbose = true)
-        evt = Event([CartesianPoint{T}(0.01,0,0.003)])
+        simulate!(sim, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
+        evt = Event([CartesianPoint{T}(0.01,0,0.00205)])
         simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
         signalsum = T(0)
         for i in 1:length(evt.waveforms)
             signalsum += abs(evt.waveforms[i].value[end])
         end
         @info signalsum
-        @test isapprox( signalsum, T(2), atol = 2e-2 )
+        @test isapprox( signalsum, T(2), atol = 1e-3 )
     end
     @testset "Simulate example detector: SigGen PPC" begin
         sim = Simulation{T}(SSD_examples[:SigGen])
-        simulate!(sim, max_refinements = 1, verbose = true)
-        evt = Event(CartesianPoint.([CylindricalPoint{T}(20e-3, deg2rad(10), 40e-3 )]))
+        simulate!(sim, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
+        evt = Event(CartesianPoint.([CylindricalPoint{T}(20e-3, deg2rad(10), 10e-3 )]))
         simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
         signalsum = T(0)
         for i in 1:length(evt.waveforms)
             signalsum += abs(evt.waveforms[i].value[end])
         end
         @info signalsum
-        @test isapprox( signalsum, T(2), atol = 2e-2 )
+        @test isapprox( signalsum, T(2), atol = 1e-3 )
     end
 end
 


### PR DESCRIPTION
In this PR the refinement of the grid is refactored: See also #178.

## Refinement

The high level keyword `max_nrefinements` is removed and the refinement is controlled via
the keyword `refinement_limits`. Prior to this PR, the keyword `refinement_limits` was a Tuple of 3 `Reals` 
to set the allowed relative (to the applied bias voltage) maximum difference in the potential between to grid points for each dimension. 

Now this keywords can take also a Vector of these tuples, where the first element sets the maximum allowed differences
for the first refinement. The second element for the second refinement.... 
Also, not only 1 tick is inserted, but multiple points can be inserted in one step depending on how large the difference is between two grid points. 

`refinement_limits` can also be just a single `Real` or a `Vector{<:Real}`.
E.g. `[0.2, 0.1, 0.05]`. Than, each element is converted into a NTuple{3, Real} with the same values:
`[(0.2, 0.2, 0.2), (0.1, 0.1, 0.1), ...]`

Here, in the first refinement, the maximum allowed relative potential difference would be 20%. 
Thus, the absolute allowed difference would be `0.2 * bias_voltage`.

I rename the old keyword `min_grid_spacing` to `min_tick_distance` in order to be consistent with 
`max_tick_distance` (see below). It also takes quantities now, see also `max_tick_distance`.
E.g. `min_tick_distance = 10u"nm"`.
(In cylindrical coordinates a single length value is translated into an angle at a radius of
`(sim.world.r[end] + sim.world.r[1])/2`)

## Initial Grid

The keywords of the initialization of the Grid have also changed. There a two keywords:
`max_tick_distance` and `max_distance_ratio`. 

`max_tick_distance` defines the maximum allowed distances between two ticks for each dimension. 
It takes units. E.g. for the cylindrical grid:
`Grid(sim_cyl, max_tick_distance = (0.3u"cm", 15u"°", 1u"m"))`
Also, a single value can be parsed: e.g. `max_tick_distance = 1u"mm"`.

For `max_distance_ratio::Real` look into #171.

Both keywords can also be given to `simulate!`, `calculate_electric_potential!` and `calculate_weighting_potential!`.