### PR TITLE
Fix plot recipe of `NBodyChargeCloud`

### DIFF
--- a/src/PlotRecipes/ChargeCloudModels.jl
+++ b/src/PlotRecipes/ChargeCloudModels.jl
@@ -22,7 +22,7 @@ end
         markersize := markersize
         label --> "NBodyChargeCloud"
         seriescolor --> seriescolor
-        PointCharge{T}(points[1])
+        PointCharge(points[1])
     end
     
     vertex_no = 1
@@ -51,7 +51,7 @@ end
         markersize := markersize
         label --> "NBodyChargeCloud"
         seriescolor --> seriescolor
-        PointCharge{T}(points[1])
+        PointCharge(points[1])
     end
     
     vertex_no = 1


### PR DESCRIPTION
With the newest release of StaticArrays (1.4.6), the plot recipe in `NBodyChargeCloud` stopped working.
This is because it tried to convert a `CartesianVector` to a `StaticVector` which previously was somewhat ambiguous.