### PR TITLE
Adjust conversion of `Geometry` to `Dictionary` for the new definition of `φ` in `Cone` and `Torus`

### DIFF
--- a/src/ConstructiveSolidGeometry/Transformations.jl
+++ b/src/ConstructiveSolidGeometry/Transformations.jl
@@ -31,7 +31,7 @@ function Dictionary(m::SMatrix{3,3,T,9}) where {T}
     mat = RotXYZ(m)
     if mat.theta1 == 0 && mat.theta2 == 0
         if mat.theta3 != 0
-            dict["Z"] = string(mat.theta3)*"rad"
+            dict["Z"] = string(rad2deg(mat.theta3))*"°"
         end
     else
         dict["M"] = m[:]

--- a/src/ConstructiveSolidGeometry/VolumePrimitives/Cone.jl
+++ b/src/ConstructiveSolidGeometry/VolumePrimitives/Cone.jl
@@ -692,10 +692,18 @@ function Dictionary(c::Cone{T, <:Any, TR})::OrderedDict{String, Any} where {T, T
             OrderedDict{String, Any}("from" => c.r[2][1], "to" => c.r[2][2])
         end
     end
-    if !isnothing(c.φ) dict["phi"] = OrderedDict("from" => 0, "to" => string(c.φ)*"rad") end
+    if !isnothing(c.φ) dict["phi"] = OrderedDict("from" => "0°", "to" => string(rad2deg(c.φ))*"°") end
     dict["h"] = 2*c.hZ
     if c.origin != zero(CartesianVector{T}) dict["origin"] = c.origin end
-    if c.rotation != one(SMatrix{3,3,T,9}) dict["rotation"] = Dictionary(c.rotation) end
+    if c.rotation != one(SMatrix{3,3,T,9}) 
+        d = Dictionary(c.rotation)
+        if unique(keys(d)) == ["Z"]
+            φ0 = mod2pi(_parse_value(T, d["Z"], internal_angle_unit))
+            dict["phi"] = OrderedDict("from" => string(rad2deg(φ0))*"°", "to" => string(rad2deg(φ0 + c.φ))*"°")
+        else
+            dict["rotation"] = d
+        end
+    end
     OrderedDict{String, Any}(name => dict)
 end
 

--- a/src/ConstructiveSolidGeometry/VolumePrimitives/Torus.jl
+++ b/src/ConstructiveSolidGeometry/VolumePrimitives/Torus.jl
@@ -137,10 +137,18 @@ function Dictionary(t::Torus{T,<:Any,TR})::OrderedDict{String, Any} where {T,TR}
     dict = OrderedDict{String, Any}()
     dict["r_torus"] = t.r_torus
     dict["r_tube"] = TR <: Real ? t.r_tube : OrderedDict{String, Any}("from" => t.r_tube[1], "to" => t.r_tube[2]) 
-    if !isnothing(t.φ) dict["phi"]   = OrderedDict("from" => 0, "to" => string(t.φ)*"rad") end
-    if !isnothing(t.θ) dict["theta"] = OrderedDict("from" => string(t.θ[1])*"rad", "to" => string(t.θ[2])*"rad") end
+    if !isnothing(t.φ) dict["phi"]   = OrderedDict("from" => "0°", "to" => string(rad2deg(t.φ))*"°") end
+    if !isnothing(t.θ) dict["theta"] = OrderedDict("from" => string(rad2deg(t.θ[1]))*"°", "to" => string(rad2deg(t.θ[2]))*"°") end
     if t.origin != zero(CartesianVector{T}) dict["origin"] = t.origin end
-    if t.rotation != one(SMatrix{3,3,T,9}) dict["rotation"] = Dictionary(t.rotation) end
+    if t.rotation != one(SMatrix{3,3,T,9}) 
+        d = Dictionary(t.rotation)
+        if unique(keys(d)) == ["Z"]
+            φ0 = mod2pi(_parse_value(T, d["Z"], internal_angle_unit))
+            dict["phi"] = OrderedDict("from" => string(rad2deg(φ0))*"°", "to" => string(rad2deg(φ0 + t.φ))*"°")
+        else
+            dict["rotation"] = d
+        end
+    end
     OrderedDict{String, Any}("torus" => dict)
 end
 


### PR DESCRIPTION
With the new implementation of `φ` in `Cone` and `Torus` that is now on the master branch (#243), the conversion of `Geometry` to a `Dictionary` needs to be updated.

Right now, the geometry
```yaml
tube:
  r : 2
  phi:
    from: 30°
    to: 210°
  h: 2
```
will be`parsed as 
```julia
Cone(
  r = 2
  φ = π
  hZ = 1
  origin = [0,0,0]
  rotation = RotZ(π/6)
)
```
When converting this back to a configuration file with `CSG.Dictionary`, this gives
```yaml
tube:
  r : 2
  phi:
    from: 0
    to: 3.141592653589793rad
  h: 2
  rotation:
    Z: 0.5235987755982988rad
```

This PR will increase the readability by
- saving the angles in units of degree (3b92123f0494afe2a6d0e20624ffb93d4a86e4c2)
- adding the offset of `φ` back to the `phi` entry in the config file if the rotation matrix is only a rotation around `Z` (d265da7c8cc0edc2bf04841b8c8043c3b72febde)
- running additional tests to ensure that the conversion between `Geometry` and `Dictionary` is done correctly (118dfb3f7dcb0738604ef6101aa532a43e524157)

resulting in
```yaml
tube:
  r : 2
  phi:
    from: 30°
    to: 210°
  h: 2
```
However, there might be rounding errors, so the initial and final dictionary are only identical within the type precision.

The `Dictionary` function is used when converting config files from v0.5 or before to v0.6 or after.
I think it would be beneficial to have the updated config file as readable and editable as possible.

After this, I would propose a new release v0.7.3.