### PR TITLE
WIP: wireframe via mesh

### DIFF
--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/ConeMantle.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/ConeMantle.jl
@@ -75,6 +75,11 @@ function connections(cm::ConeMantle, n_arc::Int64)::Vector{Vector{Int64}}
     n_arc = _get_n_points_in_arc_φ(cm, n_arc)
     [[i,i+1,i+n_arc+2,i+n_arc+1] for i in 1:n_arc]
 end
+function mesh_edges(cm::ConeMantle, n_arc::Int64, n_vert_lines::Int64)::Vector{Vector{Int64}} 
+    n_arc = _get_n_points_in_arc_φ(cm, n_arc)
+    edges = n_vert_lines == 0 ? [] : [[i, i + n_arc + 1] for i in Int.(floor.(range(1, n_arc+1, length = n_vert_lines+1)))]
+    append!(edges, [collect(1:n_arc+1), collect(n_arc+2:2(n_arc+1))])
+end
 
 const FullConeMantle{T,D} = ConeMantle{T,Tuple{T,T},Nothing,D} # ugly name but works for now, should just be `ConeMantle`...
 const PartialConeMantle{T,D} = ConeMantle{T,Tuple{T,T},Tuple{T,T},D}

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/EllipticalSurface.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/EllipticalSurface.jl
@@ -61,6 +61,18 @@ function connections(es::EllipticalSurface{T, Tuple{T,T}}, n_arc::Int64)::Vector
     [[i,i+1,i+n_arc+2,i+n_arc+1] for i in 1:n_arc]
 end
 
+function mesh_edges(es::EllipticalSurface{T, T}, n_arc::Int64,n_vert_lines::Int64)::Vector{Vector{Int64}} where {T}
+    n_arc = _get_n_points_in_arc_φ(es, n_arc)
+    edges = n_vert_lines == 0 ? [] : [[1, i + 1] for i in Int.(floor.(range(1, n_arc+1, length = n_vert_lines+1)))]
+    append!(edges, [collect(2:n_arc+2)])
+end
+
+function mesh_edges(es::EllipticalSurface{T, Tuple{T,T}}, n_arc::Int64,n_vert_lines::Int64)::Vector{Vector{Int64}} where {T}
+    n_arc = _get_n_points_in_arc_φ(es, n_arc)
+    edges = n_vert_lines == 0 ? [] : [[i, i + n_arc + 1] for i in Int.(floor.(range(1, n_arc+1, length = n_vert_lines+1)))]
+    append!(edges, [collect(1:n_arc+1), collect(n_arc+2:2(n_arc+1))])
+end
+
 extremum(es::EllipticalSurface{T,T}) where {T} = es.r
 extremum(es::EllipticalSurface{T,Tuple{T,T}}) where {T} = es.r[2] # r_out always larger r_in: es.r[2] > es.r[2]
 

--- a/src/ConstructiveSolidGeometry/plotting/Meshing.jl
+++ b/src/ConstructiveSolidGeometry/plotting/Meshing.jl
@@ -13,25 +13,48 @@ struct Mesh{T}
     y::Vector{T}
     z::Vector{T}
     connections::Vector{Vector{Int64}} 
+    edges::Vector{Vector{Int64}}
 end
 
-function mesh(p::AbstractSurfacePrimitive{T}; n_arc = 40)::Mesh{T} where {T}
+function mesh(p::AbstractSurfacePrimitive{T}; n_arc = 40, n_vert_lines = 2)::Mesh{T} where {T}
     vs = vertices(p, n_arc)
     x, y, z = broadcast(i -> getindex.(vs, i), (1,2,3))
     c = connections(p, n_arc)
-    Mesh{T}(x,y,z,c)
+    e = mesh_edges(p, n_arc, n_vert_lines)
+    Mesh{T}(x,y,z,c,e)
 end
 
-
-@recipe function f(m::Mesh{T}) where {T}
-    seriestype := :mesh3d
-    linewidth --> 0.75
-    linecolor --> :white
-    seriescolor --> 1
-    seriesalpha --> 0.5
-    connections := m.connections
+@recipe function f(m::Mesh{T}; edgewidth = 0) where {T}
+    seriestype --> :mesh3d
     xguide --> "x"
     yguide --> "y"
     zguide --> "z"
-    m.x*internal_length_unit, m.y*internal_length_unit, m.z*internal_length_unit
+    unitformat --> :slash
+    if haskey(plotattributes, :seriestype) && plotattributes[:seriestype] == :mesh3d   
+        @series begin
+            if occursin("GRBackend", string(typeof(plotattributes[:plot_object].backend)))
+                linewidth --> 0.75
+            else
+                linewidth --> 0.1
+            end
+            linecolor --> :white
+            seriescolor --> 1
+            seriesalpha --> 0.5
+            connections := m.connections
+            m.x*internal_length_unit, m.y*internal_length_unit, m.z*internal_length_unit
+        end
+    end
+    if edgewidth != 0 || (haskey(plotattributes, :seriestype) && plotattributes[:seriestype] == :path)
+        @series begin
+            label := ""
+            seriescolor --> :black
+            if haskey(plotattributes, :seriestype) && plotattributes[:seriestype] == :path
+                linewidth --> 1
+            else
+                linewidth := edgewidth
+            end
+            seriestype := :path
+            [m.x[e]*internal_length_unit for e in m.edges], [m.y[e]*internal_length_unit for e in m.edges], [m.z[e]*internal_length_unit for e in m.edges]
+        end
+    end
 end

--- a/src/ConstructiveSolidGeometry/plotting/SurfacePrimitives/ConeMantle.jl
+++ b/src/ConstructiveSolidGeometry/plotting/SurfacePrimitives/ConeMantle.jl
@@ -1,23 +1,8 @@
-@recipe function f(cm::ConeMantle; n_arc = 40, subn = 10)
+@recipe function f(cm::ConeMantle; n_arc = 40, subn = 10, n_vert_lines = 2)
     seriestype --> :mesh3d
-    if haskey(plotattributes, :seriestype) && plotattributes[:seriestype] == :mesh3d
-        @series begin
-            label --> "Cone Mantle"
-            mesh(cm, n_arc = n_arc)
-        end
-    else
-        ls = lines(cm)
-        linecolor --> :black
-        @series begin
-            label --> "Cone Mantle"
-            ls[1]
-        end
-        for i in 2:length(ls)
-            @series begin
-                label := nothing
-                ls[i]
-            end
-        end
+    @series begin
+        label --> "Cone Mantle"
+        mesh(cm, n_arc = n_arc, n_vert_lines = n_vert_lines)
     end
     if haskey(plotattributes, :show_normal) && plotattributes[:show_normal]
         @series begin

--- a/src/ConstructiveSolidGeometry/plotting/SurfacePrimitives/EllipticalSurface.jl
+++ b/src/ConstructiveSolidGeometry/plotting/SurfacePrimitives/EllipticalSurface.jl
@@ -1,25 +1,8 @@
-@recipe function f(es::EllipticalSurface; n_arc = 40)
+@recipe function f(es::EllipticalSurface; n_arc = 40, n_vert_lines = 2)
     seriestype --> :mesh3d
-    if haskey(plotattributes, :seriestype) && plotattributes[:seriestype] == :mesh3d
-        @series begin
-            label --> "Elliptical Surface"
-            mesh(es, n_arc = n_arc)
-        end
-    else
-        ls = lines(es)
-        linecolor --> :black
-        @series begin
-            label --> "Elliptical Surface"
-            ls[1]
-        end
-        if length(ls) > 1 
-            for i in 2:length(ls)
-                @series begin 
-                    label := nothing
-                    ls[i]
-                end
-            end
-        end
+    @series begin
+        label --> "Elliptical Surface"
+        mesh(es, n_arc = n_arc, n_vert_lines = n_vert_lines)
     end
     if haskey(plotattributes, :show_normal) && plotattributes[:show_normal]
         @series begin

--- a/src/PlotRecipes/SolidStateDetector.jl
+++ b/src/PlotRecipes/SolidStateDetector.jl
@@ -10,12 +10,19 @@ end
     sc.geometry
 end
 
-@recipe function f(contact::Contact)
+@recipe function f(contact::Contact{T}) where {T}
     linecolor --> contact.id
     fillcolor --> contact.id
     fillalpha --> 0.2
     l = contact.name != "" ? "$(contact.name) (id: $(contact.id))" : "Contact - id: $(contact.id)"
-    label --> l
+    @series begin
+        #add empty line so that label is shown with alpha = 1
+        seriestype := :path
+        label --> l
+        linewidth := 1
+        T[], T[]
+    end 
+    label := ""
     contact.geometry
 end
 


### PR DESCRIPTION
Implementation of wireframe via `Mesh` struct. New wireframe accepts `n_vert_lines` and is ~75 times faster for this example detector (3s --> 35 ms). 
Information necessary for wireframe is stored in `Mesh` as `edges`. For this the function `mesh_edges(s::SurfacePrimitive)` is needed. Currently only written for `ConeMantle` and `EllipticalSurface`
## Mesh Only
`plot(sim.detector)` btime ~10ms
![Screen Shot 2021-10-18 at 6 31 21 PM](https://user-images.githubusercontent.com/41748838/137773764-0e039299-0ea7-4fc4-ba76-9eb19b3df599.png)

## Wireframe Only
`plot(sim.detector, st = :path, linewidth = 5)` btime ~35ms
`linewidth` controls linewidths of the wireframe. Default set to 1.
![Screen Shot 2021-10-18 at 6 32 04 PM](https://user-images.githubusercontent.com/41748838/137773826-5d3db31b-dfbd-4155-9b49-edfb78dd9270.png)

## Both Mesh and Wireframe
`plot(sim.detector, linewidth = 0, edgewidth = 1)` btime ~45ms
equivalent to `plot(sim.detector, linewidth = 0, edgewidth = 1, n_vert_lines = 2)`
`linewidth` controls linewidths of the mesh and `edgewidth` controls the linewidth of the wireframe. Wireframe is only plotted if `edgewidth != 0 (default is edgewidth = 0)` 
![Screen Shot 2021-10-18 at 6 49 16 PM](https://user-images.githubusercontent.com/41748838/137774247-4c6fdf9c-3104-4ed1-9675-61b18237e32f.png)

### Other Changes

- Fixed labels being too transparent with mesh. This is done at the contact level by blotting empty arrays.
- Default linewidth is now backend dependent for mesh. 0.75 was too high for pyplot (looked good with gr).