### PR TITLE
Introduce support for partial Torus (not full `2π` in `φ` and `θ`)

### DIFF
--- a/examples/example_config_files/public_ppc_config_SigGen.config
+++ b/examples/example_config_files/public_ppc_config_SigGen.config
@@ -12,7 +12,7 @@ top_bullet_radius    0   # bulletization radius at top of crystal
 bottom_bullet_radius 0   # bulletization radius at bottom of BEGe crystal
 pc_length            2   # point contact length
 pc_radius            3   # point contact radius
-bulletize_PC         0   # point contact hemispherical rather than cylindrical
+bulletize_PC         1   # point contact hemispherical rather than cylindrical
 wrap_around_radius  15   # wrap-around radius. Set to zero for ORTEC
 ditch_depth          0   # depth of ditch next to wrap-around for BEGes. Set to zero for ORTEC
 ditch_thickness      0   # width of ditch next to wrap-around for BEGes. Set to zero for ORTEC

--- a/src/ConstructiveSolidGeometry/Intervals.jl
+++ b/src/ConstructiveSolidGeometry/Intervals.jl
@@ -1,8 +1,10 @@
 @inline _linear_endpoints(z::Real) = (-z, z)
 @inline _linear_endpoints(z::AbstractInterval) = endpoints(z)
+@inline _linear_endpoints(r::Tuple{T,T}) where {T} = r
 
 @inline _radial_endpoints(r::T) where {T <: Real} = (zero(T), r)
 @inline _radial_endpoints(r::AbstractInterval) = endpoints(r)
+@inline _radial_endpoints(r::Tuple{T,T}) where {T} = r
 
 @inline _in_angular_interval_closed(α::Real, α_int::Nothing, tol::Real = 0) = true
 @inline _in_angular_interval_closed(α::Real, α_int::AbstractInterval{T}, tol::Real = 0) where {T} = mod(α - (α_int.left-tol), T(2π)) ≤ (α_int.right+tol) - (α_int.left-tol)

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/EllipticalSurface.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/EllipticalSurface.jl
@@ -26,6 +26,11 @@ Surface primitive describing circular bases, e.g. the top or bottom base of a [`
     rotation::SMatrix{3,3,T,9} = one(SMatrix{3, 3, T, 9})
 end
 
+flip(es::EllipticalSurface{T,TR,Nothing}) where {T,TR} = 
+    EllipticalSurface{T,TR,Nothing}(es.r, es.φ, es.origin, es.rotation * SMatrix{3,3,T,9}(1,0,0,0,-1,0,0,0,-1))
+flip(es::EllipticalSurface{T,TR,Tuple{T,T}}) where {T,TR} = 
+    EllipticalSurface{T,TR,Tuple{T,T}}(es.r, (2π-es.φ[2], 2π-es.φ[1]), es.origin, es.rotation * SMatrix{3,3,T,9}(1,0,0,0,-1,0,0,0,-1))
+
 const CircularArea{T} = EllipticalSurface{T,T,Nothing}
 const PartialCircularArea{T} = EllipticalSurface{T,T,Tuple{T,T}}
 

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/SurfacePrimitives.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/SurfacePrimitives.jl
@@ -12,15 +12,15 @@ include("TorusMantle.jl")
 # but the normal method is generally called with a point.
 normal(p::AbstractPlanarSurfacePrimitive, ::AbstractCoordinatePoint) = normal(p)
 
-function _get_n_points_in_arc_φ(p::AbstractSurfacePrimitive, n_arc::Int64)::Int64
+function _get_n_points_in_arc_φ(p::AbstractSurfacePrimitive{T}, n_arc::Int64)::Int64 where {T}
     φMin, φMax = get_φ_limits(p)
-    f = (φMax - φMin)/(2π)
+    f = (φMax - φMin)/T(2π)
     Int(ceil(n_arc*f))
 end
 
-function _get_n_points_in_arc_θ(p::AbstractSurfacePrimitive, n_arc::Int64)::Int64
+function _get_n_points_in_arc_θ(p::AbstractSurfacePrimitive{T}, n_arc::Int64)::Int64 where {T}
     θMin, θMax = get_θ_limits(p)
-    f = (θMax - θMin)/(2π)
+    f = (θMax - θMin)/T(2π)
     Int(ceil(n_arc*f))
 end
 

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/TorusMantle.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/TorusMantle.jl
@@ -92,21 +92,22 @@ const FullTorusMantle{T,D} = TorusMantle{T,Nothing,Nothing,D}
 const FullPhiTorusMantle{T,D} = TorusMantle{T,Nothing,Tuple{T,T},D}
 const FullThetaTorusMantle{T,D} = TorusMantle{T,Tuple{T,T},Nothing,D}
 
-function lines(tm::FullTorusMantle{T}) where {T} 
+function lines(tm::TorusMantle{T,TP,TT}) where {T,TP,TT}
     top_circ_origin = CartesianPoint{T}(zero(T), zero(T),  tm.r_tube)
     top_circ_origin = _transform_into_global_coordinate_system(top_circ_origin, tm)
-    top_circ = Circle{T}(r = tm.r_torus, origin = top_circ_origin, rotation = tm.rotation)
+    top_circ = Ellipse{T,T,TP}(r = tm.r_torus, φ = tm.φ, origin = top_circ_origin, rotation = tm.rotation)
     bot_circ_origin = CartesianPoint{T}(zero(T), zero(T), -tm.r_tube)
     bot_circ_origin = _transform_into_global_coordinate_system(bot_circ_origin, tm)
-    bot_circ = Circle{T}(r = tm.r_torus, origin = bot_circ_origin, rotation = tm.rotation)
-    inner_circ = Circle{T}(r = tm.r_torus - tm.r_tube, origin = tm.origin, rotation = tm.rotation)
-    outer_circ = Circle{T}(r = tm.r_torus + tm.r_tube, origin = tm.origin, rotation = tm.rotation)
-    tube_circ_1_origin = CartesianPoint{T}(tm.r_torus, zero(T), zero(T))
+    bot_circ = Ellipse{T,T,TP}(r = tm.r_torus, φ = tm.φ, origin = bot_circ_origin, rotation = tm.rotation)
+    inner_circ = Ellipse{T,T,TP}(r = tm.r_torus - tm.r_tube, φ = tm.φ, origin = tm.origin, rotation = tm.rotation)
+    outer_circ = Ellipse{T,T,TP}(r = tm.r_torus + tm.r_tube, φ = tm.φ, origin = tm.origin, rotation = tm.rotation)
+    φmin::T, φmax::T = isnothing(tm.φ) ? (0, π) : get_φ_limits(tm)
+    tube_circ_1_origin = CartesianPoint(CylindricalPoint{T}(tm.r_torus, φmin, zero(T)))
     tube_circ_1_origin = _transform_into_global_coordinate_system(tube_circ_1_origin, tm)
-    tube_circ_1 = Circle{T}(r = tm.r_tube, origin = tube_circ_1_origin, rotation = tm.rotation * RotX(T(π)/2))
-    tube_circ_2_origin = CartesianPoint{T}(-tm.r_torus, zero(T), zero(T))
+    tube_circ_1 = Ellipse{T,T,TT}(r = tm.r_tube, φ = tm.θ, origin = tube_circ_1_origin, rotation = tm.rotation * RotZ(φmin) *RotX(T(π)/2))
+    tube_circ_2_origin = CartesianPoint(CylindricalPoint{T}(tm.r_torus, φmax, zero(T)))
     tube_circ_2_origin = _transform_into_global_coordinate_system(tube_circ_2_origin, tm)
-    tube_circ_2 = Circle{T}(r = tm.r_tube, origin = tube_circ_2_origin, rotation = tm.rotation * RotX(T(π)/2))
+    tube_circ_2 = Ellipse{T,T,TT}(r = tm.r_tube, φ = tm.θ, origin = tube_circ_2_origin, rotation = tm.rotation * RotZ(φmax) * RotX(T(π)/2))
     (bot_circ, outer_circ, top_circ, inner_circ, tube_circ_1, tube_circ_2)
 end 
 

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/TorusMantle.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/TorusMantle.jl
@@ -164,9 +164,14 @@ function intersection(tm::TorusMantle{T}, l::Line{T}) where {T}
     return pts
 end
 
-TorusThetaSurface(r::TR, φ::TP, hZ::T, origin::CartesianPoint{T}, rotation::SMatrix{3,3,T,9}, ::Val{:flat}) where {T,TR,TP} = EllipticalSurface{T,TR,TP}(r,φ,origin,rotation)
-TorusThetaSurface(r::TR, φ::TP, hZ::T, origin::CartesianPoint{T}, rotation::SMatrix{3,3,T,9}, ::Val{:inwards}) where {T,TR,TP} = ConeMantle{T,TR,TP,:inwards}(r,φ,hZ,origin,rotation)
-TorusThetaSurface(r::TR, φ::TP, hZ::T, origin::CartesianPoint{T}, rotation::SMatrix{3,3,T,9}, ::Val{:outwards}) where {T,TR,TP} = ConeMantle{T,TR,TP,:outwards}(r,φ,hZ,origin,rotation)
+# These function compose cross sections of Tori at constant θ and ensure that the height is always positive
+TorusThetaSurface(r::T, φ::TP, hZ::T, origin::CartesianPoint{T}, rotation::SMatrix{3,3,T,9}, ::Val{:flat}) where {T,TP} = EllipticalSurface{T,T,TP}(r,φ,origin,rotation)
+TorusThetaSurface(r::T, φ::TP, hZ::T, origin::CartesianPoint{T}, rotation::SMatrix{3,3,T,9}, ::Val{:inwards}) where {T,TP} = ConeMantle{T,T,TP,:inwards}(r,φ,abs(hZ),origin,rotation)
+TorusThetaSurface(r::T, φ::TP, hZ::T, origin::CartesianPoint{T}, rotation::SMatrix{3,3,T,9}, ::Val{:outwards}) where {T,TP} = ConeMantle{T,T,TP,:outwards}(r,φ,abs(hZ),origin,rotation)
+TorusThetaSurface(r::Tuple{T,T}, φ::TP, hZ::T, origin::CartesianPoint{T}, rotation::SMatrix{3,3,T,9}, ::Val{:flat}) where {T,TP} = EllipticalSurface{T,Tuple{T,T},TP}(ordered(r),φ,origin,rotation)
+TorusThetaSurface(r::Tuple{T,T}, φ::TP, hZ::T, origin::CartesianPoint{T}, rotation::SMatrix{3,3,T,9}, ::Val{:inwards}) where {T,TP} = ConeMantle{T,Tuple{T,T},TP,:inwards}(hZ < 0 ? reverse(r) : r, φ, abs(hZ), origin, rotation)
+TorusThetaSurface(r::Tuple{T,T}, φ::TP, hZ::T, origin::CartesianPoint{T}, rotation::SMatrix{3,3,T,9}, ::Val{:outwards}) where {T,TP} = ConeMantle{T,Tuple{T,T},TP,:outwards}(hZ < 0 ? reverse(r) : r, φ, abs(hZ), origin, rotation)
+
 
 # """
 #     roots_of_4th_order_polynomial(a::T, b::T, c::T, d::T, e::T)

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/TorusMantle.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/TorusMantle.jl
@@ -164,6 +164,9 @@ function intersection(tm::TorusMantle{T}, l::Line{T}) where {T}
     return pts
 end
 
+TorusThetaSurface(r::TR, φ::TP, hZ::T, origin::CartesianPoint{T}, rotation::SMatrix{3,3,T,9}, ::Val{:flat}) where {T,TR,TP} = EllipticalSurface{T,TR,TP}(r,φ,origin,rotation)
+TorusThetaSurface(r::TR, φ::TP, hZ::T, origin::CartesianPoint{T}, rotation::SMatrix{3,3,T,9}, ::Val{:inwards}) where {T,TR,TP} = ConeMantle{T,TR,TP,:inwards}(r,φ,hZ,origin,rotation)
+TorusThetaSurface(r::TR, φ::TP, hZ::T, origin::CartesianPoint{T}, rotation::SMatrix{3,3,T,9}, ::Val{:outwards}) where {T,TR,TP} = ConeMantle{T,TR,TP,:outwards}(r,φ,hZ,origin,rotation)
 
 # """
 #     roots_of_4th_order_polynomial(a::T, b::T, c::T, d::T, e::T)

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/TorusMantle.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/TorusMantle.jl
@@ -113,10 +113,10 @@ end
 extremum(tm::TorusMantle{T}) where {T} = tm.r_torus + tm.r_tube
 
 
-function _in(pt::CartesianPoint{T}, t::TorusMantle{T}; csgtol::T = csg_default_tol(T)) where {T}
-    return (isnothing(t.φ) || _in_angular_interval_closed(atan(pt.y, pt.x), t.φ, csgtol = csgtol)) &&
-           (isnothing(t.θ) || _in_angular_interval_closed(atan(pt.z, hypot(pt.x, pt.y) - t.r_torus), t.θ, csgtol = csgtol))
-end
+# function _in(pt::CartesianPoint{T}, t::TorusMantle{T}; csgtol::T = csg_default_tol(T)) where {T}
+#     return (isnothing(t.φ) || _in_angular_interval_closed(atan(pt.y, pt.x), t.φ, csgtol = csgtol)) &&
+#            (isnothing(t.θ) || _in_angular_interval_closed(atan(pt.z, hypot(pt.x, pt.y) - t.r_torus), t.θ, csgtol = csgtol))
+# end
 
 """
     intersection(tm::TorusMantle{T}, l::Line{T}) where {T}
@@ -158,10 +158,10 @@ function intersection(tm::TorusMantle{T}, l::Line{T}) where {T}
 
 	# λ1, λ2, λ3, λ4 = roots_of_4th_order_polynomial(a, b, c, d) # That does not work for all combinations of a, b, c, d...
 	# fallback to Polynomials.jl, which is slower... We should improve `roots_of_4th_order_polynomial`... 
-    pts = broadcast(λ -> _transform_into_global_coordinate_system(obj_l.origin + λ * obj_l.direction, tm), 
+    return broadcast(λ -> _transform_into_global_coordinate_system(obj_l.origin + λ * obj_l.direction, tm), 
         real.(Polynomials.roots(Polynomial((d, c, b, a, one(T))))))
-    pts[.!in.(pts, Ref(tm))] .= Ref(CartesianPoint{T}(NaN,NaN,NaN)) # for Partial Tori: discard all intersection points that are not part of the Torus
-    return pts
+    # pts[.!in.(pts, Ref(tm))] .= Ref(CartesianPoint{T}(NaN,NaN,NaN)) # for Partial Tori: discard all intersection points that are not part of the Torus
+    # return pts
 end
 
 # These function compose cross sections of Tori at constant θ and ensure that the height is always positive

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/TorusMantle.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/TorusMantle.jl
@@ -112,6 +112,12 @@ end
 
 extremum(tm::TorusMantle{T}) where {T} = tm.r_torus + tm.r_tube
 
+
+function _in(pt::CartesianPoint{T}, t::TorusMantle{T}; csgtol::T = csg_default_tol(T)) where {T}
+    return (isnothing(t.φ) || _in_angular_interval_closed(atan(pt.y, pt.x), t.φ, csgtol = csgtol)) &&
+           (isnothing(t.θ) || _in_angular_interval_closed(atan(pt.z, hypot(pt.x, pt.y) - t.r_torus), t.θ, csgtol = csgtol))
+end
+
 """
     intersection(tm::TorusMantle{T}, l::Line{T}) where {T}
 
@@ -152,8 +158,10 @@ function intersection(tm::TorusMantle{T}, l::Line{T}) where {T}
 
 	# λ1, λ2, λ3, λ4 = roots_of_4th_order_polynomial(a, b, c, d) # That does not work for all combinations of a, b, c, d...
 	# fallback to Polynomials.jl, which is slower... We should improve `roots_of_4th_order_polynomial`... 
-    return broadcast(λ -> _transform_into_global_coordinate_system(obj_l.origin + λ * obj_l.direction, tm), 
+    pts = broadcast(λ -> _transform_into_global_coordinate_system(obj_l.origin + λ * obj_l.direction, tm), 
         real.(Polynomials.roots(Polynomial((d, c, b, a, one(T))))))
+    pts[.!in.(pts, Ref(tm))] .= Ref(CartesianPoint{T}(NaN,NaN,NaN)) # for Partial Tori: discard all intersection points that are not part of the Torus
+    return pts
 end
 
 

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/TorusMantle.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/TorusMantle.jl
@@ -7,9 +7,12 @@ Surface primitive describing the mantle of a [`Torus`](@ref).
 * `T`: Precision type.
 * `TP`: Type of the azimuthial angle `φ`.
     * `TP == Nothing`: Full 2π in `φ`.
+    * `TP == Tuple{T,T}`: Partial Torus Mantle ranging from `φ[1]` to `φ[2]`.
 * `TT`: Type of the polar angle `θ`.
     * `TT == Nothing`: Full 2π in `θ`.
+    * `TP == Tuple{T,T}`: Partial Torus Mantle ranging from `θ[1]` to `θ[2]`.
 * `D`: Direction in which the normal vector points (`:inwards` or `:outwards`).
+
     
 ## Fields
 * `r_torus::T`: Distance of the center of the `TorusMantle` to the center of the tube (in m).
@@ -86,6 +89,8 @@ end
 get_label_name(::TorusMantle) = "Torus Mantle"
 
 const FullTorusMantle{T,D} = TorusMantle{T,Nothing,Nothing,D}
+const FullPhiTorusMantle{T,D} = TorusMantle{T,Nothing,Tuple{T,T},D}
+const FullThetaTorusMantle{T,D} = TorusMantle{T,Tuple{T,T},Nothing,D}
 
 function lines(tm::FullTorusMantle{T}) where {T} 
     top_circ_origin = CartesianPoint{T}(zero(T), zero(T),  tm.r_tube)

--- a/src/ConstructiveSolidGeometry/VolumePrimitives/Torus.jl
+++ b/src/ConstructiveSolidGeometry/VolumePrimitives/Torus.jl
@@ -182,13 +182,17 @@ function surfaces(t::Torus{T,OpenPrimitive,T,Tuple{T,T},Tuple{T,T}}) where {T}
 end
 
 
-function _in(pt::CartesianPoint{T}, t::FullTorus{T,ClosedPrimitive}; csgtol::T = csg_default_tol(T)) where {T}
+function _in(pt::CartesianPoint{T}, t::Torus{T,ClosedPrimitive,T}; csgtol::T = csg_default_tol(T)) where {T}
     _r = hypot(hypot(pt.x, pt.y) - t.r_torus, pt.z)
-    return _r <= t.r_tube + csgtol
+    return _r <= t.r_tube + csgtol &&
+        (isnothing(t.φ) || _in_angular_interval_closed(atan(pt.y, pt.x), t.φ, csgtol = csgtol)) &&
+        (isnothing(t.θ) || _in_angular_interval_closed(atan(pt.z, hypot(pt.x, pt.y) - t.r_torus), t.θ, csgtol = csgtol))
 end
-function _in(pt::CartesianPoint{T}, t::FullTorus{T,OpenPrimitive}; csgtol::T = csg_default_tol(T)) where {T}
+function _in(pt::CartesianPoint{T}, t::Torus{T,OpenPrimitive,T}; csgtol::T = csg_default_tol(T)) where {T}
     _r = hypot(hypot(pt.x, pt.y) - t.r_torus, pt.z)
-    return _r < t.r_tube - csgtol
+    return _r < t.r_tube - csgtol &&
+        (isnothing(t.φ) || _in_angular_interval_closed(atan(pt.y, pt.x), t.φ, csgtol = csgtol)) &&
+        (isnothing(t.θ) || _in_angular_interval_closed(atan(pt.z, hypot(pt.x, pt.y) - t.r_torus), t.θ, csgtol = csgtol))
 end
 
 # #Constructors

--- a/src/ConstructiveSolidGeometry/VolumePrimitives/Torus.jl
+++ b/src/ConstructiveSolidGeometry/VolumePrimitives/Torus.jl
@@ -269,7 +269,7 @@ end
 function _in(pt::CartesianPoint{T}, t::Torus{T,OpenPrimitive}; csgtol::T = csg_default_tol(T)) where {T}
     _r = hypot(hypot(pt.x, pt.y) - t.r_torus, pt.z)
     rmin::T, rmax::T = _radial_endpoints(t.r_tube)
-    return r_min + csgtol < _r < t.r_tube - csgtol &&
+    return rmin + csgtol < _r < rmax - csgtol &&
         (isnothing(t.φ) || _in_angular_interval_open(atan(pt.y, pt.x), t.φ, csgtol = csgtol)) &&
         (isnothing(t.θ) || _in_angular_interval_open(atan(pt.z, hypot(pt.x, pt.y) - t.r_torus), t.θ, csgtol = csgtol))
 end

--- a/src/ConstructiveSolidGeometry/VolumePrimitives/Torus.jl
+++ b/src/ConstructiveSolidGeometry/VolumePrimitives/Torus.jl
@@ -154,22 +154,22 @@ end
 function surfaces(t::FullPhiTorus{T,OpenPrimitive,TT1,TT2}) where {T,TT1,TT2}
     tm = FullPhiTorusMantle{T,:outwards}(t.r_torus, t.r_tube, t.φ, t.θ, t.origin, t.rotation)
     θ1, θ2 = t.θ
-    cm1 = TorusThetaSurface((t.r_torus, t.r_torus + t.r_tube * cos(θ1)), t.φ, t.r_tube * sin(θ1)/2, t.origin + t.rotation * CartesianVector{T}(0,0,t.r_tube * sin(θ1)/2), t.rotation, Val{TT1}())
-    cm2 = TorusThetaSurface((t.r_torus, t.r_torus + t.r_tube * cos(θ2)), t.φ, t.r_tube * sin(θ2)/2, t.origin + t.rotation * CartesianVector{T}(0,0,t.r_tube * sin(θ2)/2), t.rotation, Val{TT2}())
+    cm1 = flip(TorusThetaSurface((t.r_torus, t.r_torus + t.r_tube * cos(θ1)), t.φ, t.r_tube * sin(θ1)/2, t.origin + t.rotation * CartesianVector{T}(0,0,t.r_tube * sin(θ1)/2), t.rotation, Val{TT1}()))
+    cm2 = flip(TorusThetaSurface((t.r_torus, t.r_torus + t.r_tube * cos(θ2)), t.φ, t.r_tube * sin(θ2)/2, t.origin + t.rotation * CartesianVector{T}(0,0,t.r_tube * sin(θ2)/2), t.rotation, Val{TT2}()))
     (tm, cm1, cm2)
 end
 function surfaces(t::FullThetaTorus{T,ClosedPrimitive}) where {T}
     tm = FullThetaTorusMantle{T,:inwards}(t.r_torus, t.r_tube, t.φ, t.θ, t.origin, t.rotation)
     φ1, φ2 = t.φ
     es1 = CircularArea{T}(t.r_tube, t.θ, t.origin + t.rotation * CartesianVector{T}(t.r_torus * cos(φ1), t.r_torus * sin(φ1), 0), t.rotation * RotZ(φ1) * RotX(-π/2) )
-    es2 = CircularArea{T}(t.r_tube, t.θ, t.origin + t.rotation * CartesianVector{T}(t.r_torus * cos(φ2), t.r_torus * sin(φ2), 0), t.rotation * RotZ(φ2) * RotX(-π/2) )
+    es2 = CircularArea{T}(t.r_tube, t.θ, t.origin + t.rotation * CartesianVector{T}(t.r_torus * cos(φ2), t.r_torus * sin(φ2), 0), t.rotation * RotZ(φ2) * RotX(π/2) )
     (tm, es1, es2)
 end
 function surfaces(t::FullThetaTorus{T,OpenPrimitive}) where {T}
     tm = FullThetaTorusMantle{T,:outwards}(t.r_torus, t.r_tube, t.φ, t.θ, t.origin, t.rotation)
     φ1, φ2 = t.φ
     es1 = CircularArea{T}(t.r_tube, t.θ, t.origin + t.rotation * CartesianVector{T}(t.r_torus * cos(φ1), t.r_torus * sin(φ1), 0), t.rotation * RotZ(φ1) * RotX(π/2) )
-    es2 = CircularArea{T}(t.r_tube, t.θ, t.origin + t.rotation * CartesianVector{T}(t.r_torus * cos(φ2), t.r_torus * sin(φ2), 0), t.rotation * RotZ(φ2) * RotX(π/2) )
+    es2 = CircularArea{T}(t.r_tube, t.θ, t.origin + t.rotation * CartesianVector{T}(t.r_torus * cos(φ2), t.r_torus * sin(φ2), 0), t.rotation * RotZ(φ2) * RotX(-π/2) )
     (tm, es1, es2)
 end
 function surfaces(t::Torus{T,ClosedPrimitive,T,Tuple{T,T},Tuple{T,T},TT1,TT2}) where {T,TT1,TT2}
@@ -178,18 +178,18 @@ function surfaces(t::Torus{T,ClosedPrimitive,T,Tuple{T,T},Tuple{T,T},TT1,TT2}) w
     cm1 = TorusThetaSurface((t.r_torus, t.r_torus + t.r_tube * cos(θ1)), t.φ, t.r_tube * sin(θ1)/2, t.origin + t.rotation * CartesianVector{T}(0,0,t.r_tube * sin(θ1)/2), t.rotation, Val{TT1}())
     cm2 = TorusThetaSurface((t.r_torus, t.r_torus + t.r_tube * cos(θ2)), t.φ, t.r_tube * sin(θ2)/2, t.origin + t.rotation * CartesianVector{T}(0,0,t.r_tube * sin(θ2)/2), t.rotation, Val{TT2}())
     φ1, φ2 = t.φ
-    es1 = PartialCircularArea{T}(t.r_tube, (2π-t.θ[2], 2π-t.θ[1]), t.origin + t.rotation * CartesianVector{T}(t.r_torus * cos(φ1), t.r_torus * sin(φ1), 0), t.rotation * RotZ(φ1) * RotX(-π/2) )
-    es2 = PartialCircularArea{T}(t.r_tube, (2π-t.θ[2], 2π-t.θ[1]), t.origin + t.rotation * CartesianVector{T}(t.r_torus * cos(φ2), t.r_torus * sin(φ2), 0), t.rotation * RotZ(φ2) * RotX(-π/2) )
+    es1 = flip(PartialCircularArea{T}(t.r_tube, t.θ, t.origin + t.rotation * CartesianVector{T}(t.r_torus * cos(φ1), t.r_torus * sin(φ1), 0), t.rotation * RotZ(φ1) * RotX(π/2)))
+    es2 = PartialCircularArea{T}(t.r_tube, t.θ, t.origin + t.rotation * CartesianVector{T}(t.r_torus * cos(φ2), t.r_torus * sin(φ2), 0), t.rotation * RotZ(φ2) * RotX(π/2))
     (tm, cm1, cm2, es1, es2)
 end
 function surfaces(t::Torus{T,OpenPrimitive,T,Tuple{T,T},Tuple{T,T},TT1,TT2}) where {T,TT1,TT2}
     tm = TorusMantle{T,Tuple{T,T},Tuple{T,T},:outwards}(t.r_torus, t.r_tube, t.φ, t.θ, t.origin, t.rotation)
     θ1, θ2 = t.θ
-    cm1 = TorusThetaSurface((t.r_torus, t.r_torus + t.r_tube * cos(θ1)), t.φ, t.r_tube * sin(θ1)/2, t.origin + t.rotation * CartesianVector{T}(0,0,t.r_tube * sin(θ1)/2), t.rotation, Val{TT1}())
-    cm2 = TorusThetaSurface((t.r_torus, t.r_torus + t.r_tube * cos(θ2)), t.φ, t.r_tube * sin(θ2)/2, t.origin + t.rotation * CartesianVector{T}(0,0,t.r_tube * sin(θ2)/2), t.rotation, Val{TT2}())
+    cm1 = flip(TorusThetaSurface((t.r_torus, t.r_torus + t.r_tube * cos(θ1)), t.φ, t.r_tube * sin(θ1)/2, t.origin + t.rotation * CartesianVector{T}(0,0,t.r_tube * sin(θ1)/2), t.rotation, Val{TT1}()))
+    cm2 = flip(TorusThetaSurface((t.r_torus, t.r_torus + t.r_tube * cos(θ2)), t.φ, t.r_tube * sin(θ2)/2, t.origin + t.rotation * CartesianVector{T}(0,0,t.r_tube * sin(θ2)/2), t.rotation, Val{TT2}()))
     φ1, φ2 = t.φ
-    es1 = PartialCircularArea{T}(t.r_tube, t.θ, t.origin + t.rotation * CartesianVector{T}(t.r_torus * cos(φ1), t.r_torus * sin(φ1), 0), t.rotation * RotZ(φ1) * RotX(π/2) )
-    es2 = PartialCircularArea{T}(t.r_tube, t.θ, t.origin + t.rotation * CartesianVector{T}(t.r_torus * cos(φ2), t.r_torus * sin(φ2), 0), t.rotation * RotZ(φ2) * RotX(π/2) )
+    es1 = PartialCircularArea{T}(t.r_tube, t.θ, t.origin + t.rotation * CartesianVector{T}(t.r_torus * cos(φ1), t.r_torus * sin(φ1), 0), t.rotation * RotZ(φ1) * RotX(π/2))
+    es2 = flip(PartialCircularArea{T}(t.r_tube, t.θ, t.origin + t.rotation * CartesianVector{T}(t.r_torus * cos(φ2), t.r_torus * sin(φ2), 0), t.rotation * RotZ(φ2) * RotX(π/2)))
     (tm, cm1, cm2, es1, es2)
 end
 

--- a/src/ConstructiveSolidGeometry/VolumePrimitives/Torus.jl
+++ b/src/ConstructiveSolidGeometry/VolumePrimitives/Torus.jl
@@ -106,6 +106,7 @@ function Geometry(::Type{T}, ::Type{Torus}, dict::AbstractDict, input_units::Nam
 
     r_torus = _parse_value(T, dict["r_torus"], length_unit)
     r_tube = _parse_radial_interval(T, dict["r_tube"], length_unit)
+    r_tube isa Tuple{T,T} && iszero(r_tube[1]) ? r_tube = r_tube[2] : nothing
     φ = parse_φ_of_primitive(T, dict, angle_unit)
     θ = parse_θ_of_primitive(T, dict, angle_unit)
     TT1, TT2 = _get_conemantle_type(θ)


### PR DESCRIPTION
This PR includes the support for partial tori, which are not full `2π` in `φ` and `θ`.
This comes with:
- adding I/O for `PartialTorus`
- decomposing `PartialTorus` to its surfaces
- Adjust the `_in` function for all `Torus` cases
- adjust the `intersection` method to discard points that are not on the surface of a `PartialTorusMantle`.