### PR TITLE
Hotfix for `in` method for `CSGIntersection`

### DIFF
--- a/docs/src/man/electric_potential.md
+++ b/docs/src/man/electric_potential.md
@@ -49,7 +49,7 @@ impurity_density:
   value: 1e10cm^-3 # => 10¹⁹ m⁻³
 ```
 If no units are given, `value` is interpreted in units of `units.length`$^{-3}$.
-They are converted is SI units (m$^(-3)$) internally.
+They are converted to SI units (m$^{-3}$) internally.
 
 
 ### Linear Impurity Density

--- a/src/ConstructiveSolidGeometry/CSG.jl
+++ b/src/ConstructiveSolidGeometry/CSG.jl
@@ -106,7 +106,7 @@ struct CSGIntersection{T, A <: AbstractGeometry{T}, B <: AbstractGeometry{T}} <:
 end
 
 in(pt::AbstractCoordinatePoint{T}, csg::CSGIntersection, csgtol::T = csg_default_tol(T)) where {T} = 
-    in(pt, csg.a; csgtol) && in(pt, csg.b; csgtol)
+    in(pt, csg.a, csgtol) && in(pt, csg.b, csgtol)
 (&)(a::A, b::B) where {T, A <: AbstractGeometry{T}, B <: AbstractGeometry{T}} = CSGIntersection{T,A,B}(a, b)
 
 # read-in


### PR DESCRIPTION
This PR fixes a bug that was introduced with PR #238.
(`csgtol` stopped being a keyword argument, but the `in` method for `CSGIntersection` was not updated)