### PR TITLE
Add pseudo geometry for tests

### DIFF
--- a/docs/src/tutorial_lit.jl
+++ b/docs/src/tutorial_lit.jl
@@ -13,7 +13,7 @@ plot(sim.detector, size = (700, 700))
 #md savefig("tutorial_det.svg"); nothing # hide
 #md # [![tutorial_det](tutorial_det.svg)](tutorial_det.pdf)
 
-# One can also have a look at how the initial conditions look like on the grid (its starts with a very coarse grid):
+# One can also have a look at how the initial conditions look like on the grid (it starts with a very coarse grid):
 
 apply_initial_state!(sim, ElectricPotential) # optional
 plot(
@@ -116,7 +116,7 @@ plot_electric_fieldlines!(sim, full_det = true, φ = 0.0)
 charge_drift_model = ADLChargeDriftModel()
 sim.detector = SolidStateDetector(sim.detector, charge_drift_model)
 
-# Now, let's create an "random" multi-site event:
+# Now, let's create a "random" multi-site event:
 
 starting_positions = [ CylindricalPoint{T}( 0.020, deg2rad(10), 0.015 ),
                        CylindricalPoint{T}( 0.015, deg2rad(20), 0.045 ),

--- a/examples/example_config_files/test_geometry.yaml
+++ b/examples/example_config_files/test_geometry.yaml
@@ -39,16 +39,39 @@ detectors:
       include: ADLChargeDriftModel/drift_velocity_config.yaml
     geometry:
       box:
-          widths: [1, 1, 1]
+          widths: [20, 20, 18]
           origin:
-            x: 5.5
-            y: 5
-            z: -5
+            x: 0
+            y: 0
+            z: 0
   contacts:
+    - name: Top Contact
+      material: HPGe
+      potential: 3000
+      id: 1
+      geometry:
+        box:
+          widths: [20, 20, 1]
+          origin:
+            x: 0
+            y: 0
+            z: 9.5
+    - name: Bottom Contact
+      material: HPGe
+      potential: 3000
+      id: 2
+      geometry:
+        box:
+          widths: [20, 20, 1]
+          origin:
+            x: 0
+            y: 0
+            z: -9.5
+
     - name: Box
       material: HPGe
-      potential: 10
-      id: 1
+      potential: 0
+      id: 3
       geometry:
         union:
         - intersection:
@@ -89,7 +112,7 @@ detectors:
     - name: Cone
       material: HPGe
       potential: 0
-      id: 2
+      id: 4
       geometry:
         union:
         - cone:
@@ -119,8 +142,8 @@ detectors:
 
     - name: Ellipsoid
       material: HPGe
-      potential: 4
-      id: 3
+      potential: 0
+      id: 5
       geometry:
         sphere:
           r: 1
@@ -130,8 +153,8 @@ detectors:
 
     - name: Prism
       material: HPGe
-      potential: 4
-      id: 4
+      potential: 0
+      id: 6
       geometry:
         union:
         - HexagonalPrism:
@@ -155,8 +178,8 @@ detectors:
 
     - name: Torus
       material: HPGe
-      potential: 4
-      id: 5
+      potential: 0
+      id: 7
       geometry:
         torus:
           r_torus: 1

--- a/examples/example_config_files/test_geometry.yaml
+++ b/examples/example_config_files/test_geometry.yaml
@@ -38,83 +38,53 @@ detectors:
     charge_drift_model:
       include: ADLChargeDriftModel/drift_velocity_config.yaml
     geometry:
-      box:
-          widths: [20, 20, 18]
-          origin:
-            x: 0
-            y: 0
-            z: 0
-  contacts:
-    - name: Top Contact
-      material: HPGe
-      potential: 3000
-      id: 1
-      geometry:
-        box:
-          widths: [20, 20, 1]
-          origin:
-            x: 0
-            y: 0
-            z: 9.5
-    - name: Bottom Contact
-      material: HPGe
-      potential: 0
-      id: 2
-      geometry:
-        box:
-          widths: [20, 20, 1]
-          origin:
-            x: 0
-            y: 0
-            z: -9.5
-
-    - name: Box
-      material: HPGe
-      potential: 0
-      id: 3
-      geometry:
-        union:
-        - intersection:
-            - box:
-                hX: 0.5
-                hY: 0.5
-                hZ: 0.5
-                origin:
-                  x: 5
-                  y: 5
-                  z: -5
-            - difference:
+      union:
+      
+      - box:
+            widths: [20, 20, 18]
+            origin:
+              x: 0
+              y: 0
+              z: 0
+      
+      - union:
+          - intersection:
               - box:
-                  widths: [1, 1, 1]
+                  hX: 0.5
+                  hY: 0.5
+                  hZ: 0.5
                   origin:
-                    x: 5.5
+                    x: 5
                     y: 5
                     z: -5
-              - box:
-                  x:
-                    from: 5.25
-                    to: 5.75
-                  y:
-                    from: 4.5
-                    to: 5.5
-                  z:
-                    from: -5.5
-                    to: -4.5
+              - difference:
+                - box:
+                    widths: [1, 1, 1]
+                    origin:
+                      x: 5.5
+                      y: 5
+                      z: -5
+                - box:
+                    x:
+                      from: 5.25
+                      to: 5.75
+                    y:
+                      from: 4.5
+                      to: 5.5
+                    z:
+                      from: -5.5
+                      to: -4.5
 
-        - box:
-            halfwidths: [0.5, 0.5, 0.5]
-            origin:
-              x: 5
-              y: 6.5
-              z: -5
-            rotate:
-              Z: 20
-    - name: Cone
-      material: HPGe
-      potential: 0
-      id: 4
-      geometry:
-        union:
+          - box:
+              halfwidths: [0.5, 0.5, 0.5]
+              origin:
+                x: 5
+                y: 6.5
+                z: -5
+              rotate:
+                Z: 20
+      
+      - union:
         - cone:
             r:
               bottom:
@@ -140,23 +110,15 @@ detectors:
             rotation:
               M: [1, 0, 0, 0, 0, -1, 0, 1, 0]
 
-    - name: Ellipsoid
-      material: HPGe
-      potential: 0
-      id: 5
-      geometry:
-        sphere:
+      
+      - sphere:
           r: 1
           origin: [-3,-3,-3]
           rotation:
             M: [1, 0, 0, 0, 0, -1, 0, 1, 0]
-
-    - name: Prism
-      material: HPGe
-      potential: 0
-      id: 6
-      geometry:
-        union:
+      
+      
+      - union:
         - HexagonalPrism:
             r: 1
             h: 1
@@ -175,15 +137,36 @@ detectors:
             r: 1
             z: 1
             origin: [3,-3,3]
-
-    - name: Torus
-      material: HPGe
-      potential: 0
-      id: 7
-      geometry:
-        torus:
+  
+      - torus:
           r_torus: 1
           r_tube: 0.5
           origin: [3,-3,-3]
           rotation:
             M: [1, 0, 0, 0, 0, -1, 0, 1, 0]
+
+  contacts:
+    - name: Top Contact
+      material: HPGe
+      potential: 3000
+      id: 1
+      geometry:
+        box:
+          widths: [20, 20, 1]
+          origin:
+            x: 0
+            y: 0
+            z: 9.5
+    - name: Bottom Contact
+      material: HPGe
+      potential: 0
+      id: 2
+      geometry:
+        box:
+          widths: [20, 20, 1]
+          origin:
+            x: 0
+            y: 0
+            z: -9.5
+
+    

--- a/examples/example_config_files/test_geometry.yaml
+++ b/examples/example_config_files/test_geometry.yaml
@@ -1,0 +1,166 @@
+name: Geometry for Tests
+units:
+  length: m
+  angle: deg
+  potential: V
+  temperature: K
+grid:
+  coordinates: cartesian
+  axes:
+    x:
+      from: -10
+      to: 10
+      boundaries: reflecting
+    y:
+      from: -10
+      to: 10
+      boundaries: reflecting
+    z:
+      from: -10
+      to: 10
+      boundaries: reflecting
+medium: vacuum
+detectors:
+- semiconductor:
+    material: HPGe
+    temperature: 78
+    impurity_density:
+      name: linear
+      x:
+        init: 0
+        gradient: 0
+      y:
+        init: 0
+        gradient: 0
+      z:
+        init: 0
+        gradient: 0
+    charge_drift_model:
+      include: ADLChargeDriftModel/drift_velocity_config.yaml
+    geometry:
+      box:
+          widths: [1, 1, 1]
+          origin:
+            x: 5.5
+            y: 5
+            z: -5
+  contacts:
+    - name: Box
+      material: HPGe
+      potential: 10
+      id: 1
+      geometry:
+        union:
+        - intersection:
+            - box:
+                hX: 0.5
+                hY: 0.5
+                hZ: 0.5
+                origin:
+                  x: 5
+                  y: 5
+                  z: -5
+            - difference:
+              - box:
+                  widths: [1, 1, 1]
+                  origin:
+                    x: 5.5
+                    y: 5
+                    z: -5
+              - box:
+                  x:
+                    from: 5.25
+                    to: 5.75
+                  y:
+                    from: 4.5
+                    to: 5.5
+                  z:
+                    from: -5.5
+                    to: -4.5
+
+        - box:
+            halfwidths: [0.5, 0.5, 0.5]
+            origin:
+              x: 5
+              y: 6.5
+              z: -5
+            rotate:
+              Z: 20
+    - name: Cone
+      material: HPGe
+      potential: 0
+      id: 2
+      geometry:
+        union:
+        - cone:
+            r:
+              bottom:
+                from: 0
+                to: 1
+              top:
+                from: 0
+                to: 0
+            phi:
+              from: 0.0
+              to: 360
+            h: 1.0
+            origin: [2,2,2]
+        - tube:
+            r:
+              from: 0.5
+              to: 1
+            phi:
+              from: 0.0
+              to: 360
+            z: 1
+            origin: [3,3,3]
+            rotation:
+              M: [1, 0, 0, 0, 0, -1, 0, 1, 0]
+
+    - name: Ellipsoid
+      material: HPGe
+      potential: 4
+      id: 3
+      geometry:
+        sphere:
+          r: 1
+          origin: [-3,-3,-3]
+          rotation:
+            M: [1, 0, 0, 0, 0, -1, 0, 1, 0]
+
+    - name: Prism
+      material: HPGe
+      potential: 4
+      id: 4
+      geometry:
+        union:
+        - HexagonalPrism:
+            r: 1
+            h: 1
+            origin: [3,-3,3]
+            rotation:
+              M: [1, 0, 0, 0, 0, -1, 0, 1, 0]
+        - PentagonalPrism:
+            r: 1
+            z: 1
+            origin: [3,-3,3]
+        - QuadranglePrism:
+            r: 1
+            z: 1
+            origin: [3,-3,3]
+        - TriangularPrism:
+            r: 1
+            z: 1
+            origin: [3,-3,3]
+
+    - name: Torus
+      material: HPGe
+      potential: 4
+      id: 5
+      geometry:
+        torus:
+          r_torus: 1
+          r_tube: 0.5
+          origin: [3,-3,-3]
+          rotation:
+            M: [1, 0, 0, 0, 0, -1, 0, 1, 0]

--- a/examples/example_config_files/test_geometry.yaml
+++ b/examples/example_config_files/test_geometry.yaml
@@ -50,37 +50,37 @@ detectors:
       - union:
           - intersection:
               - box:
-                  hX: 0.5
-                  hY: 0.5
-                  hZ: 0.5
+                  hX: 1.5
+                  hY: 1.5
+                  hZ: 1.5
                   origin:
-                    x: 5
-                    y: 5
-                    z: -5
+                    x: 7.5
+                    y: 7.5
+                    z: -5.5
               - difference:
                 - box:
-                    widths: [1, 1, 1]
+                    widths: [3, 3, 3]
                     origin:
-                      x: 5.5
-                      y: 5
-                      z: -5
+                      x: 8
+                      y: 8
+                      z: -6
                 - box:
                     x:
-                      from: 5.25
-                      to: 5.75
+                      from: 7
+                      to: 9
                     y:
-                      from: 4.5
-                      to: 5.5
+                      from: 7
+                      to: 9
                     z:
-                      from: -5.5
-                      to: -4.5
+                      from: -7
+                      to: -5
 
           - box:
-              halfwidths: [0.5, 0.5, 0.5]
+              halfwidths: [1.5, 1.5, 1.5]
               origin:
-                x: 5
-                y: 6.5
-                z: -5
+                x: 7.5
+                y: 7.5
+                z: -1
               rotate:
                 Z: 20
       #Cone volume primitives
@@ -89,66 +89,66 @@ detectors:
             r:
               bottom:
                 from: 0
-                to: 1
+                to: 3
               top:
                 from: 0
                 to: 0
             phi:
               from: 0.0
               to: 360
-            h: 1.0
-            origin: [2,2,2]
+            h: 3.0
+            origin: [6,-6,2]
         - tube:
             r:
-              from: 0.5
-              to: 1
+              from: 1
+              to: 3
             phi:
-              from: 10
-              to: 20
-            z: 1
-            origin: [3,3,3]
+              from: 0
+              to: 180
+            z: 3
+            origin: [6,-6,5]
             rotation:
               M: [1, 0, 0, 0, 0, -1, 0, 1, 0]
       #Ellipsoid volume primitives
       - sphere:
-          r: 1
-          origin: [-3,-3,-3]
+          r: 3
+          origin: [6,-6,-6]
           rotation:
             M: [1, 0, 0, 0, 0, -1, 0, 1, 0]
       #Prism volume primitives
       - union:
         - HexagonalPrism:
-            r: 1
-            h: 1
-            origin: [3,-3,3]
+            r: 3
+            h: 3
+            origin: [-5,-5,-6]
             rotation:
               M: [1, 0, 0, 0, 0, -1, 0, 1, 0]
         - PentagonalPrism:
-            r: 1
-            z: 1
-            origin: [3,-3,3]
+            r: 3
+            z: 3
+            origin: [-5,-5,-2]
         - QuadranglePrism:
-            r: 1
-            z: 1
-            origin: [3,-3,3]
+            r: 3
+            z: 3
+            origin: [-5,-5,2]
         - TriangularPrism:
-            r: 1
-            z: 1
-            origin: [3,-3,3]
+            r: 3
+            z: 3
+            origin: [-5,-5,6]
       #Torus volume primitives 
       - union:     
         - torus:
-            r_torus: 1
-            r_tube: 0.5
+            r_torus: 3
+            r_tube: 2
             theta: 
-                 from: 10
-                 to: 20
-            origin: [3,-3,-3]
+                 from: 0
+                 to: 180
+            origin: [-3,3,-3]
             
         - torus:
-            r_torus: 1
-            r_tube: 0.5
-            origin: [3,-3,-3]
+            r_torus: 4
+            r_tube: 1
+            origin: [-3,3,3]
             rotation:
               M: [1, 0, 0, 0, 0, -1, 0, 1, 0]
               

--- a/examples/example_config_files/test_geometry.yaml
+++ b/examples/example_config_files/test_geometry.yaml
@@ -1,6 +1,6 @@
 name: Geometry for Tests
 units:
-  length: m
+  length: mm
   angle: deg
   potential: V
   temperature: K
@@ -58,7 +58,7 @@ detectors:
             z: 9.5
     - name: Bottom Contact
       material: HPGe
-      potential: 3000
+      potential: 0
       id: 2
       geometry:
         box:

--- a/examples/example_config_files/test_geometry.yaml
+++ b/examples/example_config_files/test_geometry.yaml
@@ -39,14 +39,14 @@ detectors:
       include: ADLChargeDriftModel/drift_velocity_config.yaml
     geometry:
       union:
-      
+      #Semiconductor
       - box:
             widths: [20, 20, 18]
             origin:
               x: 0
               y: 0
-              z: 0
-      
+              z: 0        
+      #Box volume primitives
       - union:
           - intersection:
               - box:
@@ -83,7 +83,7 @@ detectors:
                 z: -5
               rotate:
                 Z: 20
-      
+      #Cone volume primitives
       - union:
         - cone:
             r:
@@ -103,21 +103,19 @@ detectors:
               from: 0.5
               to: 1
             phi:
-              from: 0.0
-              to: 360
+              from: 10
+              to: 20
             z: 1
             origin: [3,3,3]
             rotation:
               M: [1, 0, 0, 0, 0, -1, 0, 1, 0]
-
-      
+      #Ellipsoid volume primitives
       - sphere:
           r: 1
           origin: [-3,-3,-3]
           rotation:
             M: [1, 0, 0, 0, 0, -1, 0, 1, 0]
-      
-      
+      #Prism volume primitives
       - union:
         - HexagonalPrism:
             r: 1
@@ -137,13 +135,23 @@ detectors:
             r: 1
             z: 1
             origin: [3,-3,3]
-  
-      - torus:
-          r_torus: 1
-          r_tube: 0.5
-          origin: [3,-3,-3]
-          rotation:
-            M: [1, 0, 0, 0, 0, -1, 0, 1, 0]
+      #Torus volume primitives 
+      - union:     
+        - torus:
+            r_torus: 1
+            r_tube: 0.5
+            theta: 
+                 from: 10
+                 to: 20
+            origin: [3,-3,-3]
+            
+        - torus:
+            r_torus: 1
+            r_tube: 0.5
+            origin: [3,-3,-3]
+            rotation:
+              M: [1, 0, 0, 0, 0, -1, 0, 1, 0]
+              
 
   contacts:
     - name: Top Contact

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -38,4 +38,5 @@ const SSD_examples = Dict{Symbol,String}([
     :InfiniteCoaxialCapacitorCartesianCoords => joinpath(get_path_to_example_config_files(), "infinite_coaxial_capacitor_cartesian_coords.yaml"),
     :Hexagon                                 => joinpath(get_path_to_example_config_files(), "minimum_hexagon_config.yaml"),
     :CoaxialTorus                            => joinpath(get_path_to_example_config_files(), "public_coaxial_torus_config.yaml"),
+    :TestDetector                            => joinpath(get_path_to_example_config_files(), "test_geometry.yaml"),
 ])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,8 +25,8 @@ end
 T = Float32
 
 @testset "Test real detectors" begin
-    @testset "Simulate example detector: Inverted Coax" begin
-        sim = Simulation{T}(SSD_examples[:InvertedCoax])
+    @testset "Simulate test detector" begin
+        sim = Simulation{T}(SSD_examples[:TestDetector])
         simulate!(sim, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
         evt = Event(CartesianPoint.([CylindricalPoint{T}(20e-3, deg2rad(10), 10e-3 )]))
         simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
@@ -40,30 +40,27 @@ T = Float32
         nt = NamedTuple(sim)
         @test sim == Simulation(nt)
     end
-    @testset "Simulate example detector: Inverted Coax (in cryostat)" begin
-        sim = Simulation{T}(SSD_examples[:InvertedCoaxInCryostat])
-        simulate!(sim, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
-        evt = Event(CartesianPoint.([CylindricalPoint{T}(20e-3, deg2rad(10), 10e-3 )]))
-        simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
-        signalsum = T(0)
-        for i in 1:length(evt.waveforms)
-            signalsum += abs(ustrip(evt.waveforms[i].value[end]))
-        end
-        signalsum *= inv(ustrip(SolidStateDetectors._convert_internal_energy_to_external_charge(sim.detector.semiconductor.material)))
-        @info signalsum
-        @test isapprox( signalsum, T(2), atol = 5e-3 )
-    end
-    # @testset "Simulate example detector: Coax" begin
-    #     sim = Simulation{T}(SSD_examples[:Coax])
-    #     calculate_electric_potential!(sim, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
-    #     calculate_electric_field!(sim)
-    #     calculate_weighting_potential!(sim, 1, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
-    #     calculate_weighting_potential!(sim, 2, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
-    #     for i in 3:19
-    #         calculate_weighting_potential!(sim, i, convergence_limit = 5e-6, refinement_limits = [0.2], verbose = false)
+    
+    # @testset "Simulate example detector: Inverted Coax" begin
+    #     sim = Simulation{T}(SSD_examples[:InvertedCoax])
+    #     simulate!(sim, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
+    #     evt = Event(CartesianPoint.([CylindricalPoint{T}(20e-3, deg2rad(10), 10e-3 )]))
+    #     simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
+    #     signalsum = T(0)
+    #     for i in 1:length(evt.waveforms)
+    #         signalsum += abs(ustrip(evt.waveforms[i].value[end]))
     #     end
-    #     evt = Event(CartesianPoint.([CylindricalPoint{T}(20e-3, deg2rad(30), 12e-3 )]))
-    #     simulate!(evt, sim, Δt = 5e-10, max_nsteps = 10000)
+    #     signalsum *= inv(ustrip(SolidStateDetectors._convert_internal_energy_to_external_charge(sim.detector.semiconductor.material)))
+    #     @info signalsum
+    #     @test isapprox( signalsum, T(2), atol = 5e-3 )
+    #     nt = NamedTuple(sim)
+    #     @test sim == Simulation(nt)
+    # end
+    # @testset "Simulate example detector: Inverted Coax (in cryostat)" begin
+    #     sim = Simulation{T}(SSD_examples[:InvertedCoaxInCryostat])
+    #     simulate!(sim, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
+    #     evt = Event(CartesianPoint.([CylindricalPoint{T}(20e-3, deg2rad(10), 10e-3 )]))
+    #     simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
     #     signalsum = T(0)
     #     for i in 1:length(evt.waveforms)
     #         signalsum += abs(ustrip(evt.waveforms[i].value[end]))
@@ -72,95 +69,114 @@ T = Float32
     #     @info signalsum
     #     @test isapprox( signalsum, T(2), atol = 5e-3 )
     # end
-    @testset "Simulate example detector: BEGe" begin
-        sim = Simulation{T}(SSD_examples[:BEGe])
-        calculate_electric_potential!(sim, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
-        calculate_electric_field!(sim)
-        calculate_weighting_potential!(sim, 1, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
-        for i in 2:5
-            calculate_weighting_potential!(sim, i, convergence_limit = 5e-6, refinement_limits = [0.2], verbose = false)
-        end
-        evt = Event(CartesianPoint.([CylindricalPoint{T}(20e-3, deg2rad(10), 20e-3 )]))
-        simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
-        signalsum = T(0)
-        for i in 1:length(evt.waveforms)
-            signalsum += abs(ustrip(evt.waveforms[i].value[end]))
-        end
-        signalsum *= inv(ustrip(SolidStateDetectors._convert_internal_energy_to_external_charge(sim.detector.semiconductor.material)))
-        @info signalsum
-        @test isapprox( signalsum, T(2), atol = 5e-3 )
-        nt = NamedTuple(sim)
-        @test sim == Simulation(nt)
-    end
-    @testset "Simulate example detector: HexagonalPrism" begin
-        sim = Simulation{T}(SSD_examples[:Hexagon])
-        simulate!(sim, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
-        evt = Event([CartesianPoint{T}(0, 5e-4, 1e-3)])
-        simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
-        signalsum = T(0)
-        for i in 1:length(evt.waveforms)
-            signalsum += abs(ustrip(evt.waveforms[i].value[end]))
-        end
-        signalsum *= inv(ustrip(SolidStateDetectors._convert_internal_energy_to_external_charge(sim.detector.semiconductor.material)))
-        @info signalsum
-        @test isapprox( signalsum, T(2), atol = 5e-3 )
-    end
-    @testset "Simulate example detector: CGD" begin
-        sim = Simulation{T}(SSD_examples[:CGD])
-        simulate!(sim, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
-        evt = Event([CartesianPoint{T}(0,2e-3,0)])
-        simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
-        signalsum = T(0)
-        for i in 1:length(evt.waveforms)
-            signalsum += abs(ustrip(evt.waveforms[i].value[end]))
-        end
-        signalsum *= inv(ustrip(SolidStateDetectors._convert_internal_energy_to_external_charge(sim.detector.semiconductor.material)))
-        @info signalsum
-        @test isapprox( signalsum, T(2), atol = 5e-3 )
-        nt = NamedTuple(sim)
-        @test sim == Simulation(nt)
-    end
-    @testset "Simulate example detector: Spherical" begin
-        sim = Simulation{T}(SSD_examples[:Spherical])
-        simulate!(sim, convergence_limit = 1e-5, refinement_limits = [0.2, 0.1], verbose = false)
-        evt = Event([CartesianPoint{T}(0,0,0)])
-        simulate!(evt, sim)
-        signalsum = T(0)
-        for i in 1:length(evt.waveforms)
-            signalsum += abs(ustrip(evt.waveforms[i].value[end]))
-        end
-        signalsum *= inv(ustrip(SolidStateDetectors._convert_internal_energy_to_external_charge(sim.detector.semiconductor.material)))
-        @info signalsum
-        @test isapprox( signalsum, T(2), atol = 5e-3 )
-    end 
-    @testset "Simulate example detector: Toroidal" begin
-        sim = Simulation{T}(SSD_examples[:CoaxialTorus])
-        SolidStateDetectors.apply_initial_state!(sim, ElectricPotential)
-        simulate!(sim, convergence_limit = 1e-5, refinement_limits = [0.2, 0.1, 0.05, 0.02, 0.01], 
-            max_tick_distance = 0.5u"mm", verbose = false)
-        evt = Event([CartesianPoint{T}(0.0075,0,0)])
-        simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
-        signalsum = T(0)
-        for i in 1:length(evt.waveforms)
-            signalsum += abs(ustrip(evt.waveforms[i].value[end]))
-        end
-        signalsum *= inv(ustrip(SolidStateDetectors._convert_internal_energy_to_external_charge(sim.detector.semiconductor.material)))
-        @info signalsum
-        @test isapprox( signalsum, T(2), atol = 5e-3 )
-    end
-    @testset "Simulate example detector: SigGen PPC" begin
-        sim = Simulation{T}(SSD_examples[:SigGen])
-        simulate!(sim, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
-        evt = Event(CartesianPoint.([CylindricalPoint{T}(20e-3, deg2rad(10), 10e-3 )]))
-        simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
-        signalsum = T(0)
-        for i in 1:length(evt.waveforms)
-            signalsum += abs(ustrip(evt.waveforms[i].value[end]))
-        end
-        signalsum *= inv(ustrip(SolidStateDetectors._convert_internal_energy_to_external_charge(sim.detector.semiconductor.material)))
-        @info signalsum
-        @test isapprox( signalsum, T(2), atol = 5e-3 )
-    end
+    # # @testset "Simulate example detector: Coax" begin
+    # #     sim = Simulation{T}(SSD_examples[:Coax])
+    # #     calculate_electric_potential!(sim, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
+    # #     calculate_electric_field!(sim)
+    # #     calculate_weighting_potential!(sim, 1, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
+    # #     calculate_weighting_potential!(sim, 2, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
+    # #     for i in 3:19
+    # #         calculate_weighting_potential!(sim, i, convergence_limit = 5e-6, refinement_limits = [0.2], verbose = false)
+    # #     end
+    # #     evt = Event(CartesianPoint.([CylindricalPoint{T}(20e-3, deg2rad(30), 12e-3 )]))
+    # #     simulate!(evt, sim, Δt = 5e-10, max_nsteps = 10000)
+    # #     signalsum = T(0)
+    # #     for i in 1:length(evt.waveforms)
+    # #         signalsum += abs(ustrip(evt.waveforms[i].value[end]))
+    # #     end
+    # #     signalsum *= inv(ustrip(SolidStateDetectors._convert_internal_energy_to_external_charge(sim.detector.semiconductor.material)))
+    # #     @info signalsum
+    # #     @test isapprox( signalsum, T(2), atol = 5e-3 )
+    # # end
+    # @testset "Simulate example detector: BEGe" begin
+    #     sim = Simulation{T}(SSD_examples[:BEGe])
+    #     calculate_electric_potential!(sim, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
+    #     calculate_electric_field!(sim)
+    #     calculate_weighting_potential!(sim, 1, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
+    #     for i in 2:5
+    #         calculate_weighting_potential!(sim, i, convergence_limit = 5e-6, refinement_limits = [0.2], verbose = false)
+    #     end
+    #     evt = Event(CartesianPoint.([CylindricalPoint{T}(20e-3, deg2rad(10), 20e-3 )]))
+    #     simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
+    #     signalsum = T(0)
+    #     for i in 1:length(evt.waveforms)
+    #         signalsum += abs(ustrip(evt.waveforms[i].value[end]))
+    #     end
+    #     signalsum *= inv(ustrip(SolidStateDetectors._convert_internal_energy_to_external_charge(sim.detector.semiconductor.material)))
+    #     @info signalsum
+    #     @test isapprox( signalsum, T(2), atol = 5e-3 )
+    #     nt = NamedTuple(sim)
+    #     @test sim == Simulation(nt)
+    # end
+    # @testset "Simulate example detector: HexagonalPrism" begin
+    #     sim = Simulation{T}(SSD_examples[:Hexagon])
+    #     simulate!(sim, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
+    #     evt = Event([CartesianPoint{T}(0, 5e-4, 1e-3)])
+    #     simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
+    #     signalsum = T(0)
+    #     for i in 1:length(evt.waveforms)
+    #         signalsum += abs(ustrip(evt.waveforms[i].value[end]))
+    #     end
+    #     signalsum *= inv(ustrip(SolidStateDetectors._convert_internal_energy_to_external_charge(sim.detector.semiconductor.material)))
+    #     @info signalsum
+    #     @test isapprox( signalsum, T(2), atol = 5e-3 )
+    # end
+    # @testset "Simulate example detector: CGD" begin
+    #     sim = Simulation{T}(SSD_examples[:CGD])
+    #     simulate!(sim, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
+    #     evt = Event([CartesianPoint{T}(0,2e-3,0)])
+    #     simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
+    #     signalsum = T(0)
+    #     for i in 1:length(evt.waveforms)
+    #         signalsum += abs(ustrip(evt.waveforms[i].value[end]))
+    #     end
+    #     signalsum *= inv(ustrip(SolidStateDetectors._convert_internal_energy_to_external_charge(sim.detector.semiconductor.material)))
+    #     @info signalsum
+    #     @test isapprox( signalsum, T(2), atol = 5e-3 )
+    #     nt = NamedTuple(sim)
+    #     @test sim == Simulation(nt)
+    # end
+    # @testset "Simulate example detector: Spherical" begin
+    #     sim = Simulation{T}(SSD_examples[:Spherical])
+    #     simulate!(sim, convergence_limit = 1e-5, refinement_limits = [0.2, 0.1], verbose = false)
+    #     evt = Event([CartesianPoint{T}(0,0,0)])
+    #     simulate!(evt, sim)
+    #     signalsum = T(0)
+    #     for i in 1:length(evt.waveforms)
+    #         signalsum += abs(ustrip(evt.waveforms[i].value[end]))
+    #     end
+    #     signalsum *= inv(ustrip(SolidStateDetectors._convert_internal_energy_to_external_charge(sim.detector.semiconductor.material)))
+    #     @info signalsum
+    #     @test isapprox( signalsum, T(2), atol = 5e-3 )
+    # end 
+    # @testset "Simulate example detector: Toroidal" begin
+    #     sim = Simulation{T}(SSD_examples[:CoaxialTorus])
+    #     SolidStateDetectors.apply_initial_state!(sim, ElectricPotential)
+    #     simulate!(sim, convergence_limit = 1e-5, refinement_limits = [0.2, 0.1, 0.05, 0.02, 0.01], 
+    #         max_tick_distance = 0.5u"mm", verbose = false)
+    #     evt = Event([CartesianPoint{T}(0.0075,0,0)])
+    #     simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
+    #     signalsum = T(0)
+    #     for i in 1:length(evt.waveforms)
+    #         signalsum += abs(ustrip(evt.waveforms[i].value[end]))
+    #     end
+    #     signalsum *= inv(ustrip(SolidStateDetectors._convert_internal_energy_to_external_charge(sim.detector.semiconductor.material)))
+    #     @info signalsum
+    #     @test isapprox( signalsum, T(2), atol = 5e-3 )
+    # end
+    # @testset "Simulate example detector: SigGen PPC" begin
+    #     sim = Simulation{T}(SSD_examples[:SigGen])
+    #     simulate!(sim, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
+    #     evt = Event(CartesianPoint.([CylindricalPoint{T}(20e-3, deg2rad(10), 10e-3 )]))
+    #     simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
+    #     signalsum = T(0)
+    #     for i in 1:length(evt.waveforms)
+    #         signalsum += abs(ustrip(evt.waveforms[i].value[end]))
+    #     end
+    #     signalsum *= inv(ustrip(SolidStateDetectors._convert_internal_energy_to_external_charge(sim.detector.semiconductor.material)))
+    #     @info signalsum
+    #     @test isapprox( signalsum, T(2), atol = 5e-3 )
+    # end
 end
 
 @testset "Diffusion and Self-Repulsion" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,7 +28,7 @@ T = Float32
     @testset "Simulate test detector" begin
         sim = Simulation{T}(SSD_examples[:TestDetector])
         simulate!(sim, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
-        evt = Event(CartesianPoint.([CylindricalPoint{T}(20e-3, deg2rad(10), 10e-3 )]))
+        evt = Event(CartesianPoint.([CartesianPoint{T}(0,0,0)]))
         simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
         signalsum = T(0)
         for i in 1:length(evt.waveforms)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -164,19 +164,19 @@ T = Float32
     #     @info signalsum
     #     @test isapprox( signalsum, T(2), atol = 5e-3 )
     # end
-    # @testset "Simulate example detector: SigGen PPC" begin
-    #     sim = Simulation{T}(SSD_examples[:SigGen])
-    #     simulate!(sim, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
-    #     evt = Event(CartesianPoint.([CylindricalPoint{T}(20e-3, deg2rad(10), 10e-3 )]))
-    #     simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
-    #     signalsum = T(0)
-    #     for i in 1:length(evt.waveforms)
-    #         signalsum += abs(ustrip(evt.waveforms[i].value[end]))
-    #     end
-    #     signalsum *= inv(ustrip(SolidStateDetectors._convert_internal_energy_to_external_charge(sim.detector.semiconductor.material)))
-    #     @info signalsum
-    #     @test isapprox( signalsum, T(2), atol = 5e-3 )
-    # end
+    @testset "Simulate example detector: SigGen PPC" begin
+        sim = Simulation{T}(SSD_examples[:SigGen])
+        simulate!(sim, convergence_limit = 1e-6, refinement_limits = [0.2, 0.1], verbose = false)
+        evt = Event(CartesianPoint.([CylindricalPoint{T}(20e-3, deg2rad(10), 10e-3 )]))
+        simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
+        signalsum = T(0)
+        for i in 1:length(evt.waveforms)
+            signalsum += abs(ustrip(evt.waveforms[i].value[end]))
+        end
+        signalsum *= inv(ustrip(SolidStateDetectors._convert_internal_energy_to_external_charge(sim.detector.semiconductor.material)))
+        @info signalsum
+        @test isapprox( signalsum, T(2), atol = 5e-3 )
+    end
 end
 
 @testset "Diffusion and Self-Repulsion" begin


### PR DESCRIPTION
A pseudo detector containing all volume primitives, boolean operators and transformations will be used for tests. Before, several geometries had to be calculated individually.