### PR TITLE
Fix plotting of electric field lines

### DIFF
--- a/src/PlotRecipes/ElectricField.jl
+++ b/src/PlotRecipes/ElectricField.jl
@@ -149,7 +149,7 @@ end
                 pts = ConstructiveSolidGeometry.intersection(surf,l)
                 for pt in pts
                     if pt in c
-                        pt_in = pt + T(ustrip(to_internal_units(offset))) * normalize(ConstructiveSolidGeometry.normal(surf, pt))
+                        pt_in = pt - T(ustrip(to_internal_units(offset))) * normalize(ConstructiveSolidGeometry.normal(surf, pt))
                         if pt_in in sim.detector && !(pt_in in sim.detector.contacts)
                             push!(spawn_positions, pt_in)
                         end


### PR DESCRIPTION
When plotting electric field lines, charges are drifting according to the electric field. The initial spawn positions are determined by sampling the contacts in steps of `sampling` and moving them into the bulk of the detector by an `offset`.

In `ConstructiveSolidGeometry`, the surfaces of a `VolumePrimitive` are defined such that their `normal` vector always points towards the center of the `VolumePrimitive`. In order to compute the correct spawn positions, the charges need to be spawned outside of the contact, i.e. in negative direction of the `normal` vector.

This behavior does not appear if the contacts have a thickness of 0. It does, however, when the contacts have non-zero width.