### PR TITLE
Introduce `CustomIDArray` to access `Arrays` with contact IDs

### DIFF
--- a/docs/src/man/plotting.md
+++ b/docs/src/man/plotting.md
@@ -190,7 +190,7 @@ The waveforms can be extended by calling [`add_baseline_and_extend_tail`](@ref) 
 Again, the units of the axes can be set by calling a `plot` command with units before plotting the waveforms.
 ````@example tutorial
 plot(u"µs", u"fC")
-plot!(add_baseline_and_extend_tail.(evt.waveforms,0,400), 
+plot!(add_baseline_and_extend_tail(evt.waveforms,0,400), 
       linewidth = 4, linestyle = :dash, 
       label = "", unitformat = :slash)
 ````

--- a/examples/example_config_files/ivc_splitted_config/channels/01_PointContact.yaml
+++ b/examples/example_config_files/ivc_splitted_config/channels/01_PointContact.yaml
@@ -1,5 +1,5 @@
 material: HPGe
-id: 1
+id: 100
 potential: 0
 geometry:
   translate:

--- a/examples/example_config_files/ivc_splitted_config/channels/02_Mantle.yaml
+++ b/examples/example_config_files/ivc_splitted_config/channels/02_Mantle.yaml
@@ -1,5 +1,5 @@
 material: HPGe
-id: 2
+id: 200
 potential: 3500
 geometry:
   union:

--- a/src/CustomIDVector.jl
+++ b/src/CustomIDVector.jl
@@ -1,0 +1,63 @@
+struct CustomIDArray{T, N} <: AbstractArray{T, N}
+    data::Array{T, N}
+    idx::Vector{Int}
+end
+
+const CustomIDVector{T} = CustomIDArray{T, 1}
+CustomIDVector(data::Vector{T}, idx::Vector{Int}) where {T} = CustomIDVector{T}(data, idx)
+
+const CustomIDMatrix{T} = CustomIDArray{T, 2}
+CustomIDMatrix(data::Matrix{T}, idx::Vector{Int}) where {T} = CustomIDMatrix{T}(data, idx)
+
+@inline size(cia::CustomIDArray) = size(cia.data)
+@inline length(cia::CustomIDArray) = length(cia.data)
+@inline iterate(cia::CustomIDArray, args...) = iterate(cia.data, args...)
+@inline axes(cia::CustomIDVector) = (cia.idx,)
+
+@inline function getindex(cia::CustomIDVector, i::Int)
+    !(i in cia.idx) && throw(ArgumentError("No entry for contact with ID "*string(i)))
+    idx::Int = Int(findfirst(ix -> ix == i, cia.idx))
+    getindex(cia.data, idx)
+end
+
+@inline function getindex(cia::CustomIDArray{T,N}, I::Vararg{Int,N}) where {T, N}
+    !all(in.(I, Ref(cia.idx))) && throw(ArgumentError("No entry for contact with ID "*string(I)))
+    idx = broadcast(i -> findfirst(idx -> idx == i, cia.idx), I)
+    getindex(cia.data, idx...)
+end
+
+@inline function push!(cia::CustomIDVector{T}, data::T, i::Int) where {T}
+    push!(cia.data, data)
+    push!(cia.idx, i)
+end
+
+@inline function setindex!(cia::CustomIDVector{T}, data::T, i::Int) where {T}
+    if i in cia.idx
+        idx::Int = Int(findfirst(idx -> idx == i, cia.idx))
+        setindex!(cia.data, data, idx)
+    else
+        push!(cia, data, i)
+    end
+end
+
+@inline function setindex!(cia::CustomIDArray{T, N}, data::T, I::Vararg{Int,N}) where {T, N}
+    !all(in.(I, Ref(cia.idx))) && throw(ArgumentError("No entry for contact with ID "*string(I)))
+    idx = broadcast(i -> findfirst(idx -> idx == i, cia.idx), I)
+    setindex!(cia.data, data, idx...)
+end
+
+@inline function setindex!(cia::CustomIDArray{T, N}, data, I::Vararg{Int, N}) where {T, N}
+    setindex!(cia, convert(T, data), I...)
+end
+
+@inline function Base.isequal(cia1::CIA1, cia2::CIA2) where {CIA1 <: CustomIDArray, CIA2 <: CustomIDArray}
+    CIA1 == CIA2 && cia1.idx == cia2.idx && cia1.data == cia2.data
+end
+
+@inline function Base.:(==)(cia1::CIA1, cia2::CIA2) where {CIA1 <: CustomIDArray, CIA2 <: CustomIDArray}
+    CIA1 == CIA2 && cia1.idx == cia2.idx && cia1.data == cia2.data
+end
+
+@inline print(io::IO, cia::CustomIDArray) = print(io, cia.data)
+@inline show(io::IO, cia::CustomIDArray) = print(io, cia)
+@inline show(io::IO, ::MIME"text/plain", cia::CustomIDArray) = show(io, cia)

--- a/src/PlotRecipes/Waveform.jl
+++ b/src/PlotRecipes/Waveform.jl
@@ -1,6 +1,8 @@
-# This should be in RadiationDetectorSignals.jl
-@recipe function f(wvs::Vector{Union{Missing, RadiationDetectorSignals.RDWaveform}})
+@recipe function f(wvs::CustomIDVector{<:RadiationDetectorSignals.RDWaveform})
     @series begin
-        RadiationDetectorSignals.RDWaveform[wv for wv in skipmissing(wvs)]
+        label --> wvs.idx'
+        linecolor --> wvs.idx'
+        unitformat --> :slash
+        [wv for wv in wvs.data]
     end
 end

--- a/src/SolidStateDetectors.jl
+++ b/src/SolidStateDetectors.jl
@@ -53,7 +53,7 @@ import IntervalSets
 import Tables
 import TypedTables
 
-import Base: size, sizeof, length, getindex, setindex!, axes, getproperty, broadcast,
+import Base: size, sizeof, length, getindex, setindex!, push!, axes, getproperty, broadcast, isequal,
              range, ndims, eachindex, enumerate, iterate, IndexStyle, eltype, in, convert,
              show, print, println, display, +, -, &
 
@@ -78,6 +78,7 @@ const SSDFloat = Union{Float16, Float32, Float64}
 
 
 include("Units.jl")
+include("CustomIDVector.jl")
 include("Axes/DiscreteAxis.jl")
 include("World/World.jl")
 include("Grids/Grids.jl")

--- a/test/comparison_to_analytic_solutions.jl
+++ b/test/comparison_to_analytic_solutions.jl
@@ -20,7 +20,7 @@ struct DummyImpurityDensity{T} <: SolidStateDetectors.AbstractImpurityDensity{T}
     W_true = uconvert(u"J", (ϵr * ϵ0 * E_true^2 / 2) * A * Δd)
     C_true = uconvert(u"pF", 2 * W_true / (BV_true^2))
     C_Analytical = [C_true -C_true; -C_true C_true]
-    C_ssd = calculate_capacitance_matrix(sim)
+    C_ssd = calculate_capacitance_matrix(sim).data
     @testset "Capacity" begin
         @test all(isapprox.(C_ssd, C_Analytical, rtol = 0.001))
     end   

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,8 +35,8 @@ T = Float32
         evt = Event(CartesianPoint.([CylindricalPoint{T}(20e-3, deg2rad(10), 10e-3 )]))
         simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
         signalsum = T(0)
-        for i in 1:length(evt.waveforms)
-            signalsum += abs(ustrip(evt.waveforms[i].value[end]))
+        for wf in evt.waveforms
+            signalsum += abs(ustrip(wf.value[end]))
         end
         signalsum *= inv(ustrip(SolidStateDetectors._convert_internal_energy_to_external_charge(sim.detector.semiconductor.material)))
         @info signalsum
@@ -50,8 +50,8 @@ T = Float32
         evt = Event(CartesianPoint.([CylindricalPoint{T}(20e-3, deg2rad(10), 10e-3 )]))
         simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
         signalsum = T(0)
-        for i in 1:length(evt.waveforms)
-            signalsum += abs(ustrip(evt.waveforms[i].value[end]))
+        for wf in evt.waveforms
+            signalsum += abs(ustrip(wf.value[end]))
         end
         signalsum *= inv(ustrip(SolidStateDetectors._convert_internal_energy_to_external_charge(sim.detector.semiconductor.material)))
         @info signalsum
@@ -87,8 +87,8 @@ T = Float32
         evt = Event(CartesianPoint.([CylindricalPoint{T}(20e-3, deg2rad(10), 20e-3 )]))
         simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
         signalsum = T(0)
-        for i in 1:length(evt.waveforms)
-            signalsum += abs(ustrip(evt.waveforms[i].value[end]))
+        for wf in evt.waveforms
+            signalsum += abs(ustrip(wf.value[end]))
         end
         signalsum *= inv(ustrip(SolidStateDetectors._convert_internal_energy_to_external_charge(sim.detector.semiconductor.material)))
         @info signalsum
@@ -102,8 +102,8 @@ T = Float32
         evt = Event([CartesianPoint{T}(0, 5e-4, 1e-3)])
         simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
         signalsum = T(0)
-        for i in 1:length(evt.waveforms)
-            signalsum += abs(ustrip(evt.waveforms[i].value[end]))
+        for wf in evt.waveforms
+            signalsum += abs(ustrip(wf.value[end]))
         end
         signalsum *= inv(ustrip(SolidStateDetectors._convert_internal_energy_to_external_charge(sim.detector.semiconductor.material)))
         @info signalsum
@@ -115,8 +115,8 @@ T = Float32
         evt = Event([CartesianPoint{T}(0,2e-3,0)])
         simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
         signalsum = T(0)
-        for i in 1:length(evt.waveforms)
-            signalsum += abs(ustrip(evt.waveforms[i].value[end]))
+        for wf in evt.waveforms
+            signalsum += abs(ustrip(wf.value[end]))
         end
         signalsum *= inv(ustrip(SolidStateDetectors._convert_internal_energy_to_external_charge(sim.detector.semiconductor.material)))
         @info signalsum
@@ -130,8 +130,8 @@ T = Float32
         evt = Event([CartesianPoint{T}(0,0,0)])
         simulate!(evt, sim)
         signalsum = T(0)
-        for i in 1:length(evt.waveforms)
-            signalsum += abs(ustrip(evt.waveforms[i].value[end]))
+        for wf in evt.waveforms
+            signalsum += abs(ustrip(wf.value[end]))
         end
         signalsum *= inv(ustrip(SolidStateDetectors._convert_internal_energy_to_external_charge(sim.detector.semiconductor.material)))
         @info signalsum
@@ -145,8 +145,8 @@ T = Float32
         evt = Event([CartesianPoint{T}(0.0075,0,0)])
         simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
         signalsum = T(0)
-        for i in 1:length(evt.waveforms)
-            signalsum += abs(ustrip(evt.waveforms[i].value[end]))
+        for wf in evt.waveforms
+            signalsum += abs(ustrip(wf.value[end]))
         end
         signalsum *= inv(ustrip(SolidStateDetectors._convert_internal_energy_to_external_charge(sim.detector.semiconductor.material)))
         @info signalsum
@@ -158,8 +158,8 @@ T = Float32
         evt = Event(CartesianPoint.([CylindricalPoint{T}(20e-3, deg2rad(10), 10e-3 )]))
         simulate!(evt, sim, Δt = 1e-9, max_nsteps = 10000)
         signalsum = T(0)
-        for i in 1:length(evt.waveforms)
-            signalsum += abs(ustrip(evt.waveforms[i].value[end]))
+        for wf in evt.waveforms
+            signalsum += abs(ustrip(wf.value[end]))
         end
         signalsum *= inv(ustrip(SolidStateDetectors._convert_internal_energy_to_external_charge(sim.detector.semiconductor.material)))
         @info signalsum
@@ -177,8 +177,8 @@ end
     evt = Event(nbcc)
     simulate!(evt, sim, self_repulsion = true, diffusion = true)
     signalsum = T(0)
-    for i in 1:length(evt.waveforms)
-        signalsum += abs(ustrip(evt.waveforms[i].value[end]))
+    for wf in evt.waveforms
+        signalsum += abs(ustrip(wf.value[end]))
     end
     signalsum *= inv(ustrip(SolidStateDetectors._convert_internal_energy_to_external_charge(sim.detector.semiconductor.material)))
     @info signalsum
@@ -263,7 +263,7 @@ end
 end
 
 @testset "IO" begin
-    sim = Simulation(SSD_examples[:InvertedCoax])
+    sim = Simulation(SSD_examples[:InvertedCoaxInCryostat])
     
     calculate_electric_potential!(sim, verbose = false, device_array_type = device_array_type)
     nt = NamedTuple(sim)
@@ -273,11 +273,14 @@ end
     nt = NamedTuple(sim)
     @test sim == Simulation(nt)
 
-    calculate_weighting_potential!(sim, 1, verbose = false, device_array_type = device_array_type)
+    calculate_weighting_potential!(sim, 100, verbose = false, device_array_type = device_array_type)
     nt = NamedTuple(sim)
     @test sim == Simulation(nt)
 
-    for i in findall(ismissing.(sim.weighting_potentials)) calculate_weighting_potential!(sim, i, verbose = false, device_array_type = device_array_type) end
+    contact_ids = broadcast(c -> c.id, sim.detector.contacts)
+    for c in filter!(c -> !(c in sim.weighting_potentials.idx), contact_ids) 
+        calculate_weighting_potential!(sim, c, verbose = false, device_array_type = device_array_type) 
+    end
     nt = NamedTuple(sim)
     @test sim == Simulation(nt)
 end 


### PR DESCRIPTION
Just putting it out here, probably not the most elegant solution to fix #288, and I am not really sure whether we want to do it like this, so feel free to reject this PR. The idea of this PR is that arrays can be accessed with custom indices, e.g.
`sim.weighting_potentials[100]` to get the `WeightingPotential` of the contact with ID `100`.

There are still no checks if mutliple contacts in a config file have the same contact ID,
and by accessing elements with custom indices, I rely on `findfirst` which might not be the most efficient way.
