### PR TITLE
Improve interpolation of potential for grids

### DIFF
--- a/src/ScalarPotentials/ScalarPotential.jl
+++ b/src/ScalarPotentials/ScalarPotential.jl
@@ -34,7 +34,7 @@ function getindex(ep::P, grid::Grid{T, N, S}) where {T, N, S, P <: ScalarPotenti
             end
         end
     end
-    return P(data, grid)
+    return ScalarPotential(ep, data, grid)
 end
 
 function get_2π_potential(sp::ScalarPotential{T, 3, Cylindrical}, axφ::DiscreteAxis{AT, :periodic, :periodic}, int::Interval{:closed, :open, AT}) where {T, AT}


### PR DESCRIPTION
I encountered an issue when I wanted to interpolate a potential with grid, G1, 
onto a grid, G2, with different boundary conditions. 

G2 was a subset of G1 so the boundary conditions do not care.

