### PR TITLE
Redefine `Cone` and `Torus`: `φ::Tuple{T,T}` => `φ::T`

### DIFF
--- a/src/ConstructiveSolidGeometry/Intervals.jl
+++ b/src/ConstructiveSolidGeometry/Intervals.jl
@@ -6,17 +6,20 @@
 @inline _radial_endpoints(r::AbstractInterval) = endpoints(r)
 @inline _radial_endpoints(r::Tuple{T,T}) where {T} = r
 
-@inline _in_angular_interval_closed(α::Real, α_int::Nothing, tol::Real = 0) = true
-@inline _in_angular_interval_closed(α::Real, α_int::AbstractInterval{T}, tol::Real = 0) where {T} = mod(α - (α_int.left-tol), T(2π)) ≤ (α_int.right+tol) - (α_int.left-tol)
-
+@inline _in_angular_interval_closed(α::T, α_int::T; csgtol::T = csg_default_tol(T)) where {T} = mod(α + csgtol, T(2π)) ≤ α_int + csgtol
 @inline function _in_angular_interval_closed(α::T, α_int::Tuple{T,T}; csgtol::T = csg_default_tol(T)) where {T} 
     m = mod(α - α_int[1], T(2π))
     d = (α_int[2] - α_int[1])
     m ≤ d + csgtol 
 end
+
+@inline _in_angular_interval_open(α::T, α_int::T; csgtol::T = csg_default_tol(T)) where {T} = csgtol < mod(α, T(2π)) ≤ α_int - csgtol
 @inline function _in_angular_interval_open(α::T, α_int::Tuple{T,T}; csgtol::T = csg_default_tol(T)) where {T} 
     csgtol < mod(α - α_int[1], T(2π)) < (α_int[2] - α_int[1]) - csgtol 
 end
 
-@inline _in_angular_interval_open(α::T, α_int::Nothing) where {T<:Real} = 0 < mod(α, T(2π)) < T(2π)
-@inline _in_angular_interval_open(α::Real, α_int::AbstractInterval{T}) where {T} = 0 < mod(α - α_int.left, T(2π)) < width(α_int)
+# @inline _in_angular_interval_closed(α::Real, α_int::Nothing, tol::Real = 0) = true
+# @inline _in_angular_interval_closed(α::Real, α_int::AbstractInterval{T}, tol::Real = 0) where {T} = mod(α - (α_int.left-tol), T(2π)) ≤ (α_int.right+tol) - (α_int.left-tol)
+# 
+# @inline _in_angular_interval_open(α::T, α_int::Nothing) where {T<:Real} = 0 < mod(α, T(2π)) < T(2π)
+# @inline _in_angular_interval_open(α::Real, α_int::AbstractInterval{T}) where {T} = 0 < mod(α - α_int.left, T(2π)) < width(α_int)

--- a/src/ConstructiveSolidGeometry/LinePrimitives/Ellipse.jl
+++ b/src/ConstructiveSolidGeometry/LinePrimitives/Ellipse.jl
@@ -12,7 +12,7 @@
 #     * TP = Nothing <-> Full in φ
 #     * ...
 # """
-@with_kw struct Ellipse{T,TR,TP} <: AbstractLinePrimitive{T}
+@with_kw struct Ellipse{T,TR,TP<:Union{Nothing,T}} <: AbstractLinePrimitive{T}
     r::TR = 1
     φ::TP = nothing
 
@@ -21,7 +21,7 @@
 end
 
 const Circle{T} = Ellipse{T,T,Nothing}
-const PartialCircle{T} = Ellipse{T,T,Tuple{T,T}}
+const PartialCircle{T} = Ellipse{T,T,T}
 
 extremum(e::Ellipse{T,T}) where {T} = e.r
 extremum(e::Ellipse{T,Tuple{T,T}}) where {T} = max(e.r...)
@@ -35,7 +35,7 @@ function sample(e::Circle{T}; n = 4)::Vector{CartesianPoint{T}} where {T}
     pts
 end
 function sample(e::PartialCircle{T}; n = 2)::Vector{CartesianPoint{T}} where {T}
-    φs = range(e.φ[1], stop = e.φ[1], length = n)
+    φs = range(T(0), stop = e.φ, length = n)
     pts = Vector{CartesianPoint{T}}(undef, n)
     for i in eachindex(pts)
         pts[i] = _transform_into_global_coordinate_system(CartesianPoint(CylindricalPoint{T}(e.r, φs[i], zero(T))), e)

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/EllipticalSurface.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/EllipticalSurface.jl
@@ -10,7 +10,7 @@ Surface primitive describing circular bases, e.g. the top or bottom base of a [`
     * `TR == Tuple{T, T}`: Circular Annulus (inner radius at `r[1]`, outer radius at `r[2]`).
 * `TP`: Type of the angular range `φ`.
     * `TP == Nothing`: Full 2π Cone.
-    * `TP == Tuple{T, T}`: Partial Cone ranging from `φ[1]` to `φ[2]`.
+    * `TP == T`: Partial Elliptical Surface ranging from `0` to `φ`.
     
 ## Fields
 * `r::TR`: Definition of the radius of the `EllipticalSurface` (in m).
@@ -18,7 +18,7 @@ Surface primitive describing circular bases, e.g. the top or bottom base of a [`
 * `origin::CartesianPoint{T}`: The position of the center of the `EllipticalSurface`.
 * `rotation::SMatrix{3,3,T,9}`: Matrix that describes a rotation of the `EllipticalSurface` around its `origin`.
 """
-@with_kw struct EllipticalSurface{T,TR,TP} <: AbstractPlanarSurfacePrimitive{T}
+@with_kw struct EllipticalSurface{T,TR,TP<:Union{Nothing,T}} <: AbstractPlanarSurfacePrimitive{T}
     r::TR = 1
     φ::TP = nothing
 
@@ -28,14 +28,14 @@ end
 
 flip(es::EllipticalSurface{T,TR,Nothing}) where {T,TR} = 
     EllipticalSurface{T,TR,Nothing}(es.r, es.φ, es.origin, es.rotation * SMatrix{3,3,T,9}(1,0,0,0,-1,0,0,0,-1))
-flip(es::EllipticalSurface{T,TR,Tuple{T,T}}) where {T,TR} = 
-    EllipticalSurface{T,TR,Tuple{T,T}}(es.r, (2π-es.φ[2], 2π-es.φ[1]), es.origin, es.rotation * SMatrix{3,3,T,9}(1,0,0,0,-1,0,0,0,-1))
+flip(es::EllipticalSurface{T,TR,T}) where {T,TR} = 
+    EllipticalSurface{T,TR,T}(es.r, es.φ, es.origin, es.rotation * RotZ{T}(T(2π)-es.φ)SMatrix{3,3,T,9}(1,0,0,0,-1,0,0,0,-1))
 
 const CircularArea{T} = EllipticalSurface{T,T,Nothing}
-const PartialCircularArea{T} = EllipticalSurface{T,T,Tuple{T,T}}
+const PartialCircularArea{T} = EllipticalSurface{T,T,T}
 
 const Annulus{T} = EllipticalSurface{T,Tuple{T,T},Nothing}
-const PartialAnnulus{T} = EllipticalSurface{T,Tuple{T,T},Tuple{T,T}}
+const PartialAnnulus{T} = EllipticalSurface{T,Tuple{T,T},T}
 
 Plane(es::EllipticalSurface{T}) where {T} = Plane{T}(es.origin, es.rotation * CartesianVector{T}(zero(T),zero(T),one(T)))
 
@@ -86,7 +86,7 @@ get_label_name(::EllipticalSurface) = "Elliptical Surface"
 extremum(es::EllipticalSurface{T,T}) where {T} = es.r
 extremum(es::EllipticalSurface{T,Tuple{T,T}}) where {T} = es.r[2] # r_out always larger r_in: es.r[2] > es.r[2]
 
-get_φ_limits(es::EllipticalSurface{T,<:Any,Tuple{T,T}}) where {T} = es.φ[1], es.φ[2]
+get_φ_limits(es::EllipticalSurface{T,<:Any,T}) where {T} = T(0), es.φ
 get_φ_limits(cm::EllipticalSurface{T,<:Any,Nothing}) where {T} = T(0), T(2π)
 
 function lines(sp::CircularArea{T}; n = 2) where {T} 
@@ -98,7 +98,7 @@ function lines(sp::CircularArea{T}; n = 2) where {T}
 end
 function lines(sp::PartialCircularArea{T}; n = 2) where {T} 
     circ = PartialCircle{T}(r = sp.r, φ = sp.φ, origin = sp.origin, rotation = sp.rotation)
-    φs = range(sp.φ[1], stop = sp.φ[2], length = n)
+    φs = range(T(0), stop = sp.φ, length = n)
     edges = [ Edge{T}(_transform_into_global_coordinate_system(CartesianPoint(CylindricalPoint{T}(zero(T), φ, zero(T))), sp),
                       _transform_into_global_coordinate_system(CartesianPoint(CylindricalPoint{T}(sp.r, φ, zero(T))), sp)) for φ in φs ]
     return (circ, edges)
@@ -115,7 +115,7 @@ end
 function lines(sp::PartialAnnulus{T}; n = 2) where {T} 
     circ_in  = PartialCircle{T}(r = sp.r[1], φ = sp.φ, origin = sp.origin, rotation = sp.rotation)
     circ_out = PartialCircle{T}(r = sp.r[2], φ = sp.φ, origin = sp.origin, rotation = sp.rotation)
-    φs = range(sp.φ[1], stop = sp.φ[2], length = n)
+    φs = range(T(0), stop = sp.φ, length = n)
     edges = [ Edge{T}(_transform_into_global_coordinate_system(CartesianPoint(CylindricalPoint{T}(sp.r[1], φ, zero(T))), sp),
                       _transform_into_global_coordinate_system(CartesianPoint(CylindricalPoint{T}(sp.r[2], φ, zero(T))), sp)) for φ in φs ]
     return (circ_in, circ_out, edges)

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/EllipticalSurface.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/EllipticalSurface.jl
@@ -29,7 +29,7 @@ end
 flip(es::EllipticalSurface{T,TR,Nothing}) where {T,TR} = 
     EllipticalSurface{T,TR,Nothing}(es.r, es.φ, es.origin, es.rotation * SMatrix{3,3,T,9}(1,0,0,0,-1,0,0,0,-1))
 flip(es::EllipticalSurface{T,TR,T}) where {T,TR} = 
-    EllipticalSurface{T,TR,T}(es.r, es.φ, es.origin, es.rotation * RotZ{T}(T(2π)-es.φ)SMatrix{3,3,T,9}(1,0,0,0,-1,0,0,0,-1))
+    EllipticalSurface{T,TR,T}(es.r, es.φ, es.origin, es.rotation * SMatrix{3,3,T,9}(1,0,0,0,-1,0,0,0,-1) * RotZ{T}(T(2π)-es.φ))
 
 const CircularArea{T} = EllipticalSurface{T,T,Nothing}
 const PartialCircularArea{T} = EllipticalSurface{T,T,T}

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/TorusMantle.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/TorusMantle.jl
@@ -7,7 +7,7 @@ Surface primitive describing the mantle of a [`Torus`](@ref).
 * `T`: Precision type.
 * `TP`: Type of the azimuthial angle `φ`.
     * `TP == Nothing`: Full 2π in `φ`.
-    * `TP == Tuple{T,T}`: Partial Torus Mantle ranging from `φ[1]` to `φ[2]`.
+    * `TP == T`: Partial Torus Mantle ranging from `0` to `φ`.
 * `TT`: Type of the polar angle `θ`.
     * `TT == Nothing`: Full 2π in `θ`.
     * `TP == Tuple{T,T}`: Partial Torus Mantle ranging from `θ[1]` to `θ[2]`.
@@ -22,7 +22,7 @@ Surface primitive describing the mantle of a [`Torus`](@ref).
 * `origin::CartesianPoint{T}`: The position of the center of the `TorusMantle`.
 * `rotation::SMatrix{3,3,T,9}`: Matrix that describes a rotation of the `TorusMantle` around its `origin`.
 """
-@with_kw struct TorusMantle{T,TP,TT,D} <: AbstractCurvedSurfacePrimitive{T}
+@with_kw struct TorusMantle{T,TP<:Union{Nothing,T},TT,D} <: AbstractCurvedSurfacePrimitive{T}
     r_torus::T = 1
     r_tube::T = 1
     φ::TP = nothing
@@ -35,7 +35,7 @@ end
 flip(t::TorusMantle{T,TP,TT,:inwards}) where {T,TP,TT} = 
 TorusMantle{T,TP,TT,:outwards}(t.r_torus, t.r_tube, t.φ, t.θ, t.origin, t.rotation )
 
-get_φ_limits(tm::TorusMantle{T,Tuple{T,T}}) where {T} = tm.φ[1], tm.φ[2]
+get_φ_limits(tm::TorusMantle{T,T}) where {T} = T(0), tm.φ
 get_φ_limits(tm::TorusMantle{T,Nothing}) where {T} = T(0), T(2π)
 
 get_θ_limits(tm::TorusMantle{T,<:Any,Tuple{T,T}}) where {T} = tm.θ[1], tm.θ[2]
@@ -90,9 +90,9 @@ get_label_name(::TorusMantle) = "Torus Mantle"
 
 const FullTorusMantle{T,D} = TorusMantle{T,Nothing,Nothing,D}
 const FullPhiTorusMantle{T,D} = TorusMantle{T,Nothing,Tuple{T,T},D}
-const FullThetaTorusMantle{T,D} = TorusMantle{T,Tuple{T,T},Nothing,D}
+const FullThetaTorusMantle{T,D} = TorusMantle{T,T,Nothing,D}
 
-function lines(tm::TorusMantle{T,TP,TT}) where {T,TP,TT}
+function lines(tm::TorusMantle{T,TP,Nothing}) where {T,TP}
     top_circ_origin = CartesianPoint{T}(zero(T), zero(T),  tm.r_tube)
     top_circ_origin = _transform_into_global_coordinate_system(top_circ_origin, tm)
     top_circ = Ellipse{T,T,TP}(r = tm.r_torus, φ = tm.φ, origin = top_circ_origin, rotation = tm.rotation)
@@ -104,10 +104,29 @@ function lines(tm::TorusMantle{T,TP,TT}) where {T,TP,TT}
     φmin::T, φmax::T = isnothing(tm.φ) ? (0, π) : get_φ_limits(tm)
     tube_circ_1_origin = CartesianPoint(CylindricalPoint{T}(tm.r_torus, φmin, zero(T)))
     tube_circ_1_origin = _transform_into_global_coordinate_system(tube_circ_1_origin, tm)
-    tube_circ_1 = Ellipse{T,T,TT}(r = tm.r_tube, φ = tm.θ, origin = tube_circ_1_origin, rotation = tm.rotation * RotZ(φmin) *RotX(T(π)/2))
+    tube_circ_1 = Ellipse{T,T,Nothing}(r = tm.r_tube, φ = tm.θ, origin = tube_circ_1_origin, rotation = tm.rotation * RotZ(φmin) * RotX(T(π)/2))
     tube_circ_2_origin = CartesianPoint(CylindricalPoint{T}(tm.r_torus, φmax, zero(T)))
     tube_circ_2_origin = _transform_into_global_coordinate_system(tube_circ_2_origin, tm)
-    tube_circ_2 = Ellipse{T,T,TT}(r = tm.r_tube, φ = tm.θ, origin = tube_circ_2_origin, rotation = tm.rotation * RotZ(φmax) * RotX(T(π)/2))
+    tube_circ_2 = Ellipse{T,T,Nothing}(r = tm.r_tube, φ = tm.θ, origin = tube_circ_2_origin, rotation = tm.rotation * RotZ(φmax) * RotX(T(π)/2))
+    (bot_circ, outer_circ, top_circ, inner_circ, tube_circ_1, tube_circ_2)
+end 
+
+function lines(tm::TorusMantle{T,TP,Tuple{T,T}}) where {T,TP}
+    top_circ_origin = CartesianPoint{T}(zero(T), zero(T),  tm.r_tube)
+    top_circ_origin = _transform_into_global_coordinate_system(top_circ_origin, tm)
+    top_circ = Ellipse{T,T,TP}(r = tm.r_torus, φ = tm.φ, origin = top_circ_origin, rotation = tm.rotation)
+    bot_circ_origin = CartesianPoint{T}(zero(T), zero(T), -tm.r_tube)
+    bot_circ_origin = _transform_into_global_coordinate_system(bot_circ_origin, tm)
+    bot_circ = Ellipse{T,T,TP}(r = tm.r_torus, φ = tm.φ, origin = bot_circ_origin, rotation = tm.rotation)
+    inner_circ = Ellipse{T,T,TP}(r = tm.r_torus - tm.r_tube, φ = tm.φ, origin = tm.origin, rotation = tm.rotation)
+    outer_circ = Ellipse{T,T,TP}(r = tm.r_torus + tm.r_tube, φ = tm.φ, origin = tm.origin, rotation = tm.rotation)
+    φmin::T, φmax::T = isnothing(tm.φ) ? (0, π) : get_φ_limits(tm)
+    tube_circ_1_origin = CartesianPoint(CylindricalPoint{T}(tm.r_torus, φmin, zero(T)))
+    tube_circ_1_origin = _transform_into_global_coordinate_system(tube_circ_1_origin, tm)
+    tube_circ_1 = Ellipse{T,T,T}(r = tm.r_tube, φ = abs(-(tm.θ...)), origin = tube_circ_1_origin, rotation = tm.rotation * RotZ(φmin) * RotX(T(π)/2) * RotZ(tm.θ[1]))
+    tube_circ_2_origin = CartesianPoint(CylindricalPoint{T}(tm.r_torus, φmax, zero(T)))
+    tube_circ_2_origin = _transform_into_global_coordinate_system(tube_circ_2_origin, tm)
+    tube_circ_2 = Ellipse{T,T,T}(r = tm.r_tube, φ = abs(-(tm.θ...)), origin = tube_circ_2_origin, rotation = tm.rotation * RotZ(φmax) * RotX(T(π)/2) * RotZ(tm.θ[1]))
     (bot_circ, outer_circ, top_circ, inner_circ, tube_circ_1, tube_circ_2)
 end 
 
@@ -169,7 +188,7 @@ end
 TorusThetaSurface(r::T, φ::TP, hZ::T, origin::CartesianPoint{T}, rotation::SMatrix{3,3,T,9}, ::Val{:flat}) where {T,TP} = EllipticalSurface{T,T,TP}(r,φ,origin,rotation)
 TorusThetaSurface(r::T, φ::TP, hZ::T, origin::CartesianPoint{T}, rotation::SMatrix{3,3,T,9}, ::Val{:inwards}) where {T,TP} = ConeMantle{T,T,TP,:inwards}(r,φ,abs(hZ),origin,rotation)
 TorusThetaSurface(r::T, φ::TP, hZ::T, origin::CartesianPoint{T}, rotation::SMatrix{3,3,T,9}, ::Val{:outwards}) where {T,TP} = ConeMantle{T,T,TP,:outwards}(r,φ,abs(hZ),origin,rotation)
-TorusThetaSurface(r::Tuple{T,T}, φ::TP, hZ::T, origin::CartesianPoint{T}, rotation::SMatrix{3,3,T,9}, ::Val{:flat}) where {T,TP} = EllipticalSurface{T,Tuple{T,T},TP}(ordered(r),φ,origin,rotation)
+TorusThetaSurface(r::Tuple{T,T}, φ::TP, hZ::T, origin::CartesianPoint{T}, rotation::SMatrix{3,3,T,9}, ::Val{:flat}) where {T,TP} = EllipticalSurface{T,Tuple{T,T},TP}(ordered(r...),φ,origin,rotation)
 TorusThetaSurface(r::Tuple{T,T}, φ::TP, hZ::T, origin::CartesianPoint{T}, rotation::SMatrix{3,3,T,9}, ::Val{:inwards}) where {T,TP} = ConeMantle{T,Tuple{T,T},TP,:inwards}(hZ < 0 ? reverse(r) : r, φ, abs(hZ), origin, rotation)
 TorusThetaSurface(r::Tuple{T,T}, φ::TP, hZ::T, origin::CartesianPoint{T}, rotation::SMatrix{3,3,T,9}, ::Val{:outwards}) where {T,TP} = ConeMantle{T,Tuple{T,T},TP,:outwards}(hZ < 0 ? reverse(r) : r, φ, abs(hZ), origin, rotation)
 

--- a/src/ConstructiveSolidGeometry/plotting/LinePrimitives/Ellipse.jl
+++ b/src/ConstructiveSolidGeometry/plotting/LinePrimitives/Ellipse.jl
@@ -4,8 +4,8 @@ function edges(e::Ellipse{T,T,Nothing}; n = 4) where {T}
     pts = map(p -> _transform_into_global_coordinate_system(p, e), pts)
     edges = [Edge(pts[i], pts[i+1]) for i in 1:n]
 end
-function edges(e::Ellipse{T,T,Tuple{T,T}}; n = 4) where {T}
-    φs = range(e.φ[1], stop = e.φ[2], length = n + 1)
+function edges(e::Ellipse{T,T,T}; n = 4) where {T}
+    φs = range(T(0), stop = e.φ, length = n + 1)
     pts = [CartesianPoint(CylindricalPoint{T}(e.r, φ, zero(T))) for φ in φs]
     pts = map(p -> _transform_into_global_coordinate_system(p, e), pts)
     edges = [Edge(pts[i], pts[i+1]) for i in 1:n]

--- a/src/ConstructiveSolidGeometry/plotting/SurfacePrimitives/ConeMantle.jl
+++ b/src/ConstructiveSolidGeometry/plotting/SurfacePrimitives/ConeMantle.jl
@@ -12,7 +12,7 @@
         @series begin
             label := nothing
             seriestype := :vector
-            nφ = cm.φ == nothing ? 0 : (cm.φ[2] + cm.φ[1])/2 
+            nφ = isnothing(cm.φ) ? 0 : cm.φ/2 
             T = typeof(cm.hZ)
             npt_obj = CartesianPoint(CylindricalPoint{T}(radius_at_z(cm, zero(T)), nφ, zero(T)))
             npt = _transform_into_global_coordinate_system(npt_obj, cm)

--- a/src/ConstructiveSolidGeometry/plotting/SurfacePrimitives/EllipticalSurface.jl
+++ b/src/ConstructiveSolidGeometry/plotting/SurfacePrimitives/EllipticalSurface.jl
@@ -14,13 +14,13 @@
 end
 
 _plt_area(es::CircularArea{T}) where {T} = π*es.r^2
-_plt_area(es::PartialCircularArea{T}) where {T} = π*es.r^2 / ((es.φ[2]-es.φ[1])/2π)
+_plt_area(es::PartialCircularArea{T}) where {T} = π*es.r^2 / (es.φ/2π)
 _plt_area(es::Annulus{T}) where {T} = π*(es.r[2]^2 - es.r[1]^2)
-_plt_area(es::PartialAnnulus{T}) where {T} = π*(es.r[2]^2 - es.r[1]^2) / ((es.φ[2]-es.φ[1])/2π)
+_plt_area(es::PartialAnnulus{T}) where {T} = π*(es.r[2]^2 - es.r[1]^2) / (es.φ/2π)
 
 _plt_get_start_point_for_normal(es::CircularArea{T}) where {T} = es.origin
 function _plt_get_start_point_for_normal(es::PartialCircularArea{T}) where {T}
-    cyl = CylindricalPoint{T}(es.r/2, (es.φ[2]+es.φ[1])/2, zero(T))
+    cyl = CylindricalPoint{T}(es.r/2, es.φ/2, zero(T))
     _transform_into_global_coordinate_system(CartesianPoint(cyl), es)
 end
 function _plt_get_start_point_for_normal(es::Annulus{T}) where {T}
@@ -28,6 +28,6 @@ function _plt_get_start_point_for_normal(es::Annulus{T}) where {T}
     _transform_into_global_coordinate_system(CartesianPoint(cyl), es)
 end
 function _plt_get_start_point_for_normal(es::PartialAnnulus{T}) where {T}
-    cyl = CylindricalPoint{T}((es.r[2]+es.r[1])/2, (es.φ[2]+es.φ[1])/2, zero(T))
+    cyl = CylindricalPoint{T}((es.r[2]+es.r[1])/2, es.φ/2, zero(T))
     _transform_into_global_coordinate_system(CartesianPoint(cyl), es)
 end

--- a/src/IO/SigGenInterface.jl
+++ b/src/IO/SigGenInterface.jl
@@ -291,19 +291,11 @@ function siggentodict(config::Dict;
                   "r"          => config["pc_radius"] - config["pc_length"],
                   "h"          => 0,
                   "origin"     => Dict("z" => config["pc_length"]))),
-            Dict( "difference" => [
             Dict( "torus"      => Dict(
                   "r_torus"    => config["pc_radius"] - config["pc_length"],
                   "r_tube"     => Dict("from" => config["pc_length"], 
-                                       "to"   => config["pc_length"]))),
-            Dict( "tube"       => Dict(
-                  "r"          => config["pc_radius"] - config["pc_length"],
-                  "h"          => 1.2*config["pc_length"],
-                  "origin"     => Dict("z" => 0.4*config["pc_length"]))),
-            Dict( "tube"       => Dict(
-                  "r"          => 1.2*config["pc_radius"],
-                  "h"          => 1.2*config["pc_radius"],
-                  "origin"     => Dict("z" => -0.6 * config["pc_radius"])))])])
+                                       "to"   => config["pc_length"]),
+                  "theta"      => Dict("from" => 0.0, "to" => 90.0)))])
         elseif config["pc_length"] > config["pc_radius"]
             Dict( "union"      => [
             Dict( "tube"       => Dict(

--- a/test/ConstructiveSolidGeometry/CSG_primitives.jl
+++ b/test/ConstructiveSolidGeometry/CSG_primitives.jl
@@ -1,0 +1,66 @@
+using Test
+using SolidStateDetectors
+using StaticArrays
+
+import SolidStateDetectors.ConstructiveSolidGeometry as CSG
+import SolidStateDetectors.ConstructiveSolidGeometry: Geometry
+
+T = Float64
+
+default_units = SolidStateDetectors.default_unit_tuple()
+no_translations = (rotation = one(SMatrix{3, 3, T, 9}), translation = zero(CartesianVector{T}))
+
+@testset "Test primitive parsing" begin
+    @testset "Cone" begin
+        for bot in (2.0, Dict("from" => 1.0, "to" => 2.0)),
+            top in (2.0, 1.0, Dict("from" => 1.0, "to" => 2.0), Dict("from" => 2.0, "to" => 4.0)),
+            φmax in (180,360)
+            
+            dict = Dict("difference" => [
+                Dict("cone"   => Dict(
+                    "r"       => Dict("bottom" => bot, "top" => top),
+                    "phi"     => Dict("from" => "0°", "to" => "$(φmax)°"),
+                    "h"       => 1.0))
+                for i in 1:2
+            ])
+            
+            c = Geometry(T, dict, default_units, no_translations)
+            
+            # No warnings or errors when decomposing the Cones into surfaces
+            @test_nowarn CSG.surfaces(c.a)
+            @test_nowarn CSG.surfaces(c.b)
+
+            # Check if all Cones are saved the right way
+            @test c.a isa CSG.Cone
+            @test c.b isa CSG.Cone
+        end
+    end
+    @testset "Torus" begin
+        for r_tube in (2.0, Dict("from" => 1.0, "to" => 2.0)), 
+            φmax in (180,360), 
+            θmin in 0:45:90, 
+            θmax in 135:45:270
+            
+            dict = Dict("difference" => [
+                Dict( "torus" => Dict(
+                    "r_torus" => 10.0,
+                    "r_tube"  => r_tube,
+                    "phi"     => Dict("from" => "0°", "to" => "$(φmax)°"),
+                    "theta"   => Dict("from" => "$(θmin)°", "to" => "$(θmax)°")))
+                for i in 1:2
+            ])
+            t = Geometry(T, dict, default_units, no_translations)
+            
+            # No warnings or errors when decomposing the Torus into surfaces
+            @test_nowarn CSG.surfaces(t.a)
+            @test_nowarn CSG.surfaces(t.b)
+            
+            # Check that the r field for all ConeMantles is ordered
+            for surf in CSG.surfaces(t.a) surf isa CSG.ConeMantle && @test_skip surf.r[1] <= surf.r[2] end
+            
+            # Check if all Torus are saved the right way
+            @test t.a isa CSG.Torus
+            @test t.b isa CSG.Torus
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,13 @@ end
     include("SOR_GPU_Backend.jl")
 end
 
+@testset "ConstructiveSolidGeometry" begin
+    include("ConstructiveSolidGeometry/CSG_IO.jl")
+    include("ConstructiveSolidGeometry/CSG_primitives.jl")
+end
+
+T = Float32
+
 @testset "Test real detectors" begin
     @testset "Simulate example detector: Inverted Coax" begin
         sim = Simulation{T}(SSD_examples[:InvertedCoax])
@@ -157,7 +164,7 @@ end
 end
 
 @testset "Diffusion and Self-Repulsion" begin
-    sim = Simulation(SSD_examples[:InvertedCoax])
+    sim = Simulation{T}(SSD_examples[:InvertedCoax])
     simulate!(sim, convergence_limit = 1e-5, refinement_limits = [0.2, 0.1], verbose = false)
 
     pos = CartesianPoint{T}(0.02,0,0.05); Edep = 1u"eV"
@@ -175,7 +182,7 @@ end
 end
 
 @testset "Table Simulation" begin 
-    sim = Simulation(SSD_examples[:InvertedCoax])
+    sim = Simulation{T}(SSD_examples[:InvertedCoax])
     simulate!(sim, convergence_limit = 1e-5, refinement_limits = [0.2, 0.1], verbose = false)
 
     evt_table = Table(
@@ -225,4 +232,4 @@ end
     @test sim == Simulation(nt)
 end 
 
-include("ConstructiveSolidGeometry/CSG_IO.jl")
+


### PR DESCRIPTION
This PR changes the definition of the polar angle `φ` for both `Cone` and `Torus` as requested in #215 and #236.
`φ` is can now only be full 2π (`Nothing`) or a number (`T`), where `φ = 50°` describes the range from `0°` to `50°`.
This is explicitly required in the source code by demanding `φ::TP where {TP <: Union{Nothing,T}}`.

I also added tests for `Cone` and `Torus` which should cover most (if not all) of the cases that we describe and increase the code coverage. I also spotted some bugs while running the tests that are fixed with this PR.

I tried out some combinations of rotations and translations, and the implementation seems to be right
(basically, we set `φ` to be the width of the former `φ` interval and add a rotation around the `Z` axis by `φ[1]`).

### Full 2π Cone
```yaml
cone:
  r:
    bottom:
      from: 1.0
      to: 2.0
    top:
      from: 1.0
      to: 2.0
  h: 2.0
  rotation:
    X: 45.0°
  origin: [0,1,0]
```
### Partial Cone
```yaml
cone:
  r:
    bottom:
      from: 1.0
      to: 2.0
    top:
      from: 1.0
      to: 2.0
  phi:
    from: 80.0°
    to: 140.0°
  h: 2.0
  rotation:
    X: 45.0°
  origin: [0,1,0]
```

![PartialCone](https://user-images.githubusercontent.com/30291312/140002991-c1c5b84a-b1f2-4c93-920a-78d1f578e43a.png)


The tricky part is when intervals need to be converted to the new `φ` syntax, e.g. when determining the `EllipticalSurfaces` that describe `φ` cross-sections of a `Torus`.
![TorusEllipticalSurfaces](https://user-images.githubusercontent.com/30291312/140003682-f327c9bb-a786-406a-8f0e-72adea393773.png)

Then `θ::Tuple{T,T}` is converted to the "new" `φ::T` through `φ = abs(-(θ...))` and a rotation around `θ[1]`:


Another nice thing is that the bulletized point contacts from SigGen configuration files now look quite decent, as they are not constructed using `CSGDifference` anymore:

```julia
sim = Simulation(SSD_examples[:SigGen])
plot(
    plot(sim.detector, st = :mesh3d)
    plot(sim.detector.contacts[1], st = :mesh3d)
)
```

![bulletizedPC](https://user-images.githubusercontent.com/30291312/140003983-cdfaf934-5208-46e5-a774-a75b4aa2c3f2.png)

