### PR TITLE
Fix the construction of RegularPrisms with cutout

### DIFF
--- a/src/ConstructiveSolidGeometry/VolumePrimitives/RegularPrism.jl
+++ b/src/ConstructiveSolidGeometry/VolumePrimitives/RegularPrism.jl
@@ -106,7 +106,7 @@ function Geometry(::Type{T}, ::Type{P}, dict::AbstractDict, input_units::NamedTu
     
     g = if r isa Tuple # lazy workaround for now
         _get_N_prism(T,P,ClosedPrimitive, r[2], hZ, origin, rotation) -
-        _get_N_prism(T,P,ClosedPrimitive, r[1], hZ, origin, rotation)
+        _get_N_prism(T,P,ClosedPrimitive, r[1], T(1.1) * hZ, origin, rotation) # increase volume to subtract
     else
         _get_N_prism(T,P,ClosedPrimitive, r, hZ, origin, rotation)
     end


### PR DESCRIPTION
The `RegularPrism` with cutout is (and was) defined as a difference of two solid `RegularPrisms`.

As we also stress in the documentation, the negative volume should be slightly bigger than the positive volume, such that also the boundaries are removed. 
In v0.7.3, we stretched the negative volume by 10% in `z` to make sure to also remove the top and the bottom part.
This was removed in the refactoring for v0.8 in dac73f78017a072447698f98609b6041e9cf1e4f which caused wrong results when using `RegularPrisms` with cutout.

I am reintroducing the 10% stretch in `z` that was removed in dac73f78017a072447698f98609b6041e9cf1e4f to avoid unphysical results from leftover top and bottom parts in the cutouts.

