### PR TITLE
Consistency in unit handling of plotting electric field lines

### DIFF
--- a/src/PlotRecipes/ElectricField.jl
+++ b/src/PlotRecipes/ElectricField.jl
@@ -119,7 +119,7 @@ end
         dim_number = findfirst(x -> !ismissing(x), dim_array)
         dim_symbol = dim_symbols_array[dim_number]
         vtmp = dim_array[dim_number]
-        units = vtmp isa Real ? (dim_symbol == :φ ? internal_angle_unit : internal_length_unit) : unit(vtmp)
+        units = vtmp isa Real ? (dim_symbol == :φ ? u"°" : internal_length_unit) : unit(vtmp)
         v = T(to_internal_units(dim_symbol == :φ && φ isa Real ? deg2rad(vtmp) : vtmp))
     else
         throw(ArgumentError("Only one keyword for a certain dimension is allowed. Please choose one of "*


### PR DESCRIPTION
When plotting electric field lines, unitless values for `φ` are given units of degree, but displayed in units of radians in the title.

Example:
```julia
plot(sim.electric_field, full_det = true, φ = 30)
```
![efield](https://user-images.githubusercontent.com/30291312/137566190-bdfefc0b-209b-4f23-a52b-6ae00637afac.png)

```
plot_electric_fieldlines!(sim, full_det = true, φ = 30)
```
![efield_lines](https://user-images.githubusercontent.com/30291312/137566194-be732e52-ae8d-4a50-a78b-224736246177.png)


Even though this is not wrong, it is more consistent to keep the units in the title in degree by default.
I guess that this PR, if approved, can be merged without a merge commit.
