### PR TITLE
Fix code loading via Require.jl for GPU

### DIFF
--- a/src/PotentialSimulation/ConvergenceGPU.jl
+++ b/src/PotentialSimulation/ConvergenceGPU.jl
@@ -31,8 +31,7 @@ function _update_till_convergence!( pssrb::PotentialSimulationSetupRB{T, S, 3},
     return 0
 end                
 
-get_device(DAT::Type{<:GPUArrays.AbstractGPUArray}) = DAT <: CUDAKernels.CUDA.CuArray ? CUDADevice() : ROCDevice() # This function is supposed to be replaced by KernelAbstractions.get_device
-
-
 get_sor_kernel(::Type{Cylindrical}, args...) = sor_cyl_gpu!(args...)
 get_sor_kernel(::Type{Cartesian},   args...) = sor_car_gpu!(args...)
+
+function get_device end

--- a/src/SolidStateDetectors.jl
+++ b/src/SolidStateDetectors.jl
@@ -92,6 +92,7 @@ include("ChargeDriftModels/ChargeDriftModels.jl")
 include("SolidStateDetector/DetectorGeometries.jl")
 
 include("PotentialSimulation/PotentialSimulation.jl")
+include("PotentialSimulation/ConvergenceGPU.jl")
 
 include("ElectricField/ElectricField.jl")
 
@@ -120,20 +121,12 @@ function __init__()
         end
         include("MCEventsProcessing/MCEventsProcessing_hdf5.jl")
     end
-    CUDA_loaded = false
-    #     @require CUDA="052768ef-5323-5732-b1bb-66c8b64840ba" begin
     @require CUDAKernels="72cfdca4-0801-4ab0-bf6a-d52aa10adc57" begin
-        using .CUDAKernels
-        CUDA_loaded = true
-        include("PotentialSimulation/ConvergenceGPU.jl")
+        get_device(::Type{CUDAKernels.CUDA.CuArray}) = CUDAKernels.CUDADevice()
     end
-    if !CUDA_loaded
-        @require ROCKernels="7eb9e9f0-4bd3-4c4c-8bef-26bd9629d9b9" begin
-            using .ROCKernels
-            include("PotentialSimulation/ConvergenceGPU.jl")
-        end
+    @require ROCKernels="7eb9e9f0-4bd3-4c4c-8bef-26bd9629d9b9" begin
+        get_device(::Type{ROCKernels.AMDGPU.ROCArray}) = CUDAKernels.ROCDevice()
     end
 end
-include("PotentialSimulation/ConvergenceGPU.jl")
 
 end # module


### PR DESCRIPTION
Line 137 was duplicated and should not have been loaded (without `CUDAKernels` or `ROCKernels` being present). 
This is fixed now. 