### PR TITLE
Fix bug when transforming `CartesianVector` to object coordinate systems

### DIFF
--- a/src/ConstructiveSolidGeometry/ConstructiveSolidGeometry.jl
+++ b/src/ConstructiveSolidGeometry/ConstructiveSolidGeometry.jl
@@ -72,9 +72,11 @@ module ConstructiveSolidGeometry
     rotation(p::AbstractPrimitive) = p.rotation
     origin(p::AbstractPrimitive) = p.origin
     _transform_into_global_coordinate_system(pt::CartesianPoint, p::AbstractPrimitive) = (rotation(p) * pt) + origin(p)
+    _transform_into_global_coordinate_system(pt::CartesianVector, p::AbstractPrimitive) = rotation(p) * pt
     _transform_into_global_coordinate_system(pts::AbstractVector{<:CartesianPoint}, p::AbstractPrimitive) =
         broadcast(pt -> _transform_into_global_coordinate_system(pt, p), pts)
     _transform_into_object_coordinate_system(pt::CartesianPoint, p::AbstractPrimitive) = inv(rotation(p)) * (pt - origin(p)) 
+    _transform_into_object_coordinate_system(pt::CartesianVector, p::AbstractPrimitive) = inv(rotation(p)) * pt
     in(pt::CartesianPoint{T}, p::AbstractPrimitive{T}, csgtol::T = csg_default_tol(T)) where {T} = 
         _in(_transform_into_object_coordinate_system(pt, p), p; csgtol = csgtol)
     in(pt::CylindricalPoint{T}, p::AbstractPrimitive{T}, csgtol::T = csg_default_tol(T)) where {T} = 

--- a/src/ConstructiveSolidGeometry/LinePrimitives/Line.jl
+++ b/src/ConstructiveSolidGeometry/LinePrimitives/Line.jl
@@ -29,6 +29,6 @@ distance(pt::CartesianPoint, l::Line) = norm((pt - l.origin) × l.direction) / n
 
 function _transform_into_object_coordinate_system(l::Line{T}, p::AbstractPrimitive) where {T}
     origin = _transform_into_object_coordinate_system(l.origin, p) 
-    direction = inv(rotation(p)) * l.direction
-    Line( origin, CartesianVector(direction) )  
+    direction = _transform_into_object_coordinate_system(l.direction, p)
+    Line( origin, direction )  
 end

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/ConeMantle.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/ConeMantle.jl
@@ -76,33 +76,33 @@ radius_at_z(cm::ConeMantle{T,Tuple{T,T}}, z::T) where {T} = radius_at_z(cm.hZ, c
 get_φ_limits(cm::ConeMantle{T,<:Any,T}) where {T} = T(0), cm.φ
 get_φ_limits(cm::ConeMantle{T,<:Any,Nothing}) where {T} = T(0), T(2π)
 
-function normal(cm::ConeMantle{T,T,<:Any,:inwards}, pt::CartesianPoint{T}) where {T}
+function normal(cm::ConeMantle{T,T,<:Any,:inwards}, pt::CartesianPoint{T})::CartesianVector{T} where {T}
     pto = _transform_into_object_coordinate_system(pt, cm)
     cyl = CylindricalPoint(pto)
-    return CartesianVector(_transform_into_global_coordinate_system(
-            CartesianPoint(CylindricalPoint{T}(-cyl.r, cyl.φ, zero(T))), cm))
+    return _transform_into_global_coordinate_system(
+            CartesianVector(CartesianPoint(CylindricalPoint{T}(-cyl.r, cyl.φ, zero(T)))), cm)
 end
-function normal(cm::ConeMantle{T,T,<:Any,:outwards}, pt::CartesianPoint{T}) where {T}
+function normal(cm::ConeMantle{T,T,<:Any,:outwards}, pt::CartesianPoint{T})::CartesianVector{T} where {T}
     pto = _transform_into_object_coordinate_system(pt, cm)
     cyl = CylindricalPoint(pto)
-    return CartesianVector(_transform_into_global_coordinate_system(
-            CartesianPoint(CylindricalPoint{T}(cyl.r, cyl.φ, zero(T))), cm))
+    return _transform_into_global_coordinate_system(
+            CartesianVector(CartesianPoint(CylindricalPoint{T}(cyl.r, cyl.φ, zero(T)))), cm)
 end
-function normal(cm::ConeMantle{T,Tuple{T,T},<:Any,:inwards}, pt::CartesianPoint{T}) where {T}
+function normal(cm::ConeMantle{T,Tuple{T,T},<:Any,:inwards}, pt::CartesianPoint{T})::CartesianVector{T} where {T}
     pto = _transform_into_object_coordinate_system(pt, cm)
     cyl = CylindricalPoint(pto)
     Δr = cm.r[2] - cm.r[1]
     Δz = 2cm.hZ
-    return CartesianVector(_transform_into_global_coordinate_system(
-            CartesianPoint(CylindricalPoint{T}(-one(T), cyl.φ, Δr / Δz)), cm))
+    return _transform_into_global_coordinate_system(
+            CartesianVector(CartesianPoint(CylindricalPoint{T}(-one(T), cyl.φ, Δr / Δz))), cm)
 end
-function normal(cm::ConeMantle{T,Tuple{T,T},<:Any,:outwards}, pt::CartesianPoint{T}) where {T}
+function normal(cm::ConeMantle{T,Tuple{T,T},<:Any,:outwards}, pt::CartesianPoint{T})::CartesianVector{T} where {T}
     pto = _transform_into_object_coordinate_system(pt, cm)
     cyl = CylindricalPoint(pto)
     Δr = cm.r[2] - cm.r[1]
     Δz = 2cm.hZ
-    return CartesianVector(_transform_into_global_coordinate_system(
-            CartesianPoint(CylindricalPoint{T}( one(T), cyl.φ, -Δr / Δz)), cm))
+    return _transform_into_global_coordinate_system(
+            CartesianVector(CartesianPoint(CylindricalPoint{T}( one(T), cyl.φ, -Δr / Δz))), cm)
 end
 
 function vertices(cm::ConeMantle{T}, n_arc::Int64)::Vector{CartesianPoint{T}} where {T}

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/EllipsoidMantle.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/EllipsoidMantle.jl
@@ -93,19 +93,19 @@ end
 extremum(e::EllipsoidMantle{T,T}) where {T} = e.r
 extremum(e::EllipsoidMantle{T,NTuple{3,T}}) where {T} = max(e.r...)
 
-function normal(em::EllipsoidMantle{T,NTuple{3,T},TP,TT,:outwards}, pt::CartesianPoint{T}) where {T,TP,TT}
+function normal(em::EllipsoidMantle{T,NTuple{3,T},TP,TT,:outwards}, pt::CartesianPoint{T})::CartesianVector{T} where {T,TP,TT}
     # not normalized, do we want this?
     # Or wrap this into somehting like `normal(em, pt) = normalize(direction(em, pt))` ?
     p = _transform_into_object_coordinate_system(pt, em)
     obj_normal = CartesianPoint{T}(sign(p.x)*(p.x/em.r[1])^2, sign(p.y)*(p.y/em.r[2])^2, sign(p.z)*(p.z/em.r[3])^2) # We might want to store the inv(em.r) in the struct?
-    CartesianVector(_transform_into_global_coordinate_system(obj_normal, em))
+    transform_into_global_coordinate_system(CartesianVector(_obj_normal, em))
 end
-function normal(em::EllipsoidMantle{T,T,TP,TT,:outwards}, pt::CartesianPoint{T}) where {T,TP,TT}
+function normal(em::EllipsoidMantle{T,T,TP,TT,:outwards}, pt::CartesianPoint{T})::CartesianVector{T} where {T,TP,TT}
     # not normalized, do we want this?
     # Or wrap this into somehting like `normal(em, pt) = normalize(direction(em, pt))` ?
     p = _transform_into_object_coordinate_system(pt, em)
     obj_normal = CartesianPoint{T}(sign(p.x)*(p.x/em.r)^2, sign(p.y)*(p.y/em.r)^2, sign(p.z)*(p.z/em.r)^2) # We might want to store the inv(em.r) in the struct?
-    CartesianVector(_transform_into_global_coordinate_system(obj_normal, em))
+    _transform_into_global_coordinate_system(CartesianVector(obj_normal), em)
 end
 normal(em::EllipsoidMantle{T,TR,TP,TT,:inwards}, pt::CartesianPoint{T}) where {T,TR,TP,TT} = -normal(flip(em), pt)
 

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/EllipticalSurface.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/EllipticalSurface.jl
@@ -69,9 +69,10 @@ const PartialCircularArea{T} = EllipticalSurface{T,T,T}
 const Annulus{T} = EllipticalSurface{T,Tuple{T,T},Nothing}
 const PartialAnnulus{T} = EllipticalSurface{T,Tuple{T,T},T}
 
-Plane(es::EllipticalSurface{T}) where {T} = Plane{T}(es.origin, es.rotation * CartesianVector{T}(zero(T),zero(T),one(T)))
+Plane(es::EllipticalSurface{T}) where {T} = Plane{T}(es.origin, normal(es))
 
-normal(es::EllipticalSurface{T}, ::CartesianPoint{T} = zero(CartesianPoint{T})) where {T} = es.rotation * CartesianVector{T}(zero(T), zero(T), one(T))
+normal(es::EllipticalSurface{T}, ::CartesianPoint{T} = zero(CartesianPoint{T})) where {T} = 
+    _transform_into_global_coordinate_system(CartesianVector{T}(zero(T), zero(T), one(T)), es)
 
 function vertices(es::EllipticalSurface{T, T}, n_arc::Int64)::Vector{CartesianPoint{T}} where {T}
     φMin, φMax = get_φ_limits(es)

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/TorusMantle.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/TorusMantle.jl
@@ -87,11 +87,11 @@ get_θ_limits(tm::TorusMantle{T,<:Any,Tuple{T,T}}) where {T} = tm.θ[1], tm.θ[2
 get_θ_limits(tm::TorusMantle{T,<:Any,Nothing}) where {T} = T(0), T(2π)
 get_θ_limits(tm::TorusMantle{T,<:Any,T}) where {T} = T(0), tm.θ
 
-function normal(tm::TorusMantle{T,TP,TT,:outwards}, pt::CartesianPoint{T}) where {T,TP,TT}
+function normal(tm::TorusMantle{T,TP,TT,:outwards}, pt::CartesianPoint{T})::CartesianVector{T} where {T,TP,TT}
     pto = _transform_into_object_coordinate_system(pt, tm)
     cyl = CylindricalPoint(pto)
     ptt = CartesianPoint(CylindricalPoint{T}(tm.r_torus, cyl.φ, zero(T)))
-    return pt - _transform_into_global_coordinate_system(ptt, tm)
+    return CartesianVector(pt - _transform_into_global_coordinate_system(ptt, tm))
 end
 normal(tm::TorusMantle{T,TP,TT,:inwards}, pt::CartesianPoint{T}) where {T,TP,TT} = -normal(flip(tm), pt)
 


### PR DESCRIPTION
Should fix #316.

As stated correctly by @bazzadino, `CartesianVectors` should not be translated when being transformed to the global or object coordinate system. I have introduced new methods for these functions for `CartesianVector` that do not translate but only rotate the vectors and have modified the source code accordingly.