### PR TITLE
Improve handling of material properties

### DIFF
--- a/src/ConstructiveSolidGeometry/IO.jl
+++ b/src/ConstructiveSolidGeometry/IO.jl
@@ -17,8 +17,8 @@ const CSG_dict = Dict{String, Any}(
     "union" => CSGUnion,
     "difference" => CSGDifference,
     "intersection" => CSGIntersection,
-    "translate" => CartesianVector, # we just ne some type to dispatch on
-    "rotate" => Rotations.Rotation  # we just ne some type to dispatch on
+    "translate" => CartesianVector, # we just need some type to dispatch on
+    "rotate" => Rotations.Rotation  # we just need some type to dispatch on
 )
 
 function get_geometry_key(::Type{T}, dict::AbstractDict, input_units::NamedTuple) where {T}

--- a/src/MaterialProperties/MaterialProperties.jl
+++ b/src/MaterialProperties/MaterialProperties.jl
@@ -97,11 +97,7 @@ materials = Dict{String, Symbol}(
     "Al"  => :Al,
     "LAr" => :LAr,
     "CZT" => :CdZnTe,
-    "Si" => :Si,
-    "Co" => begin
-        @warn "In v0.9.0, the material 'Co' does not denote copper anymore. Please use 'Cu' for copper."
-        :Co
-    end
+    "Si" => :Si
 )
 
 
@@ -109,4 +105,11 @@ for key in keys(material_properties)
     if !haskey(materials, string(key))
         push!(materials, string(key) => key)
     end
+end
+
+function get_material_properties(s::String, material_properties = material_properties, materials = materials)::NamedTuple
+    !haskey(materials, "Co") && s == "Co" && # users might have added 'Co' themselves
+        throw(ConfigFileError("In v0.9.0, the material 'Co' does not denote copper anymore.\n"*
+            "Please use 'Cu', 'Copper' or 'copper' to define copper in the configuration file."))
+    material_properties[materials[s]]
 end

--- a/src/PotentialCalculation/PotentialCalculationSetup/PotentialCalculationSetupCartesian3D.jl
+++ b/src/PotentialCalculation/PotentialCalculationSetup/PotentialCalculationSetupCartesian3D.jl
@@ -75,7 +75,7 @@ function fill_ρimp_ϵ_ρfix(ρ_eff_imp_tmp::Array{T}, ϵ::Array{T}, ρ_eff_fix_
 end
 
 function PotentialCalculationSetup(det::SolidStateDetector{T}, grid::CartesianGrid3D{T}, 
-                medium::NamedTuple = material_properties[materials["vacuum"]],
+                medium::NamedTuple = get_material_properties("vacuum"),
                 potential_array::Union{Missing, Array{T, 3}} = missing,
                 imp_scale::Union{Missing, Array{T, 3}} = missing;
                 weighting_potential_contact_id::Union{Missing, Int} = missing,

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -44,7 +44,7 @@ function Simulation{T,CS}() where {T <: SSDFloat, CS <: AbstractCoordinateSystem
     Simulation{T, CS}(
         Dict(),
         default_unit_tuple(),
-        material_properties[materials["vacuum"]],
+        get_material_properties("vacuum"),
         missing,
         World(CS,(T(0),T(1),T(0),T(1),T(0),T(1))),
         missing,
@@ -175,7 +175,7 @@ function Simulation{T}(dict::Dict)::Simulation{T} where {T <: SSDFloat}
     sim::Simulation{T,CS} = Simulation{T,CS}()
     sim.config_dict = dict
     sim.input_units = construct_units(dict)
-    sim.medium = material_properties[materials[haskey(dict, "medium") ? dict["medium"] : "vacuum"]]
+    sim.medium = get_material_properties(haskey(dict, "medium") ? dict["medium"] : "vacuum")
     sim.detector = SolidStateDetector{T}(dict, sim.input_units) 
     sim.world = if haskey(dict, "grid") && isa(dict["grid"], Dict) && haskey(dict["grid"], "axes")
             World(T, dict["grid"], sim.input_units)

--- a/src/SolidStateDetector/Contacts.jl
+++ b/src/SolidStateDetector/Contacts.jl
@@ -51,7 +51,7 @@ end
 
 function Contact{T}(dict::Union{Dict{String,Any}, Dict{Any, Any}}, input_units::NamedTuple, outer_transformations)::Contact{T} where {T <: SSDFloat}
     id::Int = haskey(dict, "id") ? dict["id"] : -1
-    material = haskey(dict, "material") ? material_properties[materials[dict["material"]]] : material_properties[materials["HPGe"]]
+    material = get_material_properties(haskey(dict, "material") ? dict["material"] : "HPGe")
     name = haskey(dict,"name") ? dict["name"] : ""
     inner_transformations = parse_CSG_transformation(T, dict, input_units)
     transformations = combine_transformations(inner_transformations, outer_transformations)

--- a/src/SolidStateDetector/Passive.jl
+++ b/src/SolidStateDetector/Passive.jl
@@ -62,7 +62,7 @@ function Passive{T}(dict::Dict, input_units::NamedTuple, outer_transformations) 
     name = haskey(dict, "name") ? dict["name"] : "External part"
     id::Int = haskey(dict, "id") ? dict["id"] : -1
     potential = haskey(dict, "potential") ? T(dict["potential"]) : T(POTENTIAL_FLOATING)
-    material = material_properties[materials[dict["material"]]]
+    material = get_material_properties(dict["material"])
     temperature = haskey(dict, "temperature") ? T(dict["temperature"]) : T(293)
     charge_density_model = if haskey(dict, "charge_density") 
         ChargeDensity(T, dict["charge_density"], input_units)

--- a/src/SolidStateDetector/Semiconductor.jl
+++ b/src/SolidStateDetector/Semiconductor.jl
@@ -61,7 +61,7 @@ function Semiconductor{T}(dict::Dict, input_units::NamedTuple, outer_transformat
     else
         ElectricFieldChargeDriftModel{T}()
     end
-    material = material_properties[materials[dict["material"]]]
+    material = get_material_properties(dict["material"])
     temperature = if haskey(dict, "temperature") 
         T(dict["temperature"])
     elseif material.name == "High Purity Germanium"

--- a/test/benchmarks/test_SOR_cartesian.jl
+++ b/test/benchmarks/test_SOR_cartesian.jl
@@ -26,7 +26,7 @@ pcs_car = SolidStateDetectors.PotentialCalculationSetup(
     sim_car.detector, 
     sim_car.electric_potential.grid, 
     # Grid(sim_car, max_tick_distance = 1u"mm"), 
-    SolidStateDetectors.material_properties[SolidStateDetectors.materials["vacuum"]],
+    SolidStateDetectors.get_material_properties("vacuum"),
     sim_car.electric_potential.data
 );
 

--- a/test/benchmarks/test_SOR_cylindrical.jl
+++ b/test/benchmarks/test_SOR_cylindrical.jl
@@ -25,7 +25,7 @@ calculate_electric_potential!(sim_cyl, depletion_handling = false,
 
 pcs_cyl = SolidStateDetectors.PotentialCalculationSetup(sim_cyl.detector,
     sim_cyl.electric_potential.grid,
-    SolidStateDetectors.material_properties[SolidStateDetectors.materials["vacuum"]],
+    SolidStateDetectors.get_material_properties("vacuum"),
     sim_cyl.electric_potential.data);
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -123,6 +123,11 @@ T = Float32
         @info signalsum
         @test isapprox( signalsum, T(2), atol = 5e-3 )
     end
+    @timed_testset "Deprecated symbol for Copper" begin # test until introducing cobalt to the SSD materials
+        config_file = SolidStateDetectors.parse_config_file(SSD_examples[:InvertedCoaxInCryostat])
+        config_file["detectors"][1]["passives"][1]["material"] = "Co"
+        @test_throws SolidStateDetectors.ConfigFileError sim = Simulation{T}(config_file)
+    end
     # @timed_testset "Simulate example detector: Coax" begin
     #     sim = Simulation{T}(SSD_examples[:Coax])
     #     timed_calculate_electric_potential!(sim, convergence_limit = 1e-6, device_array_type = device_array_type, refinement_limits = [0.2, 0.1], verbose = false)


### PR DESCRIPTION
Follow-up of #346:
Added a function `get_material_properties` to handle the breaking changes in defining copper as `Cu` instead of `Co`.
Added a test to check that the `ConfigFileError` is thrown when `Co` is still used.