### PR TITLE
Mesh Plotting

### DIFF
--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/ConeMantle.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/ConeMantle.jl
@@ -7,7 +7,7 @@ Surface primitive describing the mantle of a [`Cone`](@ref).
 * `T`: Precision type.
 * `TR`: Type of the radius `r`.
     * `TR == T`: CylinderMantle (constant radius `r` at all `z`).
-    * `TR == Tuple{T, T}`: VaryingCylinderMantle (inner radius at `r[1]`, outer radius at `r[2]`).
+    * `TR == Tuple{T, T}`: VaryingCylinderMantle (bottom radius at `r[1]`, top radius at `r[2]`).
 * `TP`: Type of the angular range `φ`.
     * `TP == Nothing`: Full 2π Cone.
     * `TP == Tuple{T, T}`: Partial Cone ranging from `φ[1]` to `φ[2]`.
@@ -33,6 +33,12 @@ end
 radius_at_z(hZ::T, rBot::T, rTop::T, z::T) where {T} = iszero(hZ) ? rBot : rBot + (hZ+z)*(rTop - rBot)/(2hZ) 
 radius_at_z(cm::ConeMantle{T,T}, z::T) where {T} = cm.r
 radius_at_z(cm::ConeMantle{T,Tuple{T,T}}, z::T) where {T} = radius_at_z(cm.hZ, cm.r[1], cm.r[2], z)
+
+get_r_limits(cm::ConeMantle{T,T}) where {T} = cm.r, cm.r
+get_r_limits(cm::ConeMantle{T,Tuple{T,T}}) where {T} = cm.r[1], cm.r[2]
+
+get_φ_limits(cm::ConeMantle{T,<:Any,Tuple{T,T}}) where {T} = cm.φ[1], cm.φ[2]
+get_φ_limits(cm::ConeMantle{T,<:Any,Nothing}) where {T} = T(0), T(2π)
 
 function normal(cm::ConeMantle{T,T}, pt::CartesianPoint{T}) where {T}
     pto = _transform_into_object_coordinate_system(pt, cm)

--- a/src/ConstructiveSolidGeometry/plotting/Meshing.jl
+++ b/src/ConstructiveSolidGeometry/plotting/Meshing.jl
@@ -1,5 +1,5 @@
 """
-    struct Mesh{T, N}
+    struct Mesh{T}
 
 * `x`: X-coordinate mesh in meters
 * `y`: Y-coordinate mesh in meters
@@ -8,17 +8,16 @@
 (X[i,j], Y[i,j], Z[i,j]) is a cartesian point
 """
 
-struct Mesh{T, N}
-    x::Array{T,N}
-    y::Array{T,N}
-    z::Array{T,N}
-    function Mesh(
-        x::Array{T,N},
-        y::Array{T,N},
-        z::Array{T,N}) where {T,N}
-        @assert size(x) == size(y) && size(x) == size(z)
-        new{T,N}(x, y, z)
-    end
+struct Mesh{T}
+    x::Array{T,2}
+    y::Array{T,2}
+    z::Array{T,2}
+end
+
+struct PolyMesh{T,N}
+    x::Vector{SVector{N,T}}
+    y::Vector{SVector{N,T}}
+    z::Vector{SVector{N,T}}
 end
 
 function get_cartesian_point_from_mesh(m::Mesh{T}, index::Tuple{I,I}) where {T, I<:Int}
@@ -28,26 +27,69 @@ end
 
 size(m::Mesh{T}) where {T} = size(m.x)
 
-function get_plot_meshes(v::AbstractVolumePrimitive{T}; n = 30) where {T <: AbstractFloat}
-  surfaces = get_decomposed_surfaces(v)
-  meshes = Mesh{T}[]
-  for surf in surfaces
-      push!(meshes, mesh(surf; n = n))
-  end
-  meshes
+function rotate(mesh::Mesh{T}, R::AbstractMatrix)::Mesh{T} where {T}
+    n, m = size(mesh)
+    X = zero(mesh.x)
+    Y = zero(mesh.y)
+    Z = zero(mesh.z)
+    for i in 1:n
+        for j in 1:m
+            v = get_cartesian_point_from_mesh(mesh, (i,j))
+            v = R*v
+            X[i,j], Y[i,j], Z[i,j] = v[1], v[2], v[3]
+        end
+    end
+    Mesh{T}(X,Y,Z)
+end
+(*)(R::AbstractMatrix, mesh::Mesh{T}) where {T} = rotate(mesh, R)
+
+translate(mesh::Mesh{T}, t::CartesianPoint) where {T} =
+    Mesh{T}(mesh.x .+ t.x, mesh.y .+ t.y, mesh.z .+ t.z)
+(+)(mesh::Mesh, t::CartesianPoint) = translate(mesh,t)
+
+function polymesh(mesh::Mesh{T})::PolyMesh{T,4} where {T}
+    #mesh = RotXY(0.0000001,0.0000001) * mesh
+    n, m = size(mesh)
+    x = [reshape(mesh.x[i:i+1,j:j+1], 4) for i in 1:n-1, j in 1:m-1]
+    y = [reshape(mesh.y[i:i+1,j:j+1], 4) for i in 1:n-1, j in 1:m-1]
+    z = [reshape(mesh.z[i:i+1,j:j+1], 4) for i in 1:n-1, j in 1:m-1]
+    dim = (n-1)*(m-1)
+    PolyMesh{T,4}(reshape(x,dim), reshape(y,dim), reshape(z,dim))
 end
 
-function get_plot_meshes(s::AbstractSurfacePrimitive{T}; n = 30) where {T <: AbstractFloat}
-  meshes = Mesh{T}[]
-  push!(meshes, mesh(s; n = n))
-  meshes
+#=
+function gr_mesh_patch!(x::Vector{Vector{T}}, y::Vector{Vector{T}}, z::Vector{Vector{T}}) where {T}
+    for i in 1:length(x)
+        append!(x[i], sum(x[i])/4)
+        append!(y[i], sum(y[i])/4)
+        append!(z[i], sum(z[i])/4)
+    end
+end
+=#
+
+@recipe function f(m::PolyMesh{T,4}) where {T} #only supported in gr()
+    seriestype := :mesh3d
+    colorbar := false
+    seriescolor --> 1
+    seriesalpha --> 0.5
+    connections := ([1,0],[0,2],[3,3])
+    @series begin
+        m.x[1], m.y[1], m.z[1]
+    end
+    for i in 2:length(m.x)
+        @series begin
+            label := nothing
+            m.x[i], m.y[i], m.z[i]
+        end
+    end
 end
 
 @recipe function f(m::Mesh{T}) where {T}
     seriestype := :surface
+    colorbar := false
     linewidth --> 0.1
     linecolor --> :white
-    seriescolor --> :blue
-    colorbar := false
+    seriescolor --> [1,1]
+    seriesalpha --> 0.5
     m.x, m.y, m.z
 end

--- a/src/ConstructiveSolidGeometry/plotting/SurfacePrimitives/ConeMantle.jl
+++ b/src/ConstructiveSolidGeometry/plotting/SurfacePrimitives/ConeMantle.jl
@@ -1,17 +1,52 @@
-@recipe function f(cm::ConeMantle, n = 40; subn = 10)
-    ls = lines(cm)
-    linecolor --> :black
-    @series begin
-        label --> "Cone Mantle"
-        ls[1]
+function mesh(cm::ConeMantle{T}; n = 30)::Mesh{T} where {T}
+    rbot, rtop = get_r_limits(cm)
+    φMin, φMax = get_φ_limits(cm)
+    
+    f = (φMax - φMin)/(2π)
+    n = Int(ceil(n*f))
+    φ = range(φMin, φMax, length = n+1)
+    z = range(-cm.hZ, cm.hZ, length = 2)
+
+    X::Array{T,2} = [radius_at_z(cm,z[j])*cos(φ_i) for φ_i in φ, j in 1:length(z)]
+    Y::Array{T,2} = [radius_at_z(cm,z[j])*sin(φ_i) for φ_i in φ, j in 1:length(z)]
+    Z::Array{T,2} = [j for i in 1:length(φ), j in z]
+    if cm.rotation != one(SMatrix{3, 3, T, 9})
+        cm.rotation*Mesh{T}(X,Y,Z) + cm.origin
+    else
+        Mesh{T}(X,Y,Z) + cm.origin
     end
-    for i in 2:length(ls)
+end
+
+@recipe function f(cm::ConeMantle, n = 40; subn = 10)
+    colorbar := false
+    if haskey(plotattributes, :seriestype) && plotattributes[:seriestype] == :surface
+            m = mesh(cm, n = n)
+            if occursin("GRBackend", string(typeof(plotattributes[:plot_object].backend)))
+                @series begin
+                    label --> "Cone Mantle"
+                    polymesh(m)
+                end
+            else
+                @series begin
+                    label --> "Cone Mantle"
+                    m
+                end
+            end
+    else
+        ls = lines(cm)
+        linecolor --> :black
         @series begin
-            label := nothing
-            ls[i]
+            label --> "Cone Mantle"
+            ls[1]
+        end
+        for i in 2:length(ls)
+            @series begin
+                label := nothing
+                ls[i]
+            end
         end
     end
-     if !haskey(plotattributes, :show_normal) || plotattributes[:show_normal]
+    if !haskey(plotattributes, :show_normal) || plotattributes[:show_normal]
         @series begin
             label := nothing
             seriestype := :vector

--- a/src/ConstructiveSolidGeometry/plotting/plotting.jl
+++ b/src/ConstructiveSolidGeometry/plotting/plotting.jl
@@ -3,7 +3,7 @@ include("LinePrimitives/LinePrimitives.jl")
 include("SurfacePrimitives/SurfacePrimitives.jl")
 include("VolumePrimitives/VolumePrimitives.jl")
 
-# include("Meshing.jl")
+include("Meshing.jl")
 
 # include("Wireframe.jl")
 


### PR DESCRIPTION
Added mesh plotting for ConeMantle. Supported in pyplot() and gr(). Note that the only way to do this in gr() is using `st = :mesh3d` which is "experimental". Previously `st = :surface` was able to properly color the face of a triangle in gr(), now it needs 5 or more points to work, and no longer respects the boundaries set by the points.  Therefore `:mesh3d` must be used. For consistency when `surface()` or equivalently `plot(; st = :surface)` is called, pyplot() uses `:surface` and gr() uses `:mesh3d` to produce a visually equivalent result. The experimental `:mesh3d` gives the warning (directly from GR, not from SSD) `GR: mesh3d is experimental (no face colors)` for each element in the series.  As stated, there are no face colors yet, and therefore it will look like a dense wireframe for now.

To achieve the desired plot `mesh(cm::ConeMantle{T})` is called. This will return a `Mesh{T}`. A plot recipe for `Mesh` is provided. Its fields are 3 matrices, which pyplot() `:surface` takes as input. 
With, gr() this does not work. So we turn to `:mesh3d`. However, `:mesh3d` takes arrays as inputs: a list of points just like `:path3d`. The keyword `connections` is used to tell how these points assemble into triangles (whose faces will be filled - someday). The function `polymesh` is provided to turn a `Mesh{T}` into a `PolyMesh{T,4}` whose fields are arrays of 4 points. `Mesh{T}` naturally deconstructs  into quadrangels instead of triangles and therefore `PolyMesh{T,4}` is used. In the future `PolyMesh{T,3}` will be useful for other meshes which deconstruct more naturally into triangles.

3 examples follow
```
T = Float64
cylindermantle = CSG.ConeMantle{T,Tuple{T,T},Nothing,:outwards}((1,1),nothing,1,CartesianPoint{T}(0,0,0),RotX(0))
conemantle_tranformed = CSG.ConeMantle{T,Tuple{T,T},Nothing,:outwards}((1,2),nothing,1,CartesianPoint{T}(1,0,0),RotY(π/2))
conemantle_partial = CSG.ConeMantle{T,Tuple{T,T},Tuple{T,T},:outwards}((3,2),(0,3π/2),1,CartesianPoint{T}(0,0,0),RotX(0))
```
`pyplot(); surface(cylindermantle)`
![Screen Shot 2021-09-16 at 5 59 47 PM](https://user-images.githubusercontent.com/41748838/133646162-22b16227-3aa1-4236-822c-dd60a0b2e491.png)

`gr(); surface(cylindermantle)`
![Screen Shot 2021-09-16 at 6 01 11 PM](https://user-images.githubusercontent.com/41748838/133646183-b7240aad-4b3e-4ba7-b459-5e912ae61052.png)

`pyplot(); surface(conemantle_tranformed)`
![Screen Shot 2021-09-16 at 6 00 30 PM](https://user-images.githubusercontent.com/41748838/133646221-b520f337-7acd-40ad-b409-31356fecb141.png)

`gr(); surface(conemantle_tranformed)`
![Screen Shot 2021-09-16 at 6 01 34 PM](https://user-images.githubusercontent.com/41748838/133646256-a45f96ae-7aa5-44ef-bcdf-0ab1382dbeda.png)

`pyplot(); surface(conemantle_partial)`
![Screen Shot 2021-09-16 at 6 08 08 PM](https://user-images.githubusercontent.com/41748838/133647083-12e77c72-e958-4b0c-abc5-2de58a462a91.png)
`gr(); surface(conemantle_partial)`
![Screen Shot 2021-09-16 at 6 01 57 PM](https://user-images.githubusercontent.com/41748838/133647124-207f0e8c-43ec-4d2b-9e5f-f5c2d129899f.png)


