### PR TITLE
Fix unused declared type variables in method definitions

### DIFF
--- a/src/Axes/DiscreteAxis.jl
+++ b/src/Axes/DiscreteAxis.jl
@@ -201,7 +201,7 @@ function set_periodic_boundary_ticks!( ticks::Vector{T}, interval::Interval{:ope
     nothing
 end
 
-function set_periodic_boundary_ticks!( ticks::Vector{T}, interval::Interval{:closed, :closed, T})::Nothing where {T, ispolaraxis}
+function set_periodic_boundary_ticks!( ticks::Vector{T}, interval::Interval{:closed, :closed, T})::Nothing where {T}
     if length(ticks) == 3 
         ticks[1] = ticks[2] - 2π
         ticks[end] = ticks[2] + 2π # -> Δmidpoint_φ = 2π -> area of circle is 2π * 0.5*r^2   

--- a/src/ChargeClustering/ChargeClustering.jl
+++ b/src/ChargeClustering/ChargeClustering.jl
@@ -3,10 +3,10 @@
 
 function cluster_detector_hits(
     detno::AbstractVector{<:Integer},
-    edep::AbstractVector{<:RealQuantity},
+    edep::AbstractVector{TT},
     pos::AbstractVector{<:StaticVector{3,PT}},
     cluster_radius::RealQuantity
-) where {TT<:RealQuantity,PT <: RealQuantity}
+) where {TT<:RealQuantity, PT <: RealQuantity}
     Table = TypedTables.Table
     unsorted = Table(detno = detno, edep = edep, pos = pos)
     sorting_idxs = sortperm(unsorted.detno)

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/Polygon.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/Polygon.jl
@@ -110,18 +110,17 @@ function _rotate_on_xy_plane(p::Polygon{<:Any, T}) where {T}
     map(pt -> rot * pt, p.points)
 end
 
-function in(pt::CartesianPoint{T}, p::Polygon{N,T}) where {N,T}
+function in(pt::CartesianPoint{T}, p::Polygon{N,T}, csgtol::T = csg_default_tol(T)) where {N,T}
     plane = Plane(p)
-    if (pt - origin(plane)) ⋅ normal(plane) == 0
+    return isapprox((pt - origin(plane)) ⋅ normal(plane), 0, atol = csgtol) && begin
         rot = _get_rot_for_rotation_on_xy_plane(p)
         vs = vertices(p)
         pts2d = SVector{N+1, SVector{2, T}}(
             view(rot * vs[i%N + 1], 1:2) for i in 0:N  
         )
         # PolygonOps.inpolygon -> in = 1, on = -1, out = 0)
-        b = PolygonOps.inpolygon(view(rot * pt, 1:2), pts2d) != 0 
+        return PolygonOps.inpolygon(view(rot * pt, 1:2), pts2d) != 0 
     end
-    return b
 end
 
 function _above_or_below_polygon(pt::AbstractCoordinatePoint, p::Quadrangle{T}) where {T}

--- a/src/PotentialCalculation/Painting.jl
+++ b/src/PotentialCalculation/Painting.jl
@@ -30,9 +30,9 @@ function get_sub_ind_ranges(a::Union{
     t_idx_range_ax1, t_idx_range_ax2, t_idx_range_ax3
 end
 
-get_sub_ind_ranges(p::ConstructiveSolidGeometry.AbstractSurfacePrimitive{T}, grid::CartesianGrid3D{T}) where {N,T} = 
+get_sub_ind_ranges(p::ConstructiveSolidGeometry.AbstractSurfacePrimitive{T}, grid::CartesianGrid3D{T}) where {T} = 
     get_sub_ind_ranges((ConstructiveSolidGeometry.extreme_points(p), TicksTuple(grid)))
-get_sub_ind_ranges(p::ConstructiveSolidGeometry.AbstractSurfacePrimitive{T}, grid::CylindricalGrid{T}) where {N,T} = 
+get_sub_ind_ranges(p::ConstructiveSolidGeometry.AbstractSurfacePrimitive{T}, grid::CylindricalGrid{T}) where {T} = 
     get_sub_ind_ranges((CylindricalPoint.(ConstructiveSolidGeometry.extreme_points(p)), TicksTuple(grid)))
 
 function paint!(point_types, potential, face::AbstractSurfacePrimitive{T}, geometry, pot_value, grid::CartesianGrid3D{T}) where {T}

--- a/src/PotentialCalculation/Refinement.jl
+++ b/src/PotentialCalculation/Refinement.jl
@@ -40,10 +40,10 @@ function refine_scalar_potential(p::ScalarPotential{T}, max_diffs::NTuple{3, T},
     return _convert_to_original_potential(p, new_data, new_grid)
 end             
 
-function interpolate_closed_potential(p::ScalarPotential, ::Val{true}) where {T}
+function interpolate_closed_potential(p::ScalarPotential{T}, ::Val{true}) where {T}
     interpolate!((p.grid.axes[1], p.grid.axes[3]), p.data[:,1,:], Gridded(Linear()))
 end
-function interpolate_closed_potential(p::ScalarPotential, ::Val{false}) where {T}
+function interpolate_closed_potential(p::ScalarPotential{T}, ::Val{false}) where {T}
     interpolate!(p.grid.axes, p.data, Gridded(Linear()))
 end
 
@@ -155,7 +155,7 @@ function _create_refined_grid(p::ScalarPotential{T,3}, max_diffs::NTuple{3, T}, 
     return typeof(p.grid)(new_axes)
 end
 
-function _refine_axis(ax::DiscreteAxis{T, <:Any, <:Any, ClosedInterval{T}}, ns::Vector{Int}, sub_widths::Vector{T}) where {T, I}
+function _refine_axis(ax::DiscreteAxis{T, <:Any, <:Any, ClosedInterval{T}}, ns::Vector{Int}, sub_widths::Vector{T}) where {T}
     @assert length(ns) == length(ax.ticks)-1 # for ClosedInterval axis
     ticks = Vector{T}(undef, length(ax.ticks) + sum(ns))
     i = 1 

--- a/src/PotentialCalculation/SuccessiveOverRelaxation/convergence.jl
+++ b/src/PotentialCalculation/SuccessiveOverRelaxation/convergence.jl
@@ -8,7 +8,7 @@ function _update_till_convergence!( pcs::PotentialCalculationSetup{T, S, 3},
                                     use_nthreads::Int = Base.Threads.nthreads(), 
                                     max_n_iterations::Int = 10_000, # -1
                                     verbose::Bool = true
-                                ) where {T, S, depletion_handling_enabled, only_2d, _is_weighting_potential, DAT} #  <: GPUArrays.AbstractGPUArray
+                                ) where {T, S, depletion_handling_enabled, only_2d, _is_weighting_potential} #  <: GPUArrays.AbstractGPUArray
     device = KernelAbstractions.get_device(pcs.potential)
     ndrange = size(pcs.potential)[1:3] .- 2
     kernel = get_sor_kernel(S, device, Val(via_KernelAbstractions))

--- a/src/SolidStateDetector/SolidStateDetector.jl
+++ b/src/SolidStateDetector/SolidStateDetector.jl
@@ -176,7 +176,7 @@ end
 
 function show(io::IO, det::SolidStateDetector{T}) where {T <: SSDFloat} println(io, det) end
 function print(io::IO, det::SolidStateDetector{T}) where {T <: SSDFloat} println(io, det) end
-function show(io::IO,::MIME"text/plain", det::SolidStateDetector) where {T <: SSDFloat} show(io, det) end
+function show(io::IO,::MIME"text/plain", det::SolidStateDetector{T}) where {T <: SSDFloat} show(io, det) end
 
 function determine_bias_voltage_contact_id(det::SolidStateDetector)
     contact_potentials = Int[c.potential for c in det.contacts]


### PR DESCRIPTION
When precompiling, SSD throws warning that some type variables in method definition are declared but not used. I have looked through the list of warnings and updated the method definitions accordingly by either removing the unused type variables or using them.