### PR TITLE
Force the contacts to have consecutive IDs starting from 1

### DIFF
--- a/src/SolidStateDetector/SolidStateDetector.jl
+++ b/src/SolidStateDetector/SolidStateDetector.jl
@@ -120,7 +120,14 @@ function SolidStateDetector{T}(config_file::Dict, input_units::NamedTuple) where
     @assert haskey(config_detector, "contacts") "Each detector needs at least two contacts. Please define the them in the configuration file."                    
     contacts = broadcast(c -> Contact{T}(c, input_units, transformations), config_detector["contacts"])
     
-    passives = []
+    # SolidStateDetectors.jl does not allow for arbitrary contact IDs yet (issue #288)
+    # They need to be in order (1, 2, ... , N), so throw an error if this is not the case.
+    if !all(getfield.(contacts, :id) .== eachindex(contacts))
+        ArgumentError("SolidStateDetectors.jl only supports contact IDs that are in order.\n
+            Please set the ID of the first contact to 1, the ID of the second contact to 2, etc.")
+    end
+    
+    passives = Passive{T}[]
     if haskey(config_detector, "passives") # "passives" as entry of "detectors"
         append!(passives, broadcast(p -> Passive{T}(p, input_units, transformations), config_detector["passives"]))
     end


### PR DESCRIPTION
Based on the discussion in #288, we should either allow the contact IDs to take any value or force the IDs to be in consecutive order.

As SSD will fail, if the IDs are not consecutive, starting with 1, we should throw an error if this in not the case.
This is done in this PR.