### PR TITLE
`csgtol`-keyword becomes argument

### DIFF
--- a/src/ConstructiveSolidGeometry/CSG.jl
+++ b/src/ConstructiveSolidGeometry/CSG.jl
@@ -45,8 +45,8 @@ struct CSGUnion{T, A <: AbstractGeometry{T}, B <: AbstractGeometry{T}} <: Abstra
     b::B
 end
 
-in(pt::AbstractCoordinatePoint{T}, csg::CSGUnion; csgtol::T = csg_default_tol(T)) where {T} = 
-    in(pt, csg.a; csgtol = csgtol) || in(pt, csg.b; csgtol = csgtol)
+in(pt::AbstractCoordinatePoint{T}, csg::CSGUnion, csgtol::T = csg_default_tol(T)) where {T} = 
+    in(pt, csg.a, csgtol) || in(pt, csg.b, csgtol)
 (+)(a::A, b::B) where {T, A <: AbstractGeometry{T}, B <: AbstractGeometry{T}} = CSGUnion{T,A,B}(a, b)
 
 # read-in
@@ -105,8 +105,8 @@ struct CSGIntersection{T, A <: AbstractGeometry{T}, B <: AbstractGeometry{T}} <:
     b::B
 end
 
-in(pt::AbstractCoordinatePoint{T}, csg::CSGIntersection; csgtol::T = csg_default_tol(T)) where {T} = 
-    in(pt, csg.a; csgtol = csgtol) && in(pt, csg.b; csgtol = csgtol)
+in(pt::AbstractCoordinatePoint{T}, csg::CSGIntersection, csgtol::T = csg_default_tol(T)) where {T} = 
+    in(pt, csg.a; csgtol) && in(pt, csg.b; csgtol)
 (&)(a::A, b::B) where {T, A <: AbstractGeometry{T}, B <: AbstractGeometry{T}} = CSGIntersection{T,A,B}(a, b)
 
 # read-in
@@ -173,8 +173,8 @@ struct CSGDifference{T, A <: AbstractGeometry{T}, B <: AbstractGeometry{T}} <: A
     b::B
 end
 
-in(pt::AbstractCoordinatePoint{T}, csg::CSGDifference; csgtol::T = csg_default_tol(T)) where {T} = 
-    in(pt, csg.a; csgtol = csgtol) && !in(pt, csg.b; csgtol = csgtol)
+in(pt::AbstractCoordinatePoint{T}, csg::CSGDifference, csgtol::T = csg_default_tol(T)) where {T} = 
+    in(pt, csg.a, csgtol) && !in(pt, csg.b, csgtol)
 
 function (-)(a::A, b::B) where {T, A <: AbstractGeometry{T}, B <: AbstractConstructiveGeometry{T}} 
     ob = switchClosedOpen(b)

--- a/src/ConstructiveSolidGeometry/ConstructiveSolidGeometry.jl
+++ b/src/ConstructiveSolidGeometry/ConstructiveSolidGeometry.jl
@@ -59,10 +59,10 @@ module ConstructiveSolidGeometry
     _transform_into_global_coordinate_system(pts::AbstractVector{<:CartesianPoint}, p::AbstractPrimitive) =
         broadcast(pt -> _transform_into_global_coordinate_system(pt, p), pts)
     _transform_into_object_coordinate_system(pt::CartesianPoint, p::AbstractPrimitive) = inv(rotation(p)) * (pt - origin(p)) 
-    in(pt::CartesianPoint{T}, p::AbstractPrimitive{T}; csgtol::T = csg_default_tol(T)) where {T} = 
+    in(pt::CartesianPoint{T}, p::AbstractPrimitive{T}, csgtol::T = csg_default_tol(T)) where {T} = 
         _in(_transform_into_object_coordinate_system(pt, p), p; csgtol = csgtol)
-    in(pt::CylindricalPoint{T}, p::AbstractPrimitive{T}; csgtol::T = csg_default_tol(T)) where {T} = 
-        in(CartesianPoint(pt), p; csgtol = csgtol)
+    in(pt::CylindricalPoint{T}, p::AbstractPrimitive{T}, csgtol::T = csg_default_tol(T)) where {T} = 
+        in(CartesianPoint(pt), p, csgtol)
 
     """
         extreme_points(es::AbstractPrimitive{T}) where {T}

--- a/src/PotentialSimulation/Painting/Painting.jl
+++ b/src/PotentialSimulation/Painting/Painting.jl
@@ -66,7 +66,7 @@ function paint!(point_types, potential, face::AbstractSurfacePrimitive{T}, geome
                     widths_ax1[i1], widths_ax1[i1+1],
                     widths_ax2[i2], widths_ax2[i2+1],
                 ) 
-                if in(pt, geometry, csgtol = csgtol)
+                if in(pt, geometry, csgtol)
                     point_types[i1, i2, i3] = zero(PointType)
                     potential[i1, i2, i3] = pot_value
                 end
@@ -83,7 +83,7 @@ function paint!(point_types, potential, face::AbstractSurfacePrimitive{T}, geome
                     widths_ax1[i1], widths_ax1[i1+1],
                     widths_ax3[i3], widths_ax3[i3+1]
                 )
-                if in(pt, geometry, csgtol = csgtol)
+                if in(pt, geometry, csgtol)
                     point_types[i1, i2, i3] = zero(PointType)
                     potential[i1, i2, i3] = pot_value
                 end
@@ -100,7 +100,7 @@ function paint!(point_types, potential, face::AbstractSurfacePrimitive{T}, geome
                     widths_ax2[i2], widths_ax2[i2+1],
                     widths_ax3[i3], widths_ax3[i3+1]
                 )
-                if in(pt, geometry, csgtol = csgtol)
+                if in(pt, geometry, csgtol)
                     point_types[i1, i2, i3] = zero(PointType)
                     potential[i1, i2, i3] = pot_value
                 end
@@ -140,7 +140,7 @@ function paint!(point_types, potential, face::AbstractSurfacePrimitive{T}, geome
                 csgtol = Δw_max_factor * max(
                     widths_ax3[i3], widths_ax3[i3+1],
                 ) 
-                if in(pt, geometry, csgtol = csgtol)
+                if in(pt, geometry, csgtol)
                     point_types[i1, i2, i3] = zero(PointType)
                     potential[i1, i2, i3] = pot_value
                 end
@@ -155,7 +155,7 @@ function paint!(point_types, potential, face::AbstractSurfacePrimitive{T}, geome
     #         l = ConstructiveSolidGeometry.Line(CartesianPoint{T}(ticks[1][i1], zero(T), ticks[3][i3]), eY)
     #         pt = ConstructiveSolidGeometry.intersection(plane, l)
     #         i2 = searchsortednearest(ticks[2], pt[2])
-    #         if in(pt, geometry, csgtol = abs(ticks[2][i2] - pt[2]))
+    #         if in(pt, geometry, abs(ticks[2][i2] - pt[2]))
     #             point_types[i1, i2, i3] = zero(PointType)
     #             potential[i1, i2, i3] = pot_value
     #         end
@@ -178,7 +178,7 @@ function paint!(point_types, potential, face::AbstractSurfacePrimitive{T}, geome
                     widths_ax1[i1], widths_ax1[i1+1],
                     widths_ax2[i2], widths_ax2[i2+1],
                 ) 
-                if abs(pt_cyl[2] - ticks[2][i2]) < 0.1 && in(pt_car, geometry, csgtol = csgtol)
+                if abs(pt_cyl[2] - ticks[2][i2]) < 0.1 && in(pt_car, geometry, csgtol)
                     point_types[i1, i2, i3] = zero(PointType)
                     potential[i1, i2, i3] = pot_value
                 end


### PR DESCRIPTION
Closes #207 

Okay, I found out what the problem was. The compiler does not like keywords... 

So the code
```julia
using BenchmarkTools
using SolidStateDetectors
sim = Simulation(SSD_examples[:InvertedCoax]);
g = sim.detector.contacts[2].geometry; # consists out of 6 primitives
pt = CartesianPoint{Float32}(100, 0, 0); #outside
in(pt, g); @btime in($pt, $g); 
```
results in 
on `v0.7.1`: `149.599 ns (6 allocations: 608 bytes)`
with this PR: `84.456 ns (0 allocations: 0 bytes)`
