### PR TITLE
Improve grid creation for weighting potentials

### DIFF
--- a/src/Axes/DiscreteAxis.jl
+++ b/src/Axes/DiscreteAxis.jl
@@ -313,26 +313,15 @@ end
 """
     merge_second_order_important_points(imp::Vector{T}, imp_second_order::Vector{T}; min_diff::T = T(1e-6)) where {T}
 
-Merges two vectors, removes the entries from the second vector if they are too close 
-to entries of the first vector (via `min_diff`) and returns one sorted vector.
+Merge all elements of the second vector, `imp_second_order`, into the first vector, `imp`, if they are not 
+to close (via `min_diff`) to elements of the first vector.
+Returns the sorted and uniqued vector.
 """
 function merge_second_order_important_points(imp::Vector{T}, imp_second_order::Vector{T}; min_diff::T = T(1e-6)) where {T}
     sorted_imp = sort(imp)
-    all_merged = unique!(sort!(vcat(sorted_imp, imp_second_order)))
-    Δall_merged = diff(all_merged)
-    inds_diff_too_small = findall(Δ -> Δ < min_diff, Δall_merged)
-    delete_inds = Int[]
-    for i in inds_diff_too_small
-        if insorted(all_merged[i], sorted_imp)
-            push!(delete_inds, i+1)
-        elseif insorted(all_merged[i+1], sorted_imp)
-            push!(delete_inds, i)
-        else
-            error("This should never happen.") # I will leave this for now just to be sure.
-        end
-    end
-    deleteat!(all_merged, delete_inds)
-    all_merged
+    nearest_inds = map(x -> searchsortednearest(sorted_imp, x), imp_second_order)
+    merge_inds = filter(i -> abs(sorted_imp[nearest_inds[i]] - imp_second_order[i]) >= min_diff, eachindex(imp_second_order))
+    return unique!(sort!(vcat(imp, imp_second_order[merge_inds])))
 end
 
 function get_new_ticks_to_equalize_ratios_on_side(t::AbstractVector{T}; max_ratio = T(2)) where {T}

--- a/src/Axes/DiscreteAxis.jl
+++ b/src/Axes/DiscreteAxis.jl
@@ -311,13 +311,13 @@ function merge_close_ticks(v::AbstractVector{T}; min_diff::T = T(1e-6)) where {T
 end
 
 """
-    merge_second_order_important_points(imp::Vector{T}, imp_second_order::Vector{T}; min_diff::T = T(1e-6)) where {T}
+    merge_second_order_important_ticks(imp::Vector{T}, imp_second_order::Vector{T}; min_diff::T = T(1e-6)) where {T}
 
-Merge all elements of the second vector, `imp_second_order`, into the first vector, `imp`, if they are not 
-to close (via `min_diff`) to elements of the first vector.
-Returns the sorted and uniqued vector.
+Merge all elements of the second vector, `imp_second_order`, into the first vector, `imp`, 
+if they are not too close (via `min_diff`) to elements of the first vector.
+Returns the merged vector sorted and uniqued.
 """
-function merge_second_order_important_points(imp::Vector{T}, imp_second_order::Vector{T}; min_diff::T = T(1e-6)) where {T}
+function merge_second_order_important_ticks(imp::Vector{T}, imp_second_order::Vector{T}; min_diff::T = T(1e-6)) where {T}
     sorted_imp = sort(imp)
     nearest_inds = map(x -> searchsortednearest(sorted_imp, x), imp_second_order)
     merge_inds = filter(i -> abs(sorted_imp[nearest_inds[i]] - imp_second_order[i]) >= min_diff, eachindex(imp_second_order))

--- a/src/Axes/DiscreteAxis.jl
+++ b/src/Axes/DiscreteAxis.jl
@@ -310,6 +310,30 @@ function merge_close_ticks(v::AbstractVector{T}; min_diff::T = T(1e-6)) where {T
     v[1:n]
 end
 
+"""
+    merge_second_order_important_points(imp::Vector{T}, imp_second_order::Vector{T}; min_diff::T = T(1e-6)) where {T}
+
+Merges and sorts two vectors into one sorted vector. But only add elements of the second vector, `imp_second_order`, if
+they are not too close (via `min_diff`) to elements of the first vector. 
+"""
+function merge_second_order_important_points(imp::Vector{T}, imp_second_order::Vector{T}; min_diff::T = T(1e-6)) where {T}
+    sorted_imp = sort(imp)
+    all_merged = unique!(sort!(vcat(sorted_imp, imp_second_order)))
+    Δall_merged = diff(all_merged)
+    inds_diff_too_small = findall(Δ -> Δ < min_diff, Δall_merged)
+    delete_inds = Int[]
+    for i in inds_diff_too_small
+        if insorted(all_merged[i], sorted_imp)
+            push!(delete_inds, i+1)
+        elseif insorted(all_merged[i+1], sorted_imp)
+            push!(delete_inds, i)
+        else
+            error("This should never happen.") # I will leave this for now just to be sure.
+        end
+    end
+    deleteat!(all_merged, delete_inds)
+    all_merged
+end
 
 function get_new_ticks_to_equalize_ratios_on_side(t::AbstractVector{T}; max_ratio = T(2)) where {T}
     @assert length(t) == 3 

--- a/src/Axes/DiscreteAxis.jl
+++ b/src/Axes/DiscreteAxis.jl
@@ -298,7 +298,7 @@ function merge_closest_ticks!(v::AbstractVector{T}, n::Int = length(v); min_diff
 end
 function merge_close_ticks(v::AbstractVector{T}; min_diff::T = T(1e-6)) where {T}
     l = length(v)
-    if l <= 1 return v end
+    l <= 1 && return v
     n = merge_closest_ticks!(v, min_diff = min_diff)
     reduced = n < l
     l = n
@@ -313,8 +313,8 @@ end
 """
     merge_second_order_important_points(imp::Vector{T}, imp_second_order::Vector{T}; min_diff::T = T(1e-6)) where {T}
 
-Merges and sorts two vectors into one sorted vector. But only add elements of the second vector, `imp_second_order`, if
-they are not too close (via `min_diff`) to elements of the first vector. 
+Merges two vectors, removes the entries from the second vector if they are too close 
+to entries of the first vector (via `min_diff`) and returns one sorted vector.
 """
 function merge_second_order_important_points(imp::Vector{T}, imp_second_order::Vector{T}; min_diff::T = T(1e-6)) where {T}
     sorted_imp = sort(imp)

--- a/src/Axes/DiscreteAxis.jl
+++ b/src/Axes/DiscreteAxis.jl
@@ -280,6 +280,7 @@ end
 Base.convert(T::Type{NamedTuple}, x::DiscreteAxis; unit = u"m/m") = T(x)
 
 function merge_closest_ticks!(v::AbstractVector{T}, n::Int = length(v); min_diff::T = T(1e-6)) where {T}
+    n == 1 && return n
     Δv = diff(v[1:n])
     Δ_min, Δv_min_indx = findmin(Δv)
     vFirst = v[1]

--- a/src/Axes/DiscreteAxis.jl
+++ b/src/Axes/DiscreteAxis.jl
@@ -298,7 +298,7 @@ function merge_closest_ticks!(v::AbstractVector{T}, n::Int = length(v); min_diff
 end
 function merge_close_ticks(v::AbstractVector{T}; min_diff::T = T(1e-6)) where {T}
     l = length(v)
-    if l == 1 return v end
+    if l <= 1 return v end
     n = merge_closest_ticks!(v, min_diff = min_diff)
     reduced = n < l
     l = n

--- a/src/Axes/DiscreteAxis.jl
+++ b/src/Axes/DiscreteAxis.jl
@@ -315,13 +315,13 @@ end
 
 Merge all elements of the second vector, `imp_second_order`, into the first vector, `imp`, 
 if they are not too close (via `min_diff`) to elements of the first vector.
-Returns the merged vector sorted and uniqued.
+Returns the merged vector sorted.
 """
 function merge_second_order_important_ticks(imp::Vector{T}, imp_second_order::Vector{T}; min_diff::T = T(1e-6)) where {T}
     sorted_imp = sort(imp)
     nearest_inds = map(x -> searchsortednearest(sorted_imp, x), imp_second_order)
     merge_inds = filter(i -> abs(sorted_imp[nearest_inds[i]] - imp_second_order[i]) >= min_diff, eachindex(imp_second_order))
-    return unique!(sort!(vcat(imp, imp_second_order[merge_inds])))
+    return sort!(vcat(imp, imp_second_order[merge_inds]))
 end
 
 function get_new_ticks_to_equalize_ratios_on_side(t::AbstractVector{T}; max_ratio = T(2)) where {T}

--- a/src/PotentialCalculation/PotentialCalculationSetup/PotentialCalculationSetupCartesian3D.jl
+++ b/src/PotentialCalculation/PotentialCalculationSetup/PotentialCalculationSetupCartesian3D.jl
@@ -188,6 +188,8 @@ function PotentialCalculationSetup(det::SolidStateDetector{T}, grid::CartesianGr
                         ig = find_closest_gridpoint(pt, point_types.grid)
                         if is_undepleted_point_type(point_types.data[ig...]) 
                             ϵ[ix, iy, iz] *= scaling_factor_for_permittivity_in_undepleted_region(det.semiconductor) * (1 - imp_scale[ig...])
+                        elseif is_fixed_point_type(point_types.data[ig...])
+                            ϵ[ix, iz, iz] *= scaling_factor_for_permittivity_in_undepleted_region(det.semiconductor)
                         end
                     end
                 end

--- a/src/PotentialCalculation/PotentialCalculationSetup/PotentialCalculationSetupCartesian3D.jl
+++ b/src/PotentialCalculation/PotentialCalculationSetup/PotentialCalculationSetupCartesian3D.jl
@@ -189,7 +189,7 @@ function PotentialCalculationSetup(det::SolidStateDetector{T}, grid::CartesianGr
                         if is_undepleted_point_type(point_types.data[ig...]) 
                             ϵ[ix, iy, iz] *= scaling_factor_for_permittivity_in_undepleted_region(det.semiconductor) * (1 - imp_scale[ig...])
                         elseif is_fixed_point_type(point_types.data[ig...])
-                            ϵ[ix, iz, iz] *= scaling_factor_for_permittivity_in_undepleted_region(det.semiconductor)
+                            ϵ[ix, iy, iz] *= scaling_factor_for_permittivity_in_undepleted_region(det.semiconductor)
                         end
                     end
                 end

--- a/src/PotentialCalculation/PotentialCalculationSetup/PotentialCalculationSetupCylindrical.jl
+++ b/src/PotentialCalculation/PotentialCalculationSetup/PotentialCalculationSetupCylindrical.jl
@@ -212,8 +212,10 @@ function PotentialCalculationSetup(det::SolidStateDetector{T}, grid::Cylindrical
                         if (ir == 1 && axr[1] == 0) pos_r = axr[2] * 0.5 end
                         pt::CylindricalPoint{T} = CylindricalPoint{T}(pos_r, pos_φ, pos_z)
                         ig = find_closest_gridpoint(pt, point_types.grid)
-                        if is_undepleted_point_type(point_types.data[ig...]) || is_fixed_point_type(point_types.data[ig...])
+                        if is_undepleted_point_type(point_types.data[ig...])
                             ϵ[ir, iφ, iz] *= scaling_factor_for_permittivity_in_undepleted_region(det.semiconductor) * (1 - imp_scale[ig...])
+                        elseif is_fixed_point_type(point_types.data[ig...])
+                            ϵ[ir, iφ, iz] *= scaling_factor_for_permittivity_in_undepleted_region(det.semiconductor)
                         end
                     end
                 end

--- a/src/ScalarPotentials/ElectricPotential.jl
+++ b/src/ScalarPotentials/ElectricPotential.jl
@@ -46,7 +46,8 @@ Base.convert(T::Type{ElectricPotential}, x::NamedTuple) = T(x)
     get_ticks_at_positions_of_large_gradient(epot::ElectricPotential)
 
 The electric potential is analyzed in order to find and return ticks where the gradient (electric field) is strong (relativ to its maximum).
-The electric field strength is the strongest at the position of the pn-junction at least for the 1D linear case.
+
+In the 1D case of a pn-junction, the electric field strength is the largest at the position of the pn-junction.
 Thus, this function is likely to return ticks which are located close to the pn-junction of a semiconductor.
 """
 function get_ticks_at_positions_of_large_gradient(epot::ElectricPotential{T, 3}) where T

--- a/src/ScalarPotentials/ElectricPotential.jl
+++ b/src/ScalarPotentials/ElectricPotential.jl
@@ -41,3 +41,19 @@ function ElectricPotential(nt::NamedTuple)
     ElectricPotential{T, N, S, typeof(grid.axes)}( ustrip.(uconvert.(u"V", nt.values)), grid)
 end
 Base.convert(T::Type{ElectricPotential}, x::NamedTuple) = T(x)
+
+"""
+    get_ticks_at_positions_of_large_gradient(field::ElectricPotential)
+
+The electric potential is analyzed in order to find and return ticks where the gradient (electric field) is strong.
+"""
+function get_ticks_at_positions_of_large_gradient(field::ElectricPotential{T, 3}) where T
+    dims = (1, 2, 3)
+    mps::NTuple{3, Vector{T}} = broadcast(idim -> StatsBase.midpoints(field.grid[idim]), dims)
+    extended = length.(mps) .> 0
+    max_diffs = broadcast(idim -> extended[idim] ? map(i->maximum(abs.(selectdim(field.data, idim, i+1) .- selectdim(field.data, idim, i))), eachindex(mps[idim]))::Vector{T} : T[], dims);
+    max_diff = broadcast(idim -> extended[idim] ? maximum(max_diffs[idim]) : T(0), dims)
+    normalized_max_diffs = broadcast(idim -> extended[idim] ? max_diffs[idim] ./ max_diff[idim] : T[], dims)
+    inds = broadcast(idim -> extended[idim] ? findall(Δ -> Δ > 0.5, normalized_max_diffs[idim]) : Int[], dims) # 0.5 seems to be a good limit as we don't want to add too many ticks. 
+    return broadcast(idim -> extended[idim] ? mps[idim][inds[idim]] : T[], dims)
+end

--- a/src/ScalarPotentials/ElectricPotential.jl
+++ b/src/ScalarPotentials/ElectricPotential.jl
@@ -45,7 +45,7 @@ Base.convert(T::Type{ElectricPotential}, x::NamedTuple) = T(x)
 """
     get_ticks_at_positions_of_large_gradient(epot::ElectricPotential)
 
-The electric potential is analyzed in order to find and return ticks where the gradient (electric field) is strong.
+The electric potential is analyzed in order to find and return ticks where the gradient (electric field) is strong (relativ to its maximum).
 The electric field strength is the strongest at the position of the pn-junction at least for the 1D linear case.
 Thus, this function is likely to return ticks which are located close to the pn-junction of a semiconductor.
 """

--- a/src/ScalarPotentials/ImpurityScale.jl
+++ b/src/ScalarPotentials/ImpurityScale.jl
@@ -1,7 +1,7 @@
 """
     struct ImpurityScale{T, N, S, AT} <: AbstractArray{T, N}
         
-Impurity scalar field of the simulation.
+Impurity scalar impscale of the simulation.
 It is kinda an alpha map for the impurity density of semiconductors.
 It can takes values between `0` and `1`:
  * `1`: The impurity density has its full value. For grid points in depleted region of the semiconductor. 
@@ -15,7 +15,7 @@ It can takes values between `0` and `1`:
 * `S`: Coordinate system (`Cartesian` or `Cylindrical`).
 * `AT`: Axes type.  
         
-## Fields
+## impscales
 * `data::Array{T, N}`: Array containing the values of the impurity scale at the discrete points of the `grid`.
 * `grid::Grid{T, N, S, AT}`: [`Grid`](@ref) defining the discrete points for which the impurity scale is determined.
 """
@@ -24,17 +24,17 @@ struct ImpurityScale{T, N, S, AT} <: AbstractArray{T, N}
     grid::Grid{T, N, S, AT}
 end
 
-@inline size(epot::ImpurityScale{T, N, S}) where {T, N, S} = size(epot.data)
-@inline length(epot::ImpurityScale{T, N, S}) where {T, N, S} = length(epot.data)
-@inline getindex(epot::ImpurityScale{T, N, S}, I::Vararg{Int, N}) where {T, N, S} = getindex(epot.data, I...)
-@inline getindex(epot::ImpurityScale{T, N, S}, i::Int) where {T, N, S} = getindex(epot.data, i)
-@inline getindex(epot::ImpurityScale{T, N, S}, s::Symbol) where {T, N, S} = getindex(epot.grid, s)
+@inline size(impscale::ImpurityScale{T, N, S}) where {T, N, S} = size(impscale.data)
+@inline length(impscale::ImpurityScale{T, N, S}) where {T, N, S} = length(impscale.data)
+@inline getindex(impscale::ImpurityScale{T, N, S}, I::Vararg{Int, N}) where {T, N, S} = getindex(impscale.data, I...)
+@inline getindex(impscale::ImpurityScale{T, N, S}, i::Int) where {T, N, S} = getindex(impscale.data, i)
+@inline getindex(impscale::ImpurityScale{T, N, S}, s::Symbol) where {T, N, S} = getindex(impscale.grid, s)
 
 
-function NamedTuple(epot::ImpurityScale{T, 3}) where {T}
+function NamedTuple(impscale::ImpurityScale{T, 3}) where {T}
     return (
-        grid = NamedTuple(epot.grid),
-        values = epot.data,
+        grid = NamedTuple(impscale.grid),
+        values = impscale.data,
     )
 end
 Base.convert(T::Type{NamedTuple}, x::ImpurityScale) = T(x)
@@ -50,16 +50,19 @@ Base.convert(T::Type{ImpurityScale}, x::NamedTuple) = T(x)
 
 
 """
-    get_ticks_at_positions_of_edge_of_depleted_volumes(field::ImpurityScale{T, 3})
+    get_ticks_at_positions_of_edge_of_depleted_volumes(impscale::ImpurityScale{T, 3})
 
 The impurity scale field is analyzed in order to find and return ticks where the gradient is strong,
 which is the case at the surface of the depleted volume of a semiconductor.
 """
-function get_ticks_at_positions_of_edge_of_depleted_volumes(field::ImpurityScale{T, 3}) where T
+function get_ticks_at_positions_of_edge_of_depleted_volumes(impscale::ImpurityScale{T, 3}) where T
     dims = (1, 2, 3)
-    mps::NTuple{3, Vector{T}} = broadcast(idim -> StatsBase.midpoints(field.grid[idim]), dims)
+    mps::NTuple{3, Vector{T}} = broadcast(idim -> StatsBase.midpoints(impscale.grid[idim]), dims)
     extended = length.(mps) .> 0
-    max_diffs = broadcast(idim -> extended[idim] ? map(i->maximum(abs.(selectdim(field.data, idim, i+1) .- selectdim(field.data, idim, i))), eachindex(mps[idim]))::Vector{T} : T[], dims);
+    max_diffs = broadcast(idim -> extended[idim] ? map(i->maximum(abs.(selectdim(impscale.data, idim, i+1) .- selectdim(impscale.data, idim, i))), eachindex(mps[idim]))::Vector{T} : T[], dims);
     inds = broadcast(idim -> extended[idim] ? findall(Δ -> 0.5 < Δ < 1, max_diffs[idim]) : Int[], dims) # 0.5 seems to be a good limit as we don't want to add too many ticks. 
+    # As the impurity scale only has values between `0` and `1` the change (`max_diffs`) can also only between `0` and `1`.
+    # We want to exclude a change of `1` as this happens at the surface of a semiconductor where the detector is undepleted
+    # and we only want to generate ticks in the semiconductor at the position between undepleted and depleted regions.
     return broadcast(idim -> extended[idim] ? mps[idim][inds[idim]] : T[], dims)
 end

--- a/src/ScalarPotentials/ImpurityScale.jl
+++ b/src/ScalarPotentials/ImpurityScale.jl
@@ -1,7 +1,7 @@
 """
     struct ImpurityScale{T, N, S, AT} <: AbstractArray{T, N}
         
-Impurity scalar impscale of the simulation.
+Impurity scalar field of the simulation.
 It is kinda an alpha map for the impurity density of semiconductors.
 It can takes values between `0` and `1`:
  * `1`: The impurity density has its full value. For grid points in depleted region of the semiconductor. 
@@ -15,7 +15,7 @@ It can takes values between `0` and `1`:
 * `S`: Coordinate system (`Cartesian` or `Cylindrical`).
 * `AT`: Axes type.  
         
-## impscales
+## Fields
 * `data::Array{T, N}`: Array containing the values of the impurity scale at the discrete points of the `grid`.
 * `grid::Grid{T, N, S, AT}`: [`Grid`](@ref) defining the discrete points for which the impurity scale is determined.
 """

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -216,7 +216,7 @@ The grid initialization can be tuned using a set of keyword arguments listed bel
 * `max_distance_ratio::Real = 5`: If the ratio between a tick and its left and right neighbour
    is greater than `max_distance_ratio`, additional ticks are added between the ticks that are
    further apart. This prevents the ticks from being too unevenly spaced.
-* `add_points_between_important_point::Bool = true`: If set to `true`, additional points
+* `add_ticks_between_important_ticks::Bool = true`: If set to `true`, additional points
     will be added in between the important points obtained from sampling the objects of the
     simulation. If some objects are too close together, this will ensure a noticeable gap
     between them in the calculation of potentials and fields.
@@ -228,7 +228,7 @@ function Grid(sim::Simulation{T, Cylindrical};
                 for_weighting_potential::Bool = false,
                 max_tick_distance::Union{Missing, LengthQuantity, Tuple{LengthQuantity, AngleQuantity, LengthQuantity}} = missing,
                 max_distance_ratio::Real = 5,
-                add_points_between_important_point::Bool = true)::CylindricalGrid{T} where {T}
+                add_ticks_between_important_ticks::Bool = true)::CylindricalGrid{T} where {T}
     det = sim.detector
     world = sim.world 
     world_Δs = width.(world.intervals)
@@ -271,7 +271,7 @@ function Grid(sim::Simulation{T, Cylindrical};
 
     append!(important_r_ticks, endpoints(world.intervals[1])...)
     important_r_ticks = unique!(sort!(important_r_ticks))
-    if add_points_between_important_point
+    if add_ticks_between_important_ticks
         important_r_ticks = sort!(vcat(important_r_ticks, StatsBase.midpoints(important_r_ticks)))
     end
     iL = searchsortedfirst(important_r_ticks, world.intervals[1].left)
@@ -285,7 +285,7 @@ function Grid(sim::Simulation{T, Cylindrical};
 
     append!(important_z_ticks, endpoints(world.intervals[3])...)
     important_z_ticks = unique!(sort!(important_z_ticks))
-    if add_points_between_important_point
+    if add_ticks_between_important_ticks
         important_z_ticks = sort!(vcat(important_z_ticks, StatsBase.midpoints(important_z_ticks)))
     end
     iL = searchsortedfirst(important_z_ticks, world.intervals[3].left)
@@ -299,7 +299,7 @@ function Grid(sim::Simulation{T, Cylindrical};
 
     append!(important_φ_ticks, endpoints(world_φ_int)...)
     important_φ_ticks = unique!(sort!(important_φ_ticks))
-    if add_points_between_important_point
+    if add_ticks_between_important_ticks
         important_φ_ticks = sort!(vcat(important_φ_ticks, StatsBase.midpoints(important_φ_ticks)))
     end
     iL = searchsortedfirst(important_φ_ticks, world_φ_int.left)
@@ -355,7 +355,7 @@ end
 function Grid(  sim::Simulation{T, Cartesian};
                 max_tick_distance::Union{Missing, LengthQuantity, Tuple{LengthQuantity, LengthQuantity, LengthQuantity}} = missing,
                 max_distance_ratio::Real = 5,
-                add_points_between_important_point::Bool = true,
+                add_ticks_between_important_ticks::Bool = true,
                 for_weighting_potential::Bool = false)::CartesianGrid3D{T} where {T}
     det = sim.detector
     world = sim.world 
@@ -393,7 +393,7 @@ function Grid(  sim::Simulation{T, Cartesian};
 
     append!(important_x_ticks, endpoints(world.intervals[1]))
     important_x_ticks = unique!(sort!(important_x_ticks))
-    if add_points_between_important_point
+    if add_ticks_between_important_ticks
         important_x_ticks = sort!(vcat(important_x_ticks, StatsBase.midpoints(important_x_ticks)))
     end
     iL = searchsortedfirst(important_x_ticks, world.intervals[1].left)
@@ -407,7 +407,7 @@ function Grid(  sim::Simulation{T, Cartesian};
 
     append!(important_y_ticks, endpoints(world.intervals[2]))
     important_y_ticks = unique!(sort!(important_y_ticks))
-    if add_points_between_important_point
+    if add_ticks_between_important_ticks
         important_y_ticks = sort!(vcat(important_y_ticks, StatsBase.midpoints(important_y_ticks)))
     end
     iL = searchsortedfirst(important_y_ticks, world.intervals[2].left)
@@ -421,7 +421,7 @@ function Grid(  sim::Simulation{T, Cartesian};
 
     append!(important_z_ticks, endpoints(world.intervals[3]))
     important_z_ticks = unique!(sort!(important_z_ticks))
-    if add_points_between_important_point
+    if add_ticks_between_important_ticks
         important_z_ticks = sort!(vcat(important_z_ticks, StatsBase.midpoints(important_z_ticks)))
     end
     iL = searchsortedfirst(important_z_ticks, world.intervals[3].left)

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -245,6 +245,7 @@ function Grid(sim::Simulation{T, Cylindrical};
             strong_electric_field_ticks = get_ticks_at_positions_of_large_gradient(sim.electric_potential)
             for idim in (1, 2, 3)
                 if !isempty(strong_electric_field_ticks[idim]) 
+                    # `world_Δs[idim] / 20`: Seems to be a good settings. We don't want to add to many ticks to the initial grid.
                     append!(important_points[idim], merge_close_ticks(strong_electric_field_ticks[idim], min_diff = world_Δs[idim] / 20))
                 end
             end
@@ -253,6 +254,7 @@ function Grid(sim::Simulation{T, Cylindrical};
             surface_of_depleted_volume_ticks = get_ticks_at_positions_of_edge_of_depleted_volumes(sim.imp_scale)
             for idim in (1, 2, 3)
                 if !isempty(surface_of_depleted_volume_ticks[idim]) 
+                    # `world_Δs[idim] / 20`: Seems to be a good settings. We don't want to add to many ticks to the initial grid.
                     append!(important_points[idim], merge_close_ticks(surface_of_depleted_volume_ticks[idim], min_diff = world_Δs[idim] / 20))
                 end
             end
@@ -379,6 +381,7 @@ function Grid(  sim::Simulation{T, Cartesian};
             strong_electric_field_ticks = get_ticks_at_positions_of_large_gradient(sim.electric_potential)
             for idim in (1, 2, 3)
                 if !isempty(strong_electric_field_ticks[idim]) 
+                    # `world_Δs[idim] / 20`: Seems to be a good settings. We don't want to add to many ticks to the initial grid.
                     append!(important_points[idim], merge_close_ticks(strong_electric_field_ticks[idim], min_diff = world_Δs[idim] / 20))
                 end
             end
@@ -387,6 +390,7 @@ function Grid(  sim::Simulation{T, Cartesian};
             surface_of_depleted_volume_ticks = get_ticks_at_positions_of_edge_of_depleted_volumes(sim.imp_scale)
             for idim in (1, 2, 3)
                 if !isempty(surface_of_depleted_volume_ticks[idim]) 
+                    # `world_Δs[idim] / 20`: Seems to be a good settings. We don't want to add to many ticks to the initial grid.
                     append!(important_points[idim], merge_close_ticks(surface_of_depleted_volume_ticks[idim], min_diff = world_Δs[idim] / 20))
                 end
             end

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -235,9 +235,9 @@ function Grid(sim::Simulation{T, Cylindrical};
     world_Δr, world_Δφ, world_Δz = world_Δs
                 
     samples::Vector{CylindricalPoint{T}} = sample(det, Cylindrical)
-    important_r_points::Vector{T} = map(p -> p.r, samples)
-    important_φ_points::Vector{T} = map(p -> p.φ, samples)
-    important_z_points::Vector{T} = map(p -> p.z, samples)
+    important_r_ticks::Vector{T} = map(p -> p.r, samples)
+    important_φ_ticks::Vector{T} = map(p -> p.φ, samples)
+    important_z_ticks::Vector{T} = map(p -> p.z, samples)
 
     second_order_imp_ticks = if for_weighting_potential 
         strong_electric_field_ticks = !ismissing(sim.electric_potential) ? get_ticks_at_positions_of_large_gradient(sim.electric_potential) : (T[], T[], T[])
@@ -269,52 +269,52 @@ function Grid(sim::Simulation{T, Cylindrical};
         end 
     end
 
-    append!(important_r_points, endpoints(world.intervals[1])...)
-    important_r_points = unique!(sort!(important_r_points))
+    append!(important_r_ticks, endpoints(world.intervals[1])...)
+    important_r_ticks = unique!(sort!(important_r_ticks))
     if add_points_between_important_point
-        important_r_points = sort!(vcat(important_r_points, StatsBase.midpoints(important_r_points)))
+        important_r_ticks = sort!(vcat(important_r_ticks, StatsBase.midpoints(important_r_ticks)))
     end
-    iL = searchsortedfirst(important_r_points, world.intervals[1].left)
-    iR = searchsortedfirst(important_r_points, world.intervals[1].right)
-    important_r_points = unique(map(t -> isapprox(t, 0, atol = 1e-12) ? zero(T) : t, important_r_points[iL:iR]))
-    important_r_points = merge_close_ticks(important_r_points)
-    imp2order_r_points = merge_close_ticks(second_order_imp_ticks[1], min_diff = world_Δs[1] / 20)
-    important_r_points = merge_second_order_important_points(important_r_points, imp2order_r_points)   
-    important_r_points = initialize_axis_ticks(important_r_points; max_ratio = T(max_distance_ratio))
-    important_r_points = fill_up_ticks(important_r_points, max_distance_r)
+    iL = searchsortedfirst(important_r_ticks, world.intervals[1].left)
+    iR = searchsortedfirst(important_r_ticks, world.intervals[1].right)
+    important_r_ticks = unique(map(t -> isapprox(t, 0, atol = 1e-12) ? zero(T) : t, important_r_ticks[iL:iR]))
+    important_r_ticks = merge_close_ticks(important_r_ticks)
+    imp2order_r_ticks = merge_close_ticks(second_order_imp_ticks[1], min_diff = world_Δs[1] / 20)
+    important_r_ticks = merge_second_order_important_ticks(important_r_ticks, imp2order_r_ticks)   
+    important_r_ticks = initialize_axis_ticks(important_r_ticks; max_ratio = T(max_distance_ratio))
+    important_r_ticks = fill_up_ticks(important_r_ticks, max_distance_r)
 
-    append!(important_z_points, endpoints(world.intervals[3])...)
-    important_z_points = unique!(sort!(important_z_points))
+    append!(important_z_ticks, endpoints(world.intervals[3])...)
+    important_z_ticks = unique!(sort!(important_z_ticks))
     if add_points_between_important_point
-        important_z_points = sort!(vcat(important_z_points, StatsBase.midpoints(important_z_points)))
+        important_z_ticks = sort!(vcat(important_z_ticks, StatsBase.midpoints(important_z_ticks)))
     end
-    iL = searchsortedfirst(important_z_points, world.intervals[3].left)
-    iR = searchsortedfirst(important_z_points, world.intervals[3].right)
-    important_z_points = unique(map(t -> isapprox(t, 0, atol = 1e-12) ? zero(T) : t, important_z_points[iL:iR]))
-    important_z_points = merge_close_ticks(important_z_points)
-    imp2order_z_points = merge_close_ticks(second_order_imp_ticks[3], min_diff = world_Δs[3] / 20)
-    important_z_points = merge_second_order_important_points(important_z_points, imp2order_z_points)
-    important_z_points = initialize_axis_ticks(important_z_points; max_ratio = T(max_distance_ratio))
-    important_z_points = fill_up_ticks(important_z_points, max_distance_z)
+    iL = searchsortedfirst(important_z_ticks, world.intervals[3].left)
+    iR = searchsortedfirst(important_z_ticks, world.intervals[3].right)
+    important_z_ticks = unique(map(t -> isapprox(t, 0, atol = 1e-12) ? zero(T) : t, important_z_ticks[iL:iR]))
+    important_z_ticks = merge_close_ticks(important_z_ticks)
+    imp2order_z_ticks = merge_close_ticks(second_order_imp_ticks[3], min_diff = world_Δs[3] / 20)
+    important_z_ticks = merge_second_order_important_ticks(important_z_ticks, imp2order_z_ticks)
+    important_z_ticks = initialize_axis_ticks(important_z_ticks; max_ratio = T(max_distance_ratio))
+    important_z_ticks = fill_up_ticks(important_z_ticks, max_distance_z)
 
-    append!(important_φ_points, endpoints(world_φ_int)...)
-    important_φ_points = unique!(sort!(important_φ_points))
+    append!(important_φ_ticks, endpoints(world_φ_int)...)
+    important_φ_ticks = unique!(sort!(important_φ_ticks))
     if add_points_between_important_point
-        important_φ_points = sort!(vcat(important_φ_points, StatsBase.midpoints(important_φ_points)))
+        important_φ_ticks = sort!(vcat(important_φ_ticks, StatsBase.midpoints(important_φ_ticks)))
     end
-    iL = searchsortedfirst(important_φ_points, world_φ_int.left)
-    iR = searchsortedfirst(important_φ_points, world_φ_int.right)
-    important_φ_points = unique(map(t -> isapprox(t, 0, atol = 1e-3) ? zero(T) : t, important_φ_points[iL:iR]))
-    important_φ_points = merge_close_ticks(important_φ_points, min_diff = T(1e-3))
-    imp2order_φ_points = merge_close_ticks(second_order_imp_ticks[2], min_diff = world_Δs[2] / 20)
-    important_φ_points = merge_second_order_important_points(important_φ_points, imp2order_φ_points)
-    important_φ_points = initialize_axis_ticks(important_φ_points; max_ratio = T(max_distance_ratio))
-    important_φ_points = fill_up_ticks(important_φ_points, max_distance_φ)
+    iL = searchsortedfirst(important_φ_ticks, world_φ_int.left)
+    iR = searchsortedfirst(important_φ_ticks, world_φ_int.right)
+    important_φ_ticks = unique(map(t -> isapprox(t, 0, atol = 1e-3) ? zero(T) : t, important_φ_ticks[iL:iR]))
+    important_φ_ticks = merge_close_ticks(important_φ_ticks, min_diff = T(1e-3))
+    imp2order_φ_ticks = merge_close_ticks(second_order_imp_ticks[2], min_diff = world_Δs[2] / 20)
+    important_φ_ticks = merge_second_order_important_ticks(important_φ_ticks, imp2order_φ_ticks)
+    important_φ_ticks = initialize_axis_ticks(important_φ_ticks; max_ratio = T(max_distance_ratio))
+    important_φ_ticks = fill_up_ticks(important_φ_ticks, max_distance_φ)
     
     # r
     L, R, BL, BR = get_boundary_types(world.intervals[1])
     int_r = Interval{L, R, T}(endpoints(world.intervals[1])...)
-    ax_r = even_tick_axis(DiscreteAxis{T, BL, BR}(int_r, important_r_points))
+    ax_r = even_tick_axis(DiscreteAxis{T, BL, BR}(int_r, important_r_ticks))
 
     # φ
     L, R, BL, BR = get_boundary_types(world_φ_int)
@@ -322,13 +322,13 @@ function Grid(sim::Simulation{T, Cylindrical};
     ax_φ = if int_φ.left == int_φ.right
         DiscreteAxis{T, BL, BR}(int_φ, T[int_φ.left])
     else
-        DiscreteAxis{T, BL, BR}(int_φ, important_φ_points)
+        DiscreteAxis{T, BL, BR}(int_φ, important_φ_ticks)
     end
     if length(ax_φ) > 1
         φticks = if R == :open 
-            important_φ_points[1:end-1]
+            important_φ_ticks[1:end-1]
         else
-            important_φ_points
+            important_φ_ticks
         end
         ax_φ = typeof(ax_φ)(int_φ, φticks)
     end
@@ -346,7 +346,7 @@ function Grid(sim::Simulation{T, Cylindrical};
     #z
     L, R, BL, BR = get_boundary_types(world.intervals[3])
     int_z = Interval{L, R, T}(endpoints(world.intervals[3])...)
-    ax_z = even_tick_axis(DiscreteAxis{T, BL, BR}(int_z, important_z_points))
+    ax_z = even_tick_axis(DiscreteAxis{T, BL, BR}(int_z, important_z_ticks))
 
     return CylindricalGrid{T}( (ax_r, ax_φ, ax_z) )
 end
@@ -363,9 +363,9 @@ function Grid(  sim::Simulation{T, Cartesian};
     world_Δx, world_Δy, world_Δz = world_Δs
                 
     samples::Vector{CartesianPoint{T}} = sample(det, Cartesian)
-    important_x_points::Vector{T} = map(p -> p.x, samples)
-    important_y_points::Vector{T} = map(p -> p.y, samples)
-    important_z_points::Vector{T} = map(p -> p.z, samples)
+    important_x_ticks::Vector{T} = map(p -> p.x, samples)
+    important_y_ticks::Vector{T} = map(p -> p.y, samples)
+    important_z_ticks::Vector{T} = map(p -> p.z, samples)
     
     second_order_imp_ticks = if for_weighting_potential 
         strong_electric_field_ticks = !ismissing(sim.electric_potential) ? get_ticks_at_positions_of_large_gradient(sim.electric_potential) : (T[], T[], T[])
@@ -391,62 +391,62 @@ function Grid(  sim::Simulation{T, Cartesian};
         end
     end
 
-    append!(important_x_points, endpoints(world.intervals[1]))
-    important_x_points = unique!(sort!(important_x_points))
+    append!(important_x_ticks, endpoints(world.intervals[1]))
+    important_x_ticks = unique!(sort!(important_x_ticks))
     if add_points_between_important_point
-        important_x_points = sort!(vcat(important_x_points, StatsBase.midpoints(important_x_points)))
+        important_x_ticks = sort!(vcat(important_x_ticks, StatsBase.midpoints(important_x_ticks)))
     end
-    iL = searchsortedfirst(important_x_points, world.intervals[1].left)
-    iR = searchsortedfirst(important_x_points, world.intervals[1].right)
-    important_x_points = unique(map(t -> isapprox(t, 0, atol = 1e-12) ? zero(T) : t, important_x_points[iL:iR]))
-    important_x_points = merge_close_ticks(important_x_points)
-    imp2order_x_points = merge_close_ticks(second_order_imp_ticks[1], min_diff = world_Δs[1] / 20)
-    important_x_points = merge_second_order_important_points(important_x_points, imp2order_x_points)
-    important_x_points = initialize_axis_ticks(important_x_points; max_ratio = T(max_distance_ratio))
-    important_x_points = fill_up_ticks(important_x_points, max_distance_x)
+    iL = searchsortedfirst(important_x_ticks, world.intervals[1].left)
+    iR = searchsortedfirst(important_x_ticks, world.intervals[1].right)
+    important_x_ticks = unique(map(t -> isapprox(t, 0, atol = 1e-12) ? zero(T) : t, important_x_ticks[iL:iR]))
+    important_x_ticks = merge_close_ticks(important_x_ticks)
+    imp2order_x_ticks = merge_close_ticks(second_order_imp_ticks[1], min_diff = world_Δs[1] / 20)
+    important_x_ticks = merge_second_order_important_ticks(important_x_ticks, imp2order_x_ticks)
+    important_x_ticks = initialize_axis_ticks(important_x_ticks; max_ratio = T(max_distance_ratio))
+    important_x_ticks = fill_up_ticks(important_x_ticks, max_distance_x)
 
-    append!(important_y_points, endpoints(world.intervals[2]))
-    important_y_points = unique!(sort!(important_y_points))
+    append!(important_y_ticks, endpoints(world.intervals[2]))
+    important_y_ticks = unique!(sort!(important_y_ticks))
     if add_points_between_important_point
-        important_y_points = sort!(vcat(important_y_points, StatsBase.midpoints(important_y_points)))
+        important_y_ticks = sort!(vcat(important_y_ticks, StatsBase.midpoints(important_y_ticks)))
     end
-    iL = searchsortedfirst(important_y_points, world.intervals[2].left)
-    iR = searchsortedfirst(important_y_points, world.intervals[2].right)
-    important_y_points = unique(map(t -> isapprox(t, 0, atol = 1e-12) ? zero(T) : t, important_y_points[iL:iR]))
-    important_y_points = merge_close_ticks(important_y_points)
-    imp2order_y_points = merge_close_ticks(second_order_imp_ticks[2], min_diff = world_Δs[2] / 20)
-    important_y_points = merge_second_order_important_points(important_y_points, imp2order_y_points)
-    important_y_points = initialize_axis_ticks(important_y_points; max_ratio = T(max_distance_ratio))
-    important_y_points = fill_up_ticks(important_y_points, max_distance_y)
+    iL = searchsortedfirst(important_y_ticks, world.intervals[2].left)
+    iR = searchsortedfirst(important_y_ticks, world.intervals[2].right)
+    important_y_ticks = unique(map(t -> isapprox(t, 0, atol = 1e-12) ? zero(T) : t, important_y_ticks[iL:iR]))
+    important_y_ticks = merge_close_ticks(important_y_ticks)
+    imp2order_y_ticks = merge_close_ticks(second_order_imp_ticks[2], min_diff = world_Δs[2] / 20)
+    important_y_ticks = merge_second_order_important_ticks(important_y_ticks, imp2order_y_ticks)
+    important_y_ticks = initialize_axis_ticks(important_y_ticks; max_ratio = T(max_distance_ratio))
+    important_y_ticks = fill_up_ticks(important_y_ticks, max_distance_y)
 
-    append!(important_z_points, endpoints(world.intervals[3]))
-    important_z_points = unique!(sort!(important_z_points))
+    append!(important_z_ticks, endpoints(world.intervals[3]))
+    important_z_ticks = unique!(sort!(important_z_ticks))
     if add_points_between_important_point
-        important_z_points = sort!(vcat(important_z_points, StatsBase.midpoints(important_z_points)))
+        important_z_ticks = sort!(vcat(important_z_ticks, StatsBase.midpoints(important_z_ticks)))
     end
-    iL = searchsortedfirst(important_z_points, world.intervals[3].left)
-    iR = searchsortedfirst(important_z_points, world.intervals[3].right)
-    important_z_points = unique(map(t -> isapprox(t, 0, atol = 1e-12) ? zero(T) : t, important_z_points[iL:iR]))
-    important_z_points = merge_close_ticks(important_z_points)
-    imp2order_z_points = merge_close_ticks(second_order_imp_ticks[3], min_diff = world_Δs[3] / 20)
-    important_z_points = merge_second_order_important_points(important_z_points, imp2order_z_points)
-    important_z_points = initialize_axis_ticks(important_z_points; max_ratio = T(max_distance_ratio))
-    important_z_points = fill_up_ticks(important_z_points, max_distance_z)
+    iL = searchsortedfirst(important_z_ticks, world.intervals[3].left)
+    iR = searchsortedfirst(important_z_ticks, world.intervals[3].right)
+    important_z_ticks = unique(map(t -> isapprox(t, 0, atol = 1e-12) ? zero(T) : t, important_z_ticks[iL:iR]))
+    important_z_ticks = merge_close_ticks(important_z_ticks)
+    imp2order_z_ticks = merge_close_ticks(second_order_imp_ticks[3], min_diff = world_Δs[3] / 20)
+    important_z_ticks = merge_second_order_important_ticks(important_z_ticks, imp2order_z_ticks)
+    important_z_ticks = initialize_axis_ticks(important_z_ticks; max_ratio = T(max_distance_ratio))
+    important_z_ticks = fill_up_ticks(important_z_ticks, max_distance_z)
 
     # x
     L, R, BL, BR = get_boundary_types(world.intervals[1])
     int_x = Interval{L, R, T}(endpoints(world.intervals[1])...)
-    ax_x = even_tick_axis(DiscreteAxis{T, BL, BR}(int_x, important_x_points))
+    ax_x = even_tick_axis(DiscreteAxis{T, BL, BR}(int_x, important_x_ticks))
    
     # y
     L, R, BL, BR = get_boundary_types(world.intervals[2])
     int_y = Interval{L, R, T}(endpoints(world.intervals[2])...)
-    ax_y = even_tick_axis(DiscreteAxis{T, BL, BR}(int_y, important_y_points))
+    ax_y = even_tick_axis(DiscreteAxis{T, BL, BR}(int_y, important_y_ticks))
 
     # z
     L, R, BL, BR = get_boundary_types(world.intervals[3])
     int_z = Interval{L, R, T}(endpoints(world.intervals[3])...)
-    ax_z = even_tick_axis(DiscreteAxis{T, BL, BR}(int_z, important_z_points))
+    ax_z = even_tick_axis(DiscreteAxis{T, BL, BR}(int_z, important_z_ticks))
 
     return CartesianGrid3D{T}( (ax_x, ax_y, ax_z) )
 end

--- a/test/comparison_to_analytic_solutions.jl
+++ b/test/comparison_to_analytic_solutions.jl
@@ -245,7 +245,22 @@ end
             refinement_limits = [0.2, 0.1, 0.05, 0.02, 0.01, 0.005, 0.001], 
             verbose = false
         )
-     
+        for i in (1, 2)
+            calculate_weighting_potential!(sim, i,
+                device_array_type = device_array_type, 
+                depletion_handling = true,
+                convergence_limit = 1e-7, 
+                max_tick_distance = (0.05 * u"cm"),
+                refinement_limits = [0.2, 0.1, 0.05, 0.02, 0.01, 0.005, 0.001], 
+                verbose = false
+            )
+        end
+        c_12 = calculate_mutual_capacitance(sim, (1, 2))
+        @test isapprox(c_12, -2.378u"pF", atol = 0.01u"pF") #= 
+            Not calculated analytically but tested visually.
+            Just to test if code changes influences the weighting potentials.
+        =#
+
         r_ext = SolidStateDetectors.get_extended_ticks(sim.electric_potential.grid.axes[1])
         mpr = midpoints(r_ext)
         Δmpr_squared = T(0.5) .* ((mpr[2:end].^2) .- (mpr[1:end-1].^2))

--- a/test/comparison_to_analytic_solutions.jl
+++ b/test/comparison_to_analytic_solutions.jl
@@ -43,6 +43,22 @@ struct DummyImpurityDensity{T} <: SolidStateDetectors.AbstractImpurityDensity{T}
             refinement_limits = [0.2, 0.1, 0.05, 0.025, 0.01, 0.005], 
             verbose = false
         )
+        for i in (1, 2)
+            calculate_weighting_potential!(sim, i,
+                device_array_type = device_array_type, 
+                depletion_handling = true,
+                convergence_limit = 1e-7, 
+                max_tick_distance = (0.02, 1, 1) .* u"cm",
+                min_tick_distance = 1e-12u"m",
+                refinement_limits = [0.2, 0.1, 0.05, 0.025, 0.01, 0.005], 
+                verbose = false
+            )
+        end
+        c_12 = calculate_mutual_capacitance(sim, (1, 2))
+        @test isapprox(c_12, -3.496u"pF", atol = 0.01u"pF") #= 
+            Not calculated analytically but tested visually.
+            Just to test if code changes influences the weighting potentials.
+        =#
 
         x_ext = SolidStateDetectors.get_extended_ticks(sim.electric_potential.grid.axes[1]);
         Δx_ext = diff(x_ext);


### PR DESCRIPTION
After calculating the electric potential, we can use the calculated potential and also the impurity scale field 
to add ticks in the creation of the initial grid of the weighting potentials.

This is especially important for cases where the detector is not fully depleted.