### PR TITLE
Electric field on single-grid-point contacts is now treated more properly.

### DIFF
--- a/src/ElectricField/ElectricField.jl
+++ b/src/ElectricField/ElectricField.jl
@@ -120,21 +120,33 @@ function get_electric_field_from_potential(epot::ElectricPotential{T, 3, Cylindr
                 if point_types[ir, iφ, iz] & update_bit == 0 # boundary points
                     if (1 < ir < size(point_types, 1))
                         if (point_types[ir - 1, iφ, iz] & update_bit > 0) && (point_types[ir + 1, iφ, iz] & update_bit > 0)
-                            er = 0
+                            if (point_types[ir-1, iφ, iz] & pn_junction_bit > 0) && (point_types[ir+1, iφ, iz] & pn_junction_bit == 0)
+                                er = Δp_r_2 / d_r_2
+                            elseif (point_types[ir+1, iφ, iz] & pn_junction_bit > 0) && (point_types[ir-1, iφ, iz] & pn_junction_bit == 0)
+                                er = Δp_r_1 / d_r_1
+                            end
                         elseif (point_types[ir - 1, iφ, iz] & update_bit > 0) || (point_types[ir + 1, iφ, iz] & update_bit > 0)
                             er *= 2
                         end
                     end
                     if (1 < iφ < size(point_types, 2))
                         if (point_types[ir, iφ - 1, iz] & update_bit > 0) && (point_types[ir, iφ + 1, iz] & update_bit > 0)
-                            eφ = 0
+                            if (point_types[ir, iφ-1, iz] & pn_junction_bit > 0) && (point_types[ir, iφ+1, iz] & pn_junction_bit == 0)
+                                eφ = Δp_φ_2 / d_φ_2
+                            elseif (point_types[ir, iφ+1, iz] & pn_junction_bit > 0) && (point_types[ir, iφ-1, iz] & pn_junction_bit == 0)
+                                eφ = Δp_φ_1 / d_φ_1
+                            end
                         elseif (point_types[ir, iφ - 1, iz] & update_bit > 0) || (point_types[ir, iφ + 1, iz] & update_bit > 0)
                             eφ *= 2
                         end
                     end
                     if (1 < iz < size(point_types, 3))
                         if (point_types[ir, iφ, iz - 1] & update_bit > 0) && (point_types[ir, iφ, iz + 1] & update_bit > 0)
-                            ez = 0
+                            if (point_types[ir, iφ, iz-1] & pn_junction_bit > 0) && (point_types[ir, iφ, iz+1] & pn_junction_bit == 0)
+                                ez = Δp_z_2 / d_z_2
+                            elseif (point_types[ir, iφ, iz+1] & pn_junction_bit > 0) && (point_types[ir, iφ, iz-1] & pn_junction_bit == 0)
+                                ez = Δp_z_1 / d_z_1
+                            end
                         elseif (point_types[ir, iφ, iz - 1] & update_bit > 0) || (point_types[ir, iφ, iz + 1] & update_bit > 0)
                             ez *= 2
                         end


### PR DESCRIPTION
So far, if the contact layer is only a single point in a dimension, the corresponding electric field component on that contact point was forced to be zero.

In Point-contact detectors, where electric fields are rather low close to the mantle surface, also the grid is coarse.
This led to cases, where, when the charge would enter the region between the last grid-point in the bulk and the grid-point of the contact, an "infinite" loop was created where the next stepvector, which is based on the interpolated electric field, was getting smaller and smaller as the charge came closer and closer to the contact point without ever reaching it, see the figure below.

**Before**:
![hole_stepsize_before](https://user-images.githubusercontent.com/6920236/162433820-aae9ac95-2d5e-4bbb-b3b5-714856b5cf48.png)

While it is true that the electric field WITHIN a contact is zero this is not the case at the very edge/boundary between bulk and contact.

I modified the code such that, if the contact layer is only a single point in a dimension, the electric field component is now not forced to 0, but calculated using only the potential gradient inside the detector. This is equivalent to the case if there was an additional contact point at potential zero between the real contact point and the outside.

**After**
![hole_stepsize_after](https://user-images.githubusercontent.com/6920236/162434954-056e4d99-06fe-4246-ab32-97d33ab0bb47.png)

With these modifications, the charges are collected properly.