### PR TITLE
Speed-up in set `point_types`

### DIFF
--- a/src/PotentialSimulation/PotentialSimulationSetups/PotentialSimulationSetupRBCartesian3D.jl
+++ b/src/PotentialSimulation/PotentialSimulationSetups/PotentialSimulationSetupRBCartesian3D.jl
@@ -29,7 +29,7 @@ function set_point_types_and_fixed_potentials!(point_types::Array{PointType, N},
                         end
                     end
                 end
-                if in(pt, det)
+                if in(pt, det.semiconductor)
                     point_types[ ix, iy, iz ] += pn_junction_bit
                 end
                 if NotOnlyPaintContacts

--- a/src/PotentialSimulation/PotentialSimulationSetups/PotentialSimulationSetupRBCylindrical.jl
+++ b/src/PotentialSimulation/PotentialSimulationSetups/PotentialSimulationSetupRBCylindrical.jl
@@ -29,7 +29,7 @@ function set_point_types_and_fixed_potentials!(point_types::Array{PointType, N},
                         end
                     end
                 end
-                if in(pt, det)
+                if in(pt, det.semiconductor)
                     point_types[ ir, iφ, iz ] += pn_junction_bit
                 end
                 if NotOnlyPaintContacts


### PR DESCRIPTION
We do not need to check whether a point is in any contact here. 