### PR TITLE
Fix in plotting empty `Vector{CartesianPoint}`

### DIFF
--- a/src/ConstructiveSolidGeometry/plotting/PointsAndVectors/Points.jl
+++ b/src/ConstructiveSolidGeometry/plotting/PointsAndVectors/Points.jl
@@ -27,7 +27,7 @@ end
         aspect_ratio --> 1.0
     end 
     @series begin
-        seriestype --> :scatter
+        if !isempty(v) seriestype --> :scatter end
         [v[i].x for i in eachindex(v)]*internal_length_unit, [v[i].y for i in eachindex(v)]*internal_length_unit, [v[i].z for i in eachindex(v)]*internal_length_unit
     end
 end


### PR DESCRIPTION
From SolidStateDetectors.jl/src/ConstructiveSolidGeometry/plotting/CSG/CSG.jl:
```julia
if haskey(plotattributes, :seriestype) 
            if plotattributes[:seriestype] == :samplesurface
                if occursin("GRBackend", string(typeof(plotattributes[:plot_object].backend)))
                    aspect_ratio --> 1.0
                end 
                seriesalpha --> 0.2
                filter(p -> in(p,csg), sample(ps[1], spacing))
            else
# ...
```

When plotting a `CSGDifference` with the `:samplesurface` method, sometimes `sample` with the adjusted `spacing` results an empty array of `CartesianPoint{T}`. 

With our current plot recipes, `plot(CartesianPoint{T}[])` is equivalent to `scatter([],[],[])` which results in an error in GR:
```
BoundsError: attempt to access 0-element Vector{Tuple{Float64, Float64, Float64}} at index [1]

Stacktrace:
  [1] getindex
    @ ./array.jl:861 [inlined]
  [2] unzip(v::Vector{Tuple{Float64, Float64, Float64}})
    @ RecipesPipeline /user/.julia/packages/RecipesPipeline/oVorB/src/utils.jl:211
  [3] gr_add_series(sp::Plots.Subplot{Plots.GRBackend}, series::Plots.Series)
    @ Plots /user/.julia/packages/Plots/cPJQu/src/backends/gr.jl:1845
  [4] gr_display(sp::Plots.Subplot{Plots.GRBackend}, w::Measures.AbsoluteLength, h::Measures.AbsoluteLength, viewport_canvas::Vector{Float64})
    @ Plots /user/.julia/packages/Plots/cPJQu/src/backends/gr.jl:1005
  [5] gr_display(plt::Plots.Plot{Plots.GRBackend}, fmt::String)
    @ Plots /user/.julia/packages/Plots/cPJQu/src/backends/gr.jl:670
  [6] _show(io::Base64.Base64EncodePipe, #unused#::MIME{Symbol("image/png")}, plt::Plots.Plot{Plots.GRBackend})
    @ Plots /user/.julia/packages/Plots/cPJQu/src/backends/gr.jl:2169
  [7] show(io::Base64.Base64EncodePipe, m::MIME{Symbol("image/png")}, plt::Plots.Plot{Plots.GRBackend})
    @ Plots /user/.julia/packages/Plots/cPJQu/src/output.jl:205
  [8] base64encode(::Function, ::MIME{Symbol("image/png")}, ::Vararg{Any}; context::Nothing)
    @ Base64 /opt/julia-1.7/share/julia/stdlib/v1.7/Base64/src/encode.jl:209
  [9] base64encode
    @ /opt/julia-1.7/share/julia/stdlib/v1.7/Base64/src/encode.jl:206 [inlined]
 [10] _ijulia_display_dict(plt::Plots.Plot{Plots.GRBackend})
    @ Plots /user/.julia/packages/Plots/cPJQu/src/ijulia.jl:44
 [11] display_dict(plt::Plots.Plot{Plots.GRBackend})
    @ Plots /user/.julia/packages/Plots/cPJQu/src/init.jl:92
 [12] #invokelatest#2
    @ ./essentials.jl:716 [inlined]
 [13] invokelatest
    @ ./essentials.jl:714 [inlined]
 [14] execute_request(socket::ZMQ.Socket, msg::IJulia.Msg)
    @ IJulia /user/.julia/packages/IJulia/e8kqU/src/execute_request.jl:112
 [15] #invokelatest#2
    @ ./essentials.jl:716 [inlined]
 [16] invokelatest
    @ ./essentials.jl:714 [inlined]
 [17] eventloop(socket::ZMQ.Socket)
    @ IJulia /user/.julia/packages/IJulia/e8kqU/src/eventloop.jl:8
 [18] (::IJulia.var"#15#18")()
    @ IJulia ./task.jl:423
```

This PR addresses this issue in the following way:
When plotting an empty `Vector{CartesianPoint}`, the seriestype is chosen **not** to be `:scatter` to avoid the GR problem.