### PR TITLE
Add function to determine the depletion voltage

### DIFF
--- a/docs/src/tutorial_lit.jl
+++ b/docs/src/tutorial_lit.jl
@@ -90,6 +90,11 @@ is_depleted(sim_undep.point_types)
 println("Depleted:   ", get_active_volume(sim.point_types))
 println("Undepleted: ", get_active_volume(sim_undep.point_types));
 
+# The depletion voltage can also be estimated from the simulation with the depleted detector.
+# For this, the user has to choose a contact to which to apply the voltage, as well as a range to probe:
+
+get_depletion_voltage(sim, 2, 1700:0.5:2000)
+
 
 # ## Electric field calculation
 

--- a/src/Simulation/DepletionVoltage.jl
+++ b/src/Simulation/DepletionVoltage.jl
@@ -1,0 +1,105 @@
+# """
+#     _adapt_weighting_potential_to_electric_potential_grid!(sim::Simulation, contact_id::Int)
+# 
+# Interpolates the [`WeightingPotetial`](@ref) of the [`Contact`](@ref) with id `contact_id`
+# onto the [`Grid`](@ref) of the [`ElectricPotential`](@ref) and updates it until it converges.
+# 
+# ## Arguments 
+# * `sim::Simulation{T}`: [`Simulation`](@ref) for which the [`WeightingPotential`] should be adapted.
+# * `contact_id::Int`: The `id` of the [`Contact`](@ref) at which the [`WeightingPotential`] should be adapted.
+# """
+function _adapt_weighting_potential_to_electric_potential_grid!(sim::Simulation, contact_id::Int)
+    @assert !ismissing(sim.electric_potential) "Electric potential missing"
+    if ismissing(sim.weighting_potentials[contact_id]) calculate_weighting_potential!(sim, contact_id, verbose = false) end
+    if sim.weighting_potentials[contact_id].grid != sim.electric_potential.grid
+        sim.weighting_potentials[contact_id] = sim.weighting_potentials[contact_id][sim.electric_potential.grid]
+        #apply_initial_state!(sim, WeightingPotential, contact_id, sim.electric_potential.grid)
+        update_till_convergence!(sim, WeightingPotential, contact_id)
+    end
+end
+
+"""
+    get_depletion_voltage( sim::Simulation{T}, contact_id::Int, potential_range::AbstractRange; kwargs... )::T
+
+Returns the potential (in V) needed at the [`Contact`](@ref) with id `contact_id`
+to fully deplete the detector in a given [`Simulation`](@ref). For this, all other
+contact potentials are set to `0` and the potential at the specified contact is
+increased or decreased according to the `potential_range`. The depletion voltage
+is set to the potential for which a previously undepleted detector becomes depleted,
+or for which a previously depleted detector becomes undepleted.
+
+## Arguments 
+* `sim::Simulation{T}`: [`Simulation`](@ref) for which the depletion voltage should be determined.
+* `contact_id::Int`: The `id` of the [`Contact`](@ref) at which the potential is applied.
+* `potential_range::AbstractRange`: Range of potentials to be tested.
+    
+## Keywords
+* `verbose::Bool = true`: Activate or deactivate additional info output. Default is `true`.
+
+## Example 
+```julia
+using SolidStateDetectors
+sim = Simulation(SSD_examples[:InvertedCoax])
+calculate_electric_potential!(sim)
+get_depletion_voltage(sim, 2, 1600:1:2500)
+```
+
+!!! warn
+    This method only works if the initial `sim` was calculated for a case in which the detector is fully depleted.
+
+!!! note
+    The accuracy of the result depends on the precision of the initial simulation.
+    
+See also [`is_depleted`](@ref).
+"""
+function get_depletion_voltage(sim::Simulation{T}, contact_id::Int,
+            potential_range::AbstractRange = range(extrema(broadcast(c -> c.potential, sim.detector.contacts))..., length = 1001);
+            verbose = true)::T where {T <: AbstractFloat}
+    
+    @assert is_depleted(sim.point_types) "This method only works for fully depleted simulations. Please increase the potentials in the configuration file to a greater value."
+    
+    if verbose
+        @info "Looking for the depletion voltage applied to contact $(contact_id) "*
+              "in the range $(extrema(potential_range).*u"V") in steps of $(step(potential_range)*u"V")."
+    end
+    
+    for c in sim.detector.contacts
+        if c.potential == 0 && c.id != contact_id continue end
+        if ismissing(sim.weighting_potentials[c.id]) || sim.weighting_potentials[c.id].grid != sim.electric_potential.grid
+            @info "The weighting potential $(c.id) need to be defined on the same grid as the electric potential. Adjusting weighting potential $(c.id) now."
+            _adapt_weighting_potential_to_electric_potential_grid!(sim, c.id)
+        end
+    end
+    
+    # ϕρ is the electric potential resulting only from the impurity density
+    # and setting all potentials on the contacts to zero
+    ϕρ = deepcopy(sim.electric_potential.data)
+    for c in sim.detector.contacts
+        if c.potential == 0 continue end
+        ϕρ .-= c.potential * sim.weighting_potentials[c.id].data
+    end
+    
+    inside = findall(p -> p & pn_junction_bit > 0 && p & update_bit > 0, sim.point_types.data)
+    
+    ϕmin, ϕmax = extrema((ϕρ .+ potential_range[1] * sim.weighting_potentials[contact_id].data)[inside])
+    initial_depletion::Bool = ϕmax - ϕmin < abs(potential_range[1])
+    depletion_voltage::T = NaN
+
+    @showprogress for U in potential_range
+        ϕmin, ϕmax = extrema((ϕρ .+ T(U) * sim.weighting_potentials[contact_id].data)[inside])
+        depleted = ϕmax - ϕmin < abs(U)
+        if (initial_depletion && !depleted) || (!initial_depletion && depleted)
+            depletion_voltage = T(U)
+            break
+        end
+    end
+    
+    if verbose
+        if !isnan(depletion_voltage)
+            @info "The depletion voltage of the detector is ($(depletion_voltage) ± $(T(step(potential_range)))) V applied to contact $(contact_id)."
+        else
+            @warn "The depletion voltage is not in the specified range $(extrema(potential_range).*u"V")."
+        end
+    end
+    return depletion_voltage
+end

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -1289,3 +1289,4 @@ end
 
 include("ElectricFieldEnergy.jl")
 include("Capacitance.jl")
+include("DepletionVoltage.jl")

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -80,27 +80,32 @@ Base.convert(T::Type{NamedTuple}, x::Simulation) = T(x)
 
 function Simulation(nt::NamedTuple)
     missing_tuple = NamedTuple(missing)
-    epot = ElectricPotential(nt.electric_potential)
-    T = eltype(epot.data)
-    sim = Simulation{T}( Dict(nt.detector_json_string) )
-    sim.electric_potential = epot
-    sim.q_eff_imp = EffectiveChargeDensity(nt.q_eff_imp)
-    sim.q_eff_fix = EffectiveChargeDensity(nt.q_eff_fix)
-    sim.ϵ_r = DielectricDistribution(nt.ϵ_r)
-    sim.point_types = PointTypes(nt.point_types)
-    sim.imp_scale = if !haskey(nt, :imp_scale) 
-        @warn """Stored simulation does not have a field for `imp_scale` (impurity scale) as this was 
-        first introduced in SolidStateDetectors.jl v0.8 for improved depletion handling.
-        It is advised to recalculate the simulation with the latest version.
-        The field `imp_scale` is determined from `point_types`: 
-            * undepleted point -> imp_scale = 0;  
-            * depleted point -> imp_scale = 1;  
-        """
-        ImpurityScale(T.(.!is_undepleted_point_type.(sim.point_types.data)), sim.point_types.grid)
+    if nt.electric_potential !== missing_tuple
+        epot = ElectricPotential(nt.electric_potential)
+        T = eltype(epot.data)
+        sim = Simulation{T}( Dict(nt.detector_json_string) )
+        sim.electric_potential = epot
+        sim.q_eff_imp = EffectiveChargeDensity(nt.q_eff_imp)
+        sim.q_eff_fix = EffectiveChargeDensity(nt.q_eff_fix)
+        sim.ϵ_r = DielectricDistribution(nt.ϵ_r)
+        sim.point_types = PointTypes(nt.point_types)
+        sim.imp_scale = if !haskey(nt, :imp_scale) 
+            @warn """Stored simulation does not have a field for `imp_scale` (impurity scale) as this was 
+            first introduced in SolidStateDetectors.jl v0.8 for improved depletion handling.
+            It is advised to recalculate the simulation with the latest version.
+            The field `imp_scale` is determined from `point_types`: 
+                * undepleted point -> imp_scale = 0;  
+                * depleted point -> imp_scale = 1;  
+            """
+            ImpurityScale(T.(.!is_undepleted_point_type.(sim.point_types.data)), sim.point_types.grid)
+        else
+            ImpurityScale(nt.imp_scale)
+        end
+        sim.electric_field = haskey(nt, :electric_field) && nt.electric_field !== missing_tuple ? ElectricField(nt.electric_field) : missing
     else
-        ImpurityScale(nt.imp_scale)
+        T = Float32
+        sim = Simulation{T}( Dict(nt.detector_json_string) )
     end
-    sim.electric_field = haskey(nt, :electric_field) && nt.electric_field !== missing_tuple ? ElectricField(nt.electric_field) : missing
     sim.weighting_potentials = if haskey(nt, :weighting_potentials) 
         [let wp = Symbol("WeightingPotential_$(contact.id)")
             haskey(nt.weighting_potentials, wp) && getfield(nt.weighting_potentials, wp) !== missing_tuple ? WeightingPotential(getfield(nt.weighting_potentials, wp)) : missing 

--- a/src/SolidStateDetectors.jl
+++ b/src/SolidStateDetectors.jl
@@ -66,7 +66,7 @@ export ElectricPotential, PointTypes, EffectiveChargeDensity, DielectricDistribu
 export apply_initial_state!
 export calculate_electric_potential!, calculate_weighting_potential!, calculate_electric_field!, calculate_drift_fields!
 export ElectricFieldChargeDriftModel, ADLChargeDriftModel
-export get_active_volume, is_depleted
+export get_active_volume, is_depleted, get_depletion_voltage
 export calculate_stored_energy, calculate_mutual_capacitance, calculate_capacitance_matrix
 export simulate_waveforms
 export Simulation, simulate!


### PR DESCRIPTION
This PR would close #193.
I wrote a method `get_depletion_voltage` to estimate the potential needed at a given contact to fully deplete the detector.

## How does it work?
The electric potential inside a detector (`ϕ`) is given by the contribution from the ionized impurities in the semiconductor when all contacts are grounded (`ϕρ`) and the contribution from the potentials applied to the contacts of the detector (`ϕV`).

![ElectricPotentialContributions](https://user-images.githubusercontent.com/30291312/149997861-eebe0975-591c-4df4-a25c-2a86a86322e9.png)

Mathematically, the contribution from the potentials applied to the contacts corresponds to the `WeightingPotential` of the contacts times the potentials applied to the contacts. Thus, `ϕρ` can be determined by subtracting the `WeightingPotentials` times the potentials applied to the contacts from the `ElectricPotential`.

The detector is depleted when no point in the detector has a potential value outside of the range given by the potentials applied to the contacts. In the picture above, `ϕρ` has its maximum in the center of the bulk at around 1100V.

By applying a potential (in this case to the point contact at the top of the detector), `ϕV` can be varied such that the final `ϕ` does not reach its maximum in the bulk of the detector but on the point contact. It is then depleted.
![VoltageScan](https://user-images.githubusercontent.com/30291312/149999473-34abe73a-9c6c-4822-889a-2c937e305712.gif)

The idea of `get_depletion_voltage` is to find the "first" potential, at which the minimum and maximum values of the resulting `ElectricPotential` are reached on the contacts and not in the bulk of the detector.


## How is it implemented?

This method only works, if the original `ElectricPotential` is calculated for a depleted detector. Thus, it is first checked whether the original detector setup is depleted.

Then, all the `WeightingPotentials` of the contacts, at which the potentials are non-zero, are interpolated to the `Grid` of the already calculated `ElectricPotential` (via `_adapt_weighting_potential_to_electric_potential_grid!`). By not only interpolating but also updating the resulting `WeightingPotential` until convergence, the interpolation errors are reduced.

`ϕρ` is calculated by subtracting the adapted `WeightingPotentials` times the potential of the contact from the `ElectricPotential`.
Then, the extrema values for all grid points in the semiconductor, `ϕmin` and  `ϕmax`, are determined for the initial configuration, from which can be deducted if the setup is initially depleted or not (`ìnitial_depletion`).

Then, a loop iterates through all voltages given by the `potential_range`. For each potential value, `ϕmin` and  `ϕmax` are again calculated which determine whether the detector is depleted, ie. if  `ϕmax - ϕmin` is smaller than the applied bias voltage.
If the `initial_depletion` does not match the current depletion behavior, we have reached the depletion voltage which is, then, returned by the function. If  the `initial_depletion` does not change throughout the given potential range, this means that the depletion voltage most probably is not within that range.

## Things to take into account

- `get_depletion_voltage` overwrites the `WeightingPotentials` of the `Simulation` when they are adapted (which leaves them with a new grid). Is that a problem?
- I did not add any tests for this.
