### PR TITLE
Improvements and fixes in IO for v0.6

### DIFF
--- a/src/Config/Config.jl
+++ b/src/Config/Config.jl
@@ -10,18 +10,18 @@
 # For cylindrical grids:
 # 
 # * in(pt::CylindricalPoint{T}, config::UserConfig{T})::Bool where {T <: SSDFloat}
-# * Grid(config::UserConfig{T})::Grid{T, 3, Cylindrical} where {T <: SSDFloat}
+# * Grid(config::UserConfig{T})::CylindricalGrid{T} where {T <: SSDFloat}
 # * get\\_ρ\\_and\\_ϵ(pt::CylindricalPoint{T}, config::UserConfig{T})::Tuple{T, T} where {T <: SSDFloat} 
 # * set\\_point\\_types\\_and\\_fixed\\_potentials!(point_types::Array{PointType, 3}, potential::Array{T, 3}, 
-#         grid::Grid{T, 3, Cylindrical}, config::UserConfig{T}; weighting\\_potential\\_contact\\_id::Union{Missing, Int} = missing)::Nothing where {T <: SSDFloat}
+#         grid::CylindricalGrid{T}, config::UserConfig{T}; weighting\\_potential\\_contact\\_id::Union{Missing, Int} = missing)::Nothing where {T <: SSDFloat}
 # 
 # For cartesian grids:
 # 
 # * in(pt::CartesianPoint{3, T}, config::UserConfig{T})::Bool 
-# * Grid(config::UserConfig{T})::Grid{T, 3, Cartesian} where {T <: SSDFloat}
+# * Grid(config::UserConfig{T})::CartesianGrid3D{T} where {T <: SSDFloat}
 # * get\\_ρ\\_and\\_ϵ(pt::CartesianPoint{3, T}, config::UserConfig{T})::Tuple{T, T} where {T <: SSDFloat} 
 # * set\\_point\\_types\\_and\\_fixed\\_potentials!(point_types::Array{PointType, 3}, potential::Array{T, 3}, 
-#         grid::Grid{T, 3, Cartesian}, config::UserConfig{T}; weighting\\_potential\\_contact\\_id::Union{Missing, Int} = missing)::Nothing where {T <: SSDFloat}
+#         grid::CartesianGrid3D{T}, config::UserConfig{T}; weighting\\_potential\\_contact\\_id::Union{Missing, Int} = missing)::Nothing where {T <: SSDFloat}
 # 
 # """
 abstract type AbstractConfig{T <: SSDFloat} end

--- a/src/ConstructiveSolidGeometry/IO.jl
+++ b/src/ConstructiveSolidGeometry/IO.jl
@@ -148,13 +148,13 @@ function parse_r_of_primitive(::Type{T}, dict::AbstractDict, unit::Unitful.Units
         if r_top_in == 0
             return ((r_bot_in, r_bot_out), nothing)
         else
-            return ((r_bot_in, r_bot_out), r_top_in)
+            return r # return ((r_bot_in, r_bot_out), r_top_in)
         end
     elseif r_top_in != r_top_out && r_bot_in == r_bot_out
         if r_bot_in == 0
             return (nothing, (r_top_in, r_top_out))
         else
-            return (r_bot_in, (r_top_in, r_top_out))
+            return r # return (r_bot_in, (r_top_in, r_top_out))
         end
     else
         r # VaryingTube

--- a/src/ElectricField/ElectricField.jl
+++ b/src/ElectricField/ElectricField.jl
@@ -187,7 +187,7 @@ function get_interpolated_drift_field(velocityfield, grid::CylindricalGrid{T}) w
     velocity_field_itp = extrapolate(i, (Interpolations.Line(), Periodic(), Interpolations.Line()))
     return velocity_field_itp
 end
-function get_interpolated_drift_field(velocityfield, grid::CartesianGrid{T}) where {T}
+function get_interpolated_drift_field(velocityfield, grid::CartesianGrid3D{T}) where {T}
     @inbounds knots = grid.axes[1].ticks, grid.axes[2].ticks, grid.axes[3].ticks
     i = interpolate(knots, velocityfield, Gridded(Linear()))
     velocity_field_itp = extrapolate(i, (Interpolations.Line(), Interpolations.Line(), Interpolations.Line()))

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -100,8 +100,8 @@ function get_boundary_types(grid::Grid{T, N, S}) where {T, N, S}
    return get_boundary_types.(grid.axes)
 end
 
-TicksTuple(grid::Grid{T, 3, Cartesian}) where {T} = (x = grid.axes[1].ticks, y = grid.axes[2].ticks, z = grid.axes[3].ticks)
-TicksTuple(grid::Grid{T, 3, Cylindrical}) where {T} = (r = grid.axes[1].ticks, φ = grid.axes[2].ticks, z = grid.axes[3].ticks)
+TicksTuple(grid::CartesianGrid3D{T}) where {T} = (x = grid.axes[1].ticks, y = grid.axes[2].ticks, z = grid.axes[3].ticks)
+TicksTuple(grid::CylindricalGrid{T}) where {T} = (r = grid.axes[1].ticks, φ = grid.axes[2].ticks, z = grid.axes[3].ticks)
 
 function Grid(nt::NamedTuple)
     if nt.coordtype == "cylindrical"
@@ -109,13 +109,13 @@ function Grid(nt::NamedTuple)
         axφ::DiscreteAxis = DiscreteAxis(nt.axes.phi, unit=u"rad")
         axz::DiscreteAxis = DiscreteAxis(nt.axes.z, unit=u"m")
         T = typeof(axr.ticks[1])
-        return Grid{T, 3, Cylindrical}( (axr, axφ, axz) )
+        return CylindricalGrid{T}( (axr, axφ, axz) )
     elseif nt.coordtype == "cartesian"
         axx::DiscreteAxis = DiscreteAxis(nt.axes.x, unit=u"m")
         axy::DiscreteAxis = DiscreteAxis(nt.axes.y, unit=u"m")
         axz = DiscreteAxis(nt.axes.z, unit=u"m")
         T = typeof(axx.ticks[1])
-        return Grid{T, 3, Cartesian}( (axx, axy, axz) )
+        return CartesianGrid3D{T}( (axx, axy, axz) )
     else
         error("`coordtype` = $(nt.coordtype) is not valid.")
     end
@@ -123,7 +123,7 @@ end
 
 Base.convert(T::Type{Grid}, x::NamedTuple) = T(x)
 
-function NamedTuple(grid::Grid{T, 3, Cylindrical}) where {T}
+function NamedTuple(grid::CylindricalGrid{T}) where {T}
     axr::DiscreteAxis{T} = grid.axes[1]
     axφ::DiscreteAxis{T} = grid.axes[2]
     axz::DiscreteAxis{T} = grid.axes[3]
@@ -137,7 +137,7 @@ function NamedTuple(grid::Grid{T, 3, Cylindrical}) where {T}
         )
     )
 end
-function NamedTuple(grid::Grid{T, 3, Cartesian}) where {T}
+function NamedTuple(grid::CartesianGrid3D{T}) where {T}
     axx::DiscreteAxis{T} = grid.axes[1]
     axy::DiscreteAxis{T} = grid.axes[2]
     axz::DiscreteAxis{T} = grid.axes[3]

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -46,16 +46,16 @@ CartesianGrid3D{T}(a) where {T} = Grid{T, 3, Cartesian, typeof(a)}(a)
 @inline getproperty(grid::CylindricalGrid{T}, ::Val{:r}) where {T} = @inbounds grid.axes[1]
 @inline getproperty(grid::CylindricalGrid{T}, ::Val{:φ}) where {T} = @inbounds grid.axes[2]
 @inline getproperty(grid::CylindricalGrid{T}, ::Val{:z}) where {T} = @inbounds grid.axes[3]
-@inline getproperty(grid::CartesianGrid{T}, ::Val{:x}) where {T} = @inbounds grid.axes[1]
-@inline getproperty(grid::CartesianGrid{T}, ::Val{:y}) where {T} = @inbounds grid.axes[2]
-@inline getproperty(grid::CartesianGrid{T}, ::Val{:z}) where {T} = @inbounds grid.axes[3]
+@inline getproperty(grid::CartesianGrid3D{T}, ::Val{:x}) where {T} = @inbounds grid.axes[1]
+@inline getproperty(grid::CartesianGrid3D{T}, ::Val{:y}) where {T} = @inbounds grid.axes[2]
+@inline getproperty(grid::CartesianGrid3D{T}, ::Val{:z}) where {T} = @inbounds grid.axes[3]
 
 @inline getindex(grid::CylindricalGrid{T}, ::Val{:r}) where {T} = @inbounds grid.axes[1]
 @inline getindex(grid::CylindricalGrid{T}, ::Val{:φ}) where {T} = @inbounds grid.axes[2]
 @inline getindex(grid::CylindricalGrid{T}, ::Val{:z}) where {T} = @inbounds grid.axes[3]
-@inline getindex(grid::CartesianGrid{T}, ::Val{:x}) where {T} = @inbounds grid.axes[1]
-@inline getindex(grid::CartesianGrid{T}, ::Val{:y}) where {T} = @inbounds grid.axes[2]
-@inline getindex(grid::CartesianGrid{T}, ::Val{:z}) where {T} = @inbounds grid.axes[3]
+@inline getindex(grid::CartesianGrid3D{T}, ::Val{:x}) where {T} = @inbounds grid.axes[1]
+@inline getindex(grid::CartesianGrid3D{T}, ::Val{:y}) where {T} = @inbounds grid.axes[2]
+@inline getindex(grid::CartesianGrid3D{T}, ::Val{:z}) where {T} = @inbounds grid.axes[3]
 
 function sizeof(grid::Grid{T, N, S}) where {T, N, S}
     return sum( sizeof.(grid.axes) )
@@ -162,9 +162,9 @@ function find_closest_gridpoint(pt::CartesianPoint{T}, grid::CylindricalGrid{T})
     find_closest_gridpoint(CylindricalPoint(pt),grid)
 end
 
-function find_closest_gridpoint(pt::CartesianPoint{T}, grid::CartesianGrid{T})::NTuple{3,Int} where {T <: SSDFloat}
+function find_closest_gridpoint(pt::CartesianPoint{T}, grid::CartesianGrid3D{T})::NTuple{3,Int} where {T <: SSDFloat}
     @inbounds return (searchsortednearest(grid.axes[1].ticks, pt.x), searchsortednearest(grid.axes[2].ticks, pt.y), searchsortednearest(grid.axes[3].ticks, pt.z))
 end
-function find_closest_gridpoint(pt::CylindricalPoint{T}, grid::CartesianGrid{T})::NTuple{3,Int} where {T <: SSDFloat}
+function find_closest_gridpoint(pt::CylindricalPoint{T}, grid::CartesianGrid3D{T})::NTuple{3,Int} where {T <: SSDFloat}
     find_closest_gridpoint(CartesianPoint(pt),grid)
 end

--- a/src/PlotRecipes/ElectricField.jl
+++ b/src/PlotRecipes/ElectricField.jl
@@ -5,7 +5,7 @@
                     contours_equal_potential=false,
                     full_det = false ) where {T}
 
-    grid::Grid{T, 3, Cylindrical} = ef.grid
+    grid::CylindricalGrid{T} = ef.grid
     ef_magn  = norm.(ef)
 
     seriescolor --> :inferno
@@ -25,7 +25,7 @@ end
                     z = missing,
                     contours_equal_potential = false) where {T <: SSDFloat}
 
-    grid::Grid{T, 3, Cartesian} = ef.grid
+    grid::CartesianGrid3D{T} = ef.grid
     ef_magn  = norm.(ef)
 
     seriescolor --> :inferno
@@ -38,7 +38,7 @@ end
     ElectricPotential(ef_magn, grid), cross_section, idx, value, contours_equal_potential
 end
 
-function get_sample_lines(dim_symbol::Symbol, v::T, grid::Grid{T,3,Cartesian}, sampling::T)::Vector{ConstructiveSolidGeometry.Line} where {T}
+function get_sample_lines(dim_symbol::Symbol, v::T, grid::CartesianGrid3D{T}, sampling::T)::Vector{ConstructiveSolidGeometry.Line} where {T}
     
     xrange = range(round.(endpoints(grid.x.interval)./sampling, (RoundDown, RoundUp)).*sampling..., step = sampling)
     yrange = range(round.(endpoints(grid.y.interval)./sampling, (RoundDown, RoundUp)).*sampling..., step = sampling)
@@ -64,7 +64,7 @@ function get_sample_lines(dim_symbol::Symbol, v::T, grid::Grid{T,3,Cartesian}, s
 end
 
 
-function get_sample_lines(dim_symbol::Symbol, v::T, grid::Grid{T,3,Cylindrical}, sampling::T)::Vector{ConstructiveSolidGeometry.Line} where {T}
+function get_sample_lines(dim_symbol::Symbol, v::T, grid::CylindricalGrid{T}, sampling::T)::Vector{ConstructiveSolidGeometry.Line} where {T}
     
     φsampling = 2π * sampling / (dim_symbol == :r ? v : grid.r.interval.right) # or use sampling together with the unit ?
     rrange = range(round.((-grid.r.interval.right,grid.r.interval.right)./sampling, (RoundDown, RoundUp)).*sampling..., step = sampling)

--- a/src/PlotRecipes/PotentialSimulationSetup.jl
+++ b/src/PlotRecipes/PotentialSimulationSetup.jl
@@ -3,7 +3,7 @@
                     φ = missing,
                     z = missing,
                     n_points_in_φ = 36 ) where {T}
-    grid::Grid{T, 3, Cylindrical} = pss.grid
+    grid::CylindricalGrid{T} = pss.grid
     layout --> (2, 2)
 
     cross_section::Symbol, idx::Int = if ismissing(φ) && ismissing(r) && ismissing(z)
@@ -64,7 +64,7 @@ end
                     x = missing,
                     y = missing,
                     z = missing ) where {T}
-    grid::Grid{T, 3, Cartesian} = pss.grid
+    grid::CartesianGrid3D{T} = pss.grid
     layout --> (2, 2)
 
     size --> (1000, 1000)

--- a/src/PlotRecipes/Potentials.jl
+++ b/src/PlotRecipes/Potentials.jl
@@ -1,4 +1,4 @@
-function get_crosssection_idx_and_value(grid::Grid{T, 3, Cylindrical}, r, φ, z)::Tuple{Symbol,Int,T} where {T <: SSDFloat}
+function get_crosssection_idx_and_value(grid::CylindricalGrid{T}, r, φ, z)::Tuple{Symbol,Int,T} where {T <: SSDFloat}
 
     cross_section::Symbol, idx::Int = if ismissing(φ) && ismissing(r) && ismissing(z)
         return get_crosssection_idx_and_value(grid, r, T(0.0), z)
@@ -37,7 +37,7 @@ end
 
     if !(epot.grid[2][end] - epot.grid[2][1] ≈ 2π) epot = get_2π_potential(epot, n_points_in_φ = 72) end
 
-    grid::Grid{T, 3, Cylindrical} = epot.grid
+    grid::CylindricalGrid{T} = epot.grid
     cross_section::Symbol, idx::Int, value::T = get_crosssection_idx_and_value(grid, r, φ, z)
 
     seriescolor --> :viridis
@@ -53,7 +53,7 @@ end
         wpot = get_2π_potential(wpot, n_points_in_φ = 72)
     end
 
-    grid::Grid{T, 3, Cylindrical} = wpot.grid
+    grid::CylindricalGrid{T} = wpot.grid
     cross_section::Symbol, idx::Int, value::T = get_crosssection_idx_and_value(grid, r, φ, z)
 
     seriescolor --> :viridis
@@ -70,7 +70,7 @@ end
         ρ = get_2π_potential(ρ, n_points_in_φ = 72)
     end
 
-    grid::Grid{T, 3, Cylindrical} = ρ.grid
+    grid::CylindricalGrid{T} = ρ.grid
     cross_section::Symbol, idx::Int, value::T = get_crosssection_idx_and_value(grid, r, φ, z)
 
     seriescolor --> :inferno
@@ -85,7 +85,7 @@ end
         point_types = get_2π_potential(point_types, n_points_in_φ = 72)
     end
 
-    grid::Grid{T, 3, Cylindrical} = point_types.grid
+    grid::CylindricalGrid{T} = point_types.grid
     cross_section::Symbol, idx::Int, value::T = get_crosssection_idx_and_value(grid, r, φ, z)
 
     seriescolor --> :viridis
@@ -96,7 +96,7 @@ end
 end
 
 @recipe function f(sp::ScalarPotential{T,3,Cylindrical}, cross_section::Symbol, idx::Int, value::T, contours_equal_potential::Bool = false, full_det::Bool = false) where {T <: SSDFloat}
-    grid::Grid{T, 3, Cylindrical} = sp.grid
+    grid::CylindricalGrid{T} = sp.grid
     @series begin
         seriestype := :heatmap
         foreground_color_border --> nothing
@@ -168,7 +168,7 @@ end
 
 @recipe function f(ϵ::DielectricDistribution{T,3,Cylindrical}; φ = 0) where {T <: SSDFloat}
 
-    grid::Grid{T, 3, Cylindrical} = ϵ.grid
+    grid::CylindricalGrid{T} = ϵ.grid
     cross_section::Symbol, idx::Int, value::T = get_crosssection_idx_and_value(grid, missing, φ, missing)
 
     seriestype --> :heatmap
@@ -203,7 +203,7 @@ end
 
 
 
-function get_crosssection_idx_and_value(grid::Grid{T, 3, Cartesian}, x, y, z)::Tuple{Symbol,Int,T} where {T <: SSDFloat}
+function get_crosssection_idx_and_value(grid::CartesianGrid3D{T}, x, y, z)::Tuple{Symbol,Int,T} where {T <: SSDFloat}
 
     cross_section::Symbol, idx::Int = if ismissing(x) && ismissing(y) && ismissing(z)
         return get_crosssection_idx_and_value(grid, T(0.0), y, z)
@@ -221,7 +221,7 @@ function get_crosssection_idx_and_value(grid::Grid{T, 3, Cartesian}, x, y, z)::T
 end
 
 @recipe function f(epot::ElectricPotential{T,3,Cartesian}; x = missing, y = missing, z = missing, contours_equal_potential = false) where {T <: SSDFloat}
-    grid::Grid{T, 3, Cartesian} = epot.grid
+    grid::CartesianGrid3D{T} = epot.grid
     cross_section::Symbol, idx::Int, value::T = get_crosssection_idx_and_value(grid, x, y, z)
 
     seriescolor --> :viridis
@@ -232,7 +232,7 @@ end
 
 @recipe function f(wpot::WeightingPotential{T,3,Cartesian}; x = missing, y = missing, z = missing, contours_equal_potential = false) where {T <: SSDFloat}
 
-    grid::Grid{T, 3, Cartesian} = wpot.grid
+    grid::CartesianGrid3D{T} = wpot.grid
     cross_section::Symbol, idx::Int, value::T = get_crosssection_idx_and_value(grid, x, y, z)
 
     seriescolor --> :viridis
@@ -244,7 +244,7 @@ end
 
 
 @recipe function f(ρ::EffectiveChargeDensity{T,3,Cartesian}; x = missing, y = missing, z = missing) where {T <: SSDFloat}
-    grid::Grid{T, 3, Cartesian} = ρ.grid
+    grid::CartesianGrid3D{T} = ρ.grid
     cross_section::Symbol, idx::Int, value::T = get_crosssection_idx_and_value(grid, x, y, z)
 
     seriescolor --> :inferno
@@ -256,7 +256,7 @@ end
 
 @recipe function f(point_types::PointTypes{T,3,Cartesian}; x = missing, y = missing, z = missing) where {T <: SSDFloat}
 
-    grid::Grid{T, 3, Cartesian} = point_types.grid
+    grid::CartesianGrid3D{T} = point_types.grid
     cross_section::Symbol, idx::Int, value::T = get_crosssection_idx_and_value(grid, x, y, z)
 
     seriescolor --> :viridis
@@ -268,7 +268,7 @@ end
 
 
 @recipe function f(sp::ScalarPotential{T,3,Cartesian}, cross_section::Symbol, idx::Int, value::T, contours_equal_potential::Bool = false) where {T <: SSDFloat}
-    grid::Grid{T, 3, Cartesian} = sp.grid
+    grid::CartesianGrid3D{T} = sp.grid
     @series begin
         seriestype := :heatmap
         foreground_color_border --> nothing
@@ -340,7 +340,7 @@ end
 
 @recipe function f(ϵ::DielectricDistribution{T,3,Cartesian}; x = missing, y = missing, z = missing) where {T <: SSDFloat}
 
-    grid::Grid{T, 3, Cartesian} = ϵ.grid
+    grid::CartesianGrid3D{T} = ϵ.grid
     cross_section::Symbol, idx::Int, value::T = get_crosssection_idx_and_value(grid, x, y, z)
 
     seriestype --> :heatmap

--- a/src/PotentialSimulation/Painting/Painting.jl
+++ b/src/PotentialSimulation/Painting/Painting.jl
@@ -30,12 +30,12 @@ function get_sub_ind_ranges(a::Union{
     t_idx_range_ax1, t_idx_range_ax2, t_idx_range_ax3
 end
 
-get_sub_ind_ranges(p::ConstructiveSolidGeometry.AbstractSurfacePrimitive{T}, grid::CartesianGrid{T}) where {N,T} = 
+get_sub_ind_ranges(p::ConstructiveSolidGeometry.AbstractSurfacePrimitive{T}, grid::CartesianGrid3D{T}) where {N,T} = 
     get_sub_ind_ranges((ConstructiveSolidGeometry.extreme_points(p), TicksTuple(grid)))
 get_sub_ind_ranges(p::ConstructiveSolidGeometry.AbstractSurfacePrimitive{T}, grid::CylindricalGrid{T}) where {N,T} = 
     get_sub_ind_ranges((CylindricalPoint.(ConstructiveSolidGeometry.extreme_points(p)), TicksTuple(grid)))
 
-function paint!(point_types, potential, face::AbstractSurfacePrimitive{T}, geometry, pot_value, grid::CartesianGrid) where {T}
+function paint!(point_types, potential, face::AbstractSurfacePrimitive{T}, geometry, pot_value, grid::CartesianGrid3D{T}) where {T}
     t_idx_r1, t_idx_r2, t_idx_r3 = get_sub_ind_ranges(face, grid)
     ticks = (grid.axes[1].ticks, grid.axes[2].ticks, grid.axes[3].ticks)
     eX = CartesianVector{T}(1,0,0);

--- a/src/PotentialSimulation/PotentialSimulationSetups/PotentialSimulationSetupRBCartesian3D.jl
+++ b/src/PotentialSimulation/PotentialSimulationSetups/PotentialSimulationSetupRBCartesian3D.jl
@@ -64,7 +64,7 @@ function set_point_types_and_fixed_potentials!(point_types::Array{PointType, N},
 end
 
 
-function PotentialSimulationSetupRB(det::SolidStateDetector{T}, grid::Grid{T, 3, Cartesian}, medium::NamedTuple = material_properties[materials["vacuum"]],
+function PotentialSimulationSetupRB(det::SolidStateDetector{T}, grid::CartesianGrid3D{T}, medium::NamedTuple = material_properties[materials["vacuum"]],
                 potential_array::Union{Missing, Array{T, 3}} = missing; weighting_potential_contact_id::Union{Missing, Int} = missing,
                 sor_consts::T = T(1), not_only_paint_contacts::Bool = true, paint_contacts::Bool = true ) where {T}#::PotentialSimulationSetupRB{T} where {T}
                 is_weighting_potential::Bool = !ismissing(weighting_potential_contact_id)

--- a/src/PotentialSimulation/PotentialSimulationSetups/PotentialSimulationSetupRBCartesian3D.jl
+++ b/src/PotentialSimulation/PotentialSimulationSetups/PotentialSimulationSetupRBCartesian3D.jl
@@ -17,7 +17,7 @@ function set_point_types_and_fixed_potentials!(point_types::Array{PointType, N},
 
                 if !ismissing(det.passives)
                     for passive in det.passives
-                        if passive.potential != :floating
+                        if !isnan(passive.potential)
                             if pt in passive
                                 potential[ ix, iy, iz ] = if ismissing(weighting_potential_contact_id)
                                     passive.potential

--- a/src/PotentialSimulation/PotentialSimulationSetups/PotentialSimulationSetupRBCylindrical.jl
+++ b/src/PotentialSimulation/PotentialSimulationSetups/PotentialSimulationSetupRBCylindrical.jl
@@ -17,7 +17,7 @@ function set_point_types_and_fixed_potentials!(point_types::Array{PointType, N},
 
                 if !ismissing(det.passives)
                     for passive in det.passives
-                        if passive.potential != :floating
+                        if !isnan(passive.potential)
                             if pt in passive
                                 potential[ ir, iφ, iz ] = if ismissing(weighting_potential_contact_id)
                                     passive.potential

--- a/src/PotentialSimulation/PotentialSimulationSetups/PotentialSimulationSetupRBCylindrical.jl
+++ b/src/PotentialSimulation/PotentialSimulationSetups/PotentialSimulationSetupRBCylindrical.jl
@@ -64,7 +64,7 @@ function set_point_types_and_fixed_potentials!(point_types::Array{PointType, N},
 end
 
 
-function PotentialSimulationSetupRB(det::SolidStateDetector{T}, grid::Grid{T, 3, Cylindrical}, medium::NamedTuple = material_properties[materials["vacuum"]],
+function PotentialSimulationSetupRB(det::SolidStateDetector{T}, grid::CylindricalGrid{T}, medium::NamedTuple = material_properties[materials["vacuum"]],
                 potential_array::Union{Missing, Array{T, 3}} = missing; sor_consts = (1.0, 1.0),
                 weighting_potential_contact_id::Union{Missing, Int} = missing,
                 not_only_paint_contacts::Bool = true, paint_contacts::Bool = true)::PotentialSimulationSetupRB{T} where {T}

--- a/src/PotentialSimulation/RedBlack/RedBlack.jl
+++ b/src/PotentialSimulation/RedBlack/RedBlack.jl
@@ -106,11 +106,11 @@ end
 
 
 # """
-#     RBExtBy2Array( et::Type, grid::Grid{T, 3, Cartesian} )::Array{et, 4} where {T}
+#     RBExtBy2Array( et::Type, grid::CartesianGrid3D{T} )::Array{et, 4} where {T}
 # 
 # Returns a RedBlack array for the `grid`. The RedBlack array is extended in its size by 2 in each geometrical dimension.
 # """
-function RBExtBy2Array( et::Type, grid::Grid{T, 3, Cartesian} )::Array{et, 4} where {T}
+function RBExtBy2Array( et::Type, grid::CartesianGrid3D{T} )::Array{et, 4} where {T}
     nx, ny, nz = size(grid)
     return zeros(T, div(nx, 2) + mod(nx, 2) + 2, ny + 2, nz + 2, 2)
 end

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -210,7 +210,7 @@ The grid initialization can be tuned using a set of keyword arguments listed bel
     Additional grid ticks will be added if two neighbouring ticks are too far apart.
     `max_tick_distance` can either be a `Quantity`, e.g. `1u"mm"`, or a Tuple of `Quantity`, 
     e.g. `(1u"mm", 15u"°", 3u"mm")`,
-    to set it for each axis of the `Grid` separately. Note that a `CartesianGrid` requires a 
+    to set it for each axis of the `Grid` separately. Note that a `CartesianGrid3D` requires a 
     `Tuple{LengthQuantity, LengthQuantity, LengthQuantity}` while a `CylindricalGrid` requires a
     `Tuple{LengthQuantity, AngleQuantity, LengthQuantity}`.
     If `max_tick_distance` is `missing`, one fourth of the axis length is used.

--- a/src/SolidStateDetector/Passive.jl
+++ b/src/SolidStateDetector/Passive.jl
@@ -19,6 +19,7 @@ profile that has an influence on the [`ElectricPotential`](@ref).
 * `name::String`: Custom name for the passive, relevant for plotting.
 * `id::Int`: Unique id that will unambiguously identify the passive.
 * `potential::T`: Potential (in V) to which the passive will be fixed during the calculation of the electric potential.
+    For floating passives, the `potential` value is `NaN`.
 * `temperature::T`: Temperature (in K) of the passive.
 * `material::MT`: Material of the passive.
 * `charge_density_model::CDM`: Charge density model for the points inside the passive.
@@ -48,17 +49,19 @@ passives:
 mutable struct Passive{T,G,MT,CDM} <: AbstractPassive{T}
     name::String
     id::Int
-    potential::T
+    potential::T # NaN is floating
     temperature::T
     material::MT
     charge_density_model::CDM
     geometry::G
 end
 
-function Passive{T}(dict::Dict, input_units::NamedTuple, outer_transformations) where T <: SSDFloat
-    name = haskey(dict, "name") ? dict["name"] : "external part"
+const POTENTIAL_FLOATING = NaN
+
+function Passive{T}(dict::Dict, input_units::NamedTuple, outer_transformations) where {T <: SSDFloat}
+    name = haskey(dict, "name") ? dict["name"] : "External part"
     id::Int = haskey(dict, "id") ? dict["id"] : -1
-    potential = haskey(dict, "potential") ? T(dict["potential"]) : :floating
+    potential = haskey(dict, "potential") ? T(dict["potential"]) : T(POTENTIAL_FLOATING)
     material = material_properties[materials[dict["material"]]]
     temperature = haskey(dict, "temperature") ? T(dict["temperature"]) : T(293)
     charge_density_model = if haskey(dict, "charge_density") 
@@ -81,10 +84,10 @@ function Passive{T}(dict::Dict, input_units::NamedTuple, outer_transformations) 
 end
 
 function println(io::IO, d::Passive{T}) where {T}
-    println("\t________"*"Passive{$T} $(d.name) $(d.id)"*"________\n")
+    println("\t________"*"$(d.name)"*"________\n")
     println("\t---General Properties---")
-    println("\t-Potential: \t\t $(d.potential) V")
-    println("\t-Material: \t $(d.material.name)")
+    println("\t-Potential: \t\t " * (isnan(d.potential) ? "floating" :  "$(d.potential) V"))
+    println("\t-Material:  \t\t $(d.material.name)")
     println()
 end
 print(io::IO, d::Passive{T}) where {T} = print(io, "Passive $(d.name) - id $(d.id) - $(d.potential) V")


### PR DESCRIPTION
Two fixes:
- The `Cone` IO was adapted to the cases that are implemented (previously radii of type `Tuple{T, Tuple{T,T}}` were possible if the radii at the top were identical. However, this is not implemented as special case yet)
- Floating passives had a `floating` potential that is not compatible with the type `T <: SSDFloat`. Thus, `:floating` was changed to `NaN`. I added a small entry to the docstring.

For consistency: 
- Change the name of `Grid{T,3,...}` to `CartesianGrid3D{T}` or `CylindricalGrid{T}` everywhere possible.