### PR TITLE
Fix in plot recipe for `EHDriftPath`

### DIFF
--- a/src/PlotRecipes/DriftPaths.jl
+++ b/src/PlotRecipes/DriftPaths.jl
@@ -1,35 +1,34 @@
-@recipe function f(dp::EHDriftPath{T}; showlabel = true, scaling = 1.0) where {T <: Real}
+@recipe function f(dp::EHDriftPath{T}; showlabel = true) where {T <: Real}
     legendfontsize --> 15
     linewidth --> 3
     seriestype --> :path3d
     @series begin
         showlabel ? label --> "e-" : label --> ""
         seriescolor --> :red
-        [CartesianPoint{T}(path * scaling) for path in dp.e_path]
+        [CartesianPoint{T}(path) for path in dp.e_path]
     end
     @series begin
         showlabel ? label --> "h+" : label --> ""
         seriescolor --> :green
-        [CartesianPoint{T}(path * scaling) for path in dp.h_path]
+        [CartesianPoint{T}(path) for path in dp.h_path]
     end
     @series begin
         label := ""
         seriestype := :scatter
         seriescolor --> :red
-        CartesianPoint{T}(dp.e_path[end] * scaling)
+        CartesianPoint{T}(dp.e_path[end])
     end
     @series begin
         label := ""
         seriestype := :scatter
         seriescolor --> :green
-        CartesianPoint{T}(dp.h_path[end] * scaling)
+        CartesianPoint{T}(dp.h_path[end])
     end
 end
-@recipe function f(dps::Vector{EHDriftPath{T}}, scaling = 1.0) where {T <: Real}
+@recipe function f(dps::Vector{EHDriftPath{T}}) where {T <: Real}
     for i in eachindex(dps)
         @series begin
-            scaling --> scaling
-            i == 1 ? showlabel --> true : showlabel --> false
+            showlabel --> i == 1
             dps[i]
         end
     end

--- a/src/PlotRecipes/DriftPaths.jl
+++ b/src/PlotRecipes/DriftPaths.jl
@@ -1,5 +1,5 @@
 @recipe function f(dp::EHDriftPath{T}; showlabel = true, scaling = 1.0) where {T <: Real}
-    legendfont --> 15
+    legendfontsize --> 15
     linewidth --> 3
     seriestype --> :path3d
     @series begin


### PR DESCRIPTION
Based on the newest Plots.jl release (v1.23.6), the plot recipe for `EHDriftPath` results in an error.
This is fixed with this PR. The code shown here also works with older Plots versions.