### PR TITLE
Prevent charges at exact same position to self-repel

### DIFF
--- a/src/ChargeDrift/ChargeDrift.jl
+++ b/src/ChargeDrift/ChargeDrift.jl
@@ -131,6 +131,9 @@ function _add_fieldvector_selfrepulsion!(step_vectors::Vector{CartesianVector{T}
             if done[m] continue end
             if m > n
                 direction::CartesianVector{T} = current_pos[n] .- current_pos[m]
+                if iszero(direction) # if the two charges are at the exact same position
+                    continue         # don't let them self-repel each other but treat them as same change
+                end                  # if diffusion is simulated, they will very likely be separated in the next step
                 tmp::T = elementary_charge * inv(4 * pi * ϵ0 * ϵ_r * max(sum(direction.^2), T(1e-10))) # minimum distance is 10µm 
                 step_vectors[n] += charges[m] * tmp * normalize(direction)
                 step_vectors[m] -= charges[n] * tmp * normalize(direction)


### PR DESCRIPTION
When simulating self-repulsion, the code would return `NaN` values in the step vectors if at least two charges are at the exact same position. This is because SSD cannot compute the direction, into which the charges self-repel, resulting in a division of 0 by 0. This can happen in very very rare occasions, where e.g. a charge cloud is spawned close to a `Torus` contact and some of the charges are relocated into the semiconductor.

I propose this fix that if the distance of two charges is **exactly** zero, the charges are treated as "the same" (no self-repulsion).
If diffusion is simulated, the two charges will very likely be at different positions such that they can be treated as distinct again in the next iteration step of the charge drift.