### PR TITLE
Final adjustments before v0.6.0 release

### DIFF
--- a/src/IO/ParseConfigFiles.jl
+++ b/src/IO/ParseConfigFiles.jl
@@ -32,18 +32,6 @@ function parse_config_file(filename::AbstractString)::Dict{Any,Any}
     else
         error("Currently only .json and .yaml files are supported.")
     end
-    @assert !haskey(dict, "objects") "Configuration file deprecation.\n
-        The configuration file format was updated in v0.6.0.
-        However, this configuration file still seems to be in the old format.\n
-        To update your configuration file to the new format (v0.6.0 and newer),
-        open a new Julia session and load the following file:\n
-        \tinclude(\"<path_to_SolidStateDetectors.jl>/test/update_config_files.jl\")\n
-        Afterwards, run\n
-        \tupdate_config_file(\"<path_to_configuration_file>\")\n
-        This method returns the file name of the updated configuration file.
-        Please close the Julia session after updating the configuration files, as some
-        parsing methods are overridden with old methods."
-        
     dict
 end
 

--- a/src/IO/Update.jl
+++ b/src/IO/Update.jl
@@ -119,7 +119,7 @@ function restructure_config_file_dict!(config_file_dict::AbstractDict, T::DataTy
         delete!(contact, "type")
         if "channel" in keys(contact)
             contact["id"] = contact["channel"]
-            delete!(contact, "id")
+            delete!(contact, "channel")
         end
         update_geometry!(contact, T, update_units)
         contact

--- a/src/SolidStateDetector/VirtualVolumes.jl
+++ b/src/SolidStateDetector/VirtualVolumes.jl
@@ -44,9 +44,9 @@ function modulate_driftvector(sv::CartesianVector{T}, pt::CartesianPoint{T}, tl:
     return CartesianVector{T}(0,0,0)
 end
 
-function DeadVolume{T}(dict::Dict, input_units::NamedTuple, transformations = missing) where T <: SSDFloat
+function DeadVolume{T}(dict::Dict, input_units::NamedTuple, transformations::Transformations) where T <: SSDFloat
     n = haskey(dict, "name") ? dict["name"] : "external part"
-    g = transform(Geometry(T, dict["geometry"], input_units), transformations)
+    g = Geometry(T, dict["geometry"], input_units, transformations)
     return DeadVolume{T, typeof(g)}(n, g)
 end
 
@@ -73,9 +73,9 @@ function modulate_driftvector(sv::CartesianVector{T}, pt::CartesianPoint{T}, tl:
 end
 
 
-function ArbitraryDriftModificationVolume{T}(dict::Dict, input_units::NamedTuple, transformations = missing) where T <: SSDFloat
+function ArbitraryDriftModificationVolume{T}(dict::Dict, input_units::NamedTuple, transformations::Transformations) where T <: SSDFloat
     n = haskey(dict, "name") ? dict["name"] : "external part"
-    g = transform(Geometry(T, dict["geometry"], input_units), transformations)
+    g = Geometry(T, dict["geometry"], input_units, transformations)
     id = Int(dict["id"])
     return ArbitraryDriftModificationVolume{T}(n, id, g)
 end


### PR DESCRIPTION
Now, the update string saves the `id` of the contacts in `id` rather than `channel` (change in 68f7c8100b7fb9e14c21053d280924d493797342).

The config file deprecation warning was moved to `SolidStateDetectors{T}` where the config dictionary is parsed.

To be consistent with the documentation, `Passives` can be stored in `passives` and `surroundings`.

And minor adjustment to the read-in functions of `VirtualVolumes` were made.

After this, we should be good to go for a release.