### PR TITLE
New experimental feature: Calculation of weighting potentials for undepleted detectors

### DIFF
--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -977,6 +977,10 @@ There are several keyword arguments which can be used to tune the calculation.
         If the ratio is too large, additional ticks are generated such that the new ratios are smaller than `max_distance_ratio`.
         Default is `5`.
 * `grid::Grid`: Initial grid used to start the simulation. Default is `Grid(sim)`.
+* `depletion_handling::Bool`: Enables the handling of undepleted regions. Default is `false`. This is an experimental feature:
+    In undepleted regions (determined in `calculate_electric_potential!(sim; depletion_handling = true)`), the dielectric permittivity
+    of the semiconductor is scaled up to mimic conductive behavior. The scale factor can be tuned via 
+    the function [`scaling_factor_for_permittivity_in_undepleted_region`](@ref).
 * `use_nthreads::Union{Int, Vector{Int}}`: If `<:Int`, `use_nthreads` defines the maximum number of threads to be used in the computation. 
     Fewer threads might be used depending on the current grid size due to threading overhead. Default is `Base.Threads.nthreads()`.
     If `<:Vector{Int}`, `use_nthreads[i]` defines the number of threads used for each grid (refinement) stage of the field simulation.

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -622,7 +622,10 @@ There are several keyword arguments which can be used to tune the simulation.
 * `n_iterations_between_checks::Int`: Number of iterations between checks. Default is set to `500`.
 * `max_n_iterations::Int`: Set the maximum number of iterations which are performed after each grid refinement.
     Default is `-1`. If set to `-1` there will be no limit.
-* `depletion_handling::Bool`: Enables the handling of undepleted regions. Default is `false`.
+* `depletion_handling::Bool`: Enables the handling of undepleted regions. Default is `false`. This is an experimental feature:
+    In undepleted regions (determined in `calculate_electric_potential!(sim; depletion_handling = true)`), the dielectric permittivity
+    of the semiconductor is scaled up to mimic conductive behavior. The scale factor can be tuned via 
+    the function [`scaling_factor_for_permittivity_in_undepleted_region`](@ref).
 * `use_nthreads::Int`: Number of threads to use in the computation. Default is `Base.Threads.nthreads()`.
     The environment variable `JULIA_NUM_THREADS` must be set appropriately before the Julia session was
     started (e.g. `export JULIA_NUM_THREADS=8` in case of bash).

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -483,10 +483,10 @@ apply_initial_state!(sim, WeightingPotential, 1) # =>  applies initial state for
 ```
 """
 function apply_initial_state!(sim::Simulation{T}, ::Type{WeightingPotential}, contact_id::Int, grid::Grid{T} = Grid(sim);
-        not_only_paint_contacts::Bool = true, paint_contacts::Bool = true)::Nothing where {T <: SSDFloat}
+        not_only_paint_contacts::Bool = true, paint_contacts::Bool = true, depletion_handling::Bool = false)::Nothing where {T <: SSDFloat}
     pssrb::PotentialSimulationSetupRB{T, 3, 4, get_coordinate_system(sim)} =
         PotentialSimulationSetupRB(sim.detector, grid, sim.medium, weighting_potential_contact_id = contact_id; 
-            not_only_paint_contacts, paint_contacts);
+            not_only_paint_contacts, paint_contacts, point_types = sim.point_types);
 
     sim.weighting_potentials[contact_id] = WeightingPotential(ElectricPotentialArray(pssrb), grid)
     nothing
@@ -667,7 +667,7 @@ function update_till_convergence!( sim::Simulation{T, CS},
     pssrb = PotentialSimulationSetupRB(sim.detector, sim.weighting_potentials[contact_id].grid, sim.medium, sim.weighting_potentials[contact_id].data,
                 sor_consts = T.(sor_consts), weighting_potential_contact_id = contact_id, 
                 use_nthreads = _guess_optimal_number_of_threads_for_SOR(size(sim.weighting_potentials[contact_id].grid), Base.Threads.nthreads(), CS),    
-                not_only_paint_contacts = not_only_paint_contacts, paint_contacts = paint_contacts)
+                not_only_paint_contacts = not_only_paint_contacts, paint_contacts = paint_contacts, point_types = sim.point_types)
 
     cf::T = _update_till_convergence!( pssrb, T(convergence_limit);
                                        only2d = Val{only_2d}(),
@@ -870,7 +870,7 @@ function _calculate_potential!( sim::Simulation{T, CS}, potential_type::UnionAll
         end
     end
     if isEP
-        apply_initial_state!(sim, potential_type, grid, not_only_paint_contacts = not_only_paint_contacts, paint_contacts = paint_contacts)
+        apply_initial_state!(sim, potential_type, grid; not_only_paint_contacts, paint_contacts)
         update_till_convergence!( sim, potential_type, convergence_limit,
                                   n_iterations_between_checks = n_iterations_between_checks,
                                   max_n_iterations = max_n_iterations,
@@ -878,7 +878,7 @@ function _calculate_potential!( sim::Simulation{T, CS}, potential_type::UnionAll
                                   use_nthreads = guess_nt ? _guess_optimal_number_of_threads_for_SOR(size(sim.electric_potential.grid), max_nthreads[1], CS) : max_nthreads[1],
                                   sor_consts = sor_consts )
     else
-        apply_initial_state!(sim, potential_type, contact_id, grid, not_only_paint_contacts = not_only_paint_contacts, paint_contacts = paint_contacts)
+        apply_initial_state!(sim, potential_type, contact_id, grid; not_only_paint_contacts, paint_contacts, depletion_handling)
         update_till_convergence!( sim, potential_type, contact_id, convergence_limit,
                                     n_iterations_between_checks = n_iterations_between_checks,
                                     max_n_iterations = max_n_iterations,

--- a/src/SolidStateDetector/Semiconductor.jl
+++ b/src/SolidStateDetector/Semiconductor.jl
@@ -107,6 +107,7 @@ a very high value should be returned in order to mimic perfect conductivity if t
 
 !!! danger "Experimental feature!"
     This feature is under research. The goal is to study the properties / signal response of undepleted detector. 
+    This function is indented to be overwritten by the user to study the response. 
 """
 function scaling_factor_for_permittivity_in_undepleted_region(sc::Semiconductor{T})::T where {T}
     100000

--- a/src/SolidStateDetector/Semiconductor.jl
+++ b/src/SolidStateDetector/Semiconductor.jl
@@ -93,3 +93,22 @@ end
 function Semiconductor(sc::Semiconductor{T,G,MT,CDM,IDM}, chargedriftmodel::AbstractChargeDriftModel{T}) where {T,G,MT,CDM,IDM}
     Semiconductor(sc.temperature, sc.material, sc.impurity_density_model, chargedriftmodel, sc.geometry)
 end
+
+"""
+    scaling_factor_for_permittivity_in_undepleted_region(sc::Semiconductor{T})::T where {T}
+
+This function is called in the calculations of weighting potentials of undepleted detectors. 
+The electric permittivity, ``ϵ_{r}``, is scaled with this function in areas where the detector is undepleted.
+A value between `[0, +Inf]` should be returned. However, `Inf` should not be returned but instead
+a very high value should be returned in order to mimic perfect conductivity if that is desired. 
+
+## Arguments
+* `sc::Semiconductor{T}`: Semiconductor for which the dielectric permittivity should be scaled up.
+
+!!! danger "Experimental feature!"
+    This feature is under research. The goal is to study the properties / signal response of undepleted detector. 
+"""
+function scaling_factor_for_permittivity_in_undepleted_region(sc::Semiconductor{T})::T where {T}
+    100000
+end
+

--- a/src/Types/point_types.jl
+++ b/src/Types/point_types.jl
@@ -25,6 +25,7 @@ const undepleted_bit  = 0x02 # parse(UInt8, "00000010", base=2) # 0 -> depleted 
 const pn_junction_bit = 0x04 # parse(UInt8, "00001000", base=2) # 0 -> point is not inside a bubble; 1 -> point is inside a bubble
 
 is_pn_junction_point_type(p::PointType) = p & pn_junction_bit > 0
+is_undepleted_point_type(p::PointType) = p & undepleted_bit > 0
 """
     struct PointTypes{T, N, S, AT} <: AbstractArray{T, N}
         


### PR DESCRIPTION
In `calculate_weighting_potential!(sim, contact_id)` the keyword `depletion_handling::Bool` is now actually used.
If `depletion_handling == true` the possible undepleted region of the detector (`sim.point_types`) is used
in the application of the boundary conditions. 

The dielectric permittivity is scaled by a factor in undepleted regions. 
The factor is defined in the function `scaling_factor_for_permittivity_in_undepleted_region(::Semiconductor)`.
So the scaling can be overwritten by overwriting this internal function. 

Here, some example cases for three different scaling factors:

The upper one for an scaling factor of 1 (no scaling):

![eps_1](https://user-images.githubusercontent.com/16963906/132241096-7c7e8090-5d68-4b08-8198-ee5fe4330c77.png)

The second one for an scaling factor of 100:

![eps_100](https://user-images.githubusercontent.com/16963906/132240860-f34beff2-f493-4f2d-a08b-e4132b1e0995.png)


The last one for an scaling factor of 100000 which basically mimics perfect conductivity:

![eps_100000](https://user-images.githubusercontent.com/16963906/132240870-ebebef56-83de-4d4c-bd53-c965e4dc671a.png)