### PR TITLE
Add tests for depletion handling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -73,6 +73,7 @@ julia = "1.7"
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [targets]
-test = ["Test", "Unitful"]
+test = ["Test", "Unitful", "SpecialFunctions"]

--- a/examples/example_config_files/infinite_coaxial_capacitor.yaml
+++ b/examples/example_config_files/infinite_coaxial_capacitor.yaml
@@ -47,7 +47,7 @@ detectors:
           tube:
             r:
               from: 5
-              to: 5
+              to: 5.1
             h: 2
       - material: HPGe
         id: 2
@@ -55,6 +55,6 @@ detectors:
         geometry:
           tube:
             r:
-              from: 35
+              from: 34.9
               to: 35
             h: 2

--- a/examples/example_config_files/infinite_coaxial_capacitor_cartesian_coords.yaml
+++ b/examples/example_config_files/infinite_coaxial_capacitor_cartesian_coords.yaml
@@ -48,7 +48,7 @@ detectors:
           tube:
             r:
               from: 5
-              to: 5
+              to: 5.1
             h: 2
       - material: HPGe
         id: 2
@@ -56,6 +56,6 @@ detectors:
         geometry:
           tube:
             r:
-              from: 35
+              from: 34.9
               to: 35
             h: 2

--- a/examples/example_config_files/infinite_parallel_plate_capacitor.yaml
+++ b/examples/example_config_files/infinite_parallel_plate_capacitor.yaml
@@ -1,6 +1,6 @@
 name: Infinite Parallel Plate Capacitor
 units:
-  length: mm
+  length: cm
   angle: deg
   potential: V
   temperature: K
@@ -12,12 +12,12 @@ grid:
       to: 0.5
       boundaries: reflecting
     y:
-      from: -5
-      to: 5
+      from: -0.5
+      to: 0.5
       boundaries: reflecting
     z:
-      from: -5
-      to: 5
+      from: -0.5
+      to: 0.5
       boundaries: reflecting
 medium: HPGe
 detectors:
@@ -43,7 +43,7 @@ detectors:
     contacts:
       - material: HPGe
         name: n+ contact
-        potential: 10
+        potential: 100
         id: 1
         geometry:
           box:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,9 +4,11 @@ using Test
 # using CUDAKernels # Uncomment this line in order to run all tests on (CUDA) GPU
 using SolidStateDetectors
 
-using Unitful
+using SpecialFunctions
 using StaticArrays
+using StatsBase
 using Tables, TypedTables
+using Unitful
 
 T = Float32
 device_array_type = (@isdefined CUDAKernels) ? CUDAKernels.CUDA.CuArray : Array


### PR DESCRIPTION
Add two tests (Cartesian & cylindrical) for the depletion handling by simulating p-n junctions. 

The tests are based on the charge neutrality of a p-n junction:
The integrated charge of the depleted region should be `0`.

(As long as the depletion region does not touches one of the contacts).