### PR TITLE
Update the script to update config files 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SolidStateDetectors"
 uuid = "71e43887-2bd9-5f77-aebd-47f656f0a3f0"
-version = "0.6.0-DEV"
+version = "0.6.0"
 
 [deps]
 ArraysOfArrays = "65a8f2f4-9b39-5baf-92e2-a9cc46fdf018"

--- a/src/IO/Update.jl
+++ b/src/IO/Update.jl
@@ -117,6 +117,10 @@ function restructure_config_file_dict!(config_file_dict::AbstractDict, T::DataTy
     contacts = [
         begin 
         delete!(contact, "type")
+        if "channel" in keys(contact)
+            contact["id"] = contact["channel"]
+            delete!(contact, "id")
+        end
         update_geometry!(contact, T, update_units)
         contact
         end


### PR DESCRIPTION
The config file entry for the contact id was renamed from `channel` to `id`.
This needs to be taken into account when updating config files.