### PR TITLE
Allow setting the units in detector plots using the `xunits` keyword

### DIFF
--- a/docs/src/tutorials/complete_simulation_chain_IVC_lit.jl
+++ b/docs/src/tutorials/complete_simulation_chain_IVC_lit.jl
@@ -7,7 +7,7 @@ using Unitful
 T = Float32
 sim = Simulation{T}(SSD_examples[:InvertedCoax])
 
-plot(sim.detector, size = (700, 700))
+plot(sim.detector, xunit = u"mm", yunit = u"mm", zunit = u"mm", size = (700, 700))
 #jl savefig("tutorial_det.pdf") # hide
 #md savefig("tutorial_det.pdf") # hide
 #md savefig("tutorial_det.svg"); nothing # hide
@@ -134,7 +134,7 @@ evt = Event(starting_positions, energy_depos);
 time_step = 5u"ns"
 drift_charges!(evt, sim, Δt = time_step)
 
-plot(sim.detector, size = (700, 700))
+plot(sim.detector, xunit = u"mm", yunit = u"mm", zunit = u"mm", size = (700, 700))
 plot!(evt.drift_paths)
 #jl savefig("tutorial_drift_paths.pdf") # hide
 #md savefig("tutorial_drift_paths.pdf") # hide

--- a/src/ConstructiveSolidGeometry/plotting/CSG/CSG.jl
+++ b/src/ConstructiveSolidGeometry/plotting/CSG/CSG.jl
@@ -1,8 +1,8 @@
-primitives(vp::AbstractVolumePrimitive) = (vp,)
-function primitives(csg::AbstractConstructiveGeometry)
+@inline primitives(vp::AbstractVolumePrimitive) = (vp,)
+@inline function primitives(csg::AbstractConstructiveGeometry)
     (
-        (@inline primitives(csg.a))...,
-        (@inline primitives(csg.b))...
+        primitives(csg.a)...,
+        primitives(csg.b)...
     )
 end
 

--- a/src/ConstructiveSolidGeometry/plotting/CSG/CSG.jl
+++ b/src/ConstructiveSolidGeometry/plotting/CSG/CSG.jl
@@ -1,13 +1,16 @@
 primitives(vp::AbstractVolumePrimitive) = (vp,)
 function primitives(csg::AbstractConstructiveGeometry)
-    ps = []
-    push!(ps, primitives(csg.a)...)
-    push!(ps, primitives(csg.b)...)
-    ps
+    (
+        (@inline primitives(csg.a))...,
+        (@inline primitives(csg.b))...
+    )
 end
 
 @recipe function f(csg::AbstractConstructiveGeometry{T}; n_samples = 40, CSG_scale = missing) where {T}
     seriestype --> :csg
+    xunit --> internal_length_unit
+    yunit --> internal_length_unit
+    zunit --> internal_length_unit
     ps = primitives(csg)
     if haskey(plotattributes, :seriestype) && plotattributes[:seriestype] == :samplesurface
         spacing::T = T((ismissing(CSG_scale) ? get_scale(csg) : CSG_scale)/n_samples)

--- a/src/ConstructiveSolidGeometry/plotting/SurfacePrimitives/SurfacePrimitives.jl
+++ b/src/ConstructiveSolidGeometry/plotting/SurfacePrimitives/SurfacePrimitives.jl
@@ -5,7 +5,11 @@
 #include("Polygon.jl")
 #include("TorusMantle.jl")
 
-@recipe function f(s::AbstractSurfacePrimitive{T}; n_arc = 40, n_vert_lines = 2, n_samples = 40) where {T}
+@recipe function f(s::Plane)
+    throw(ArgumentError("No plot recipe defined for Plane."))
+end
+
+@recipe function f(s::AbstractSurfacePrimitive; n_arc = 40, n_vert_lines = 2, n_samples = 40)
     seriestype --> :csg
     l = get_label_name(s)
     if haskey(plotattributes, :seriestype) 

--- a/src/PlotRecipes/SolidStateDetector.jl
+++ b/src/PlotRecipes/SolidStateDetector.jl
@@ -2,14 +2,17 @@
     seriestype --> :csg
     linecolor --> :silver
     seriescolor --> :silver
+    xunit --> internal_length_unit
+    yunit --> internal_length_unit
+    zunit --> internal_length_unit
     fillalpha --> 0.2
     l = p.name != "" ? p.name : "Passive $(p.id)"
     @series begin
         #add empty line so that label is shown with alpha = 1
-        seriestype := :path
+        seriestype := :path3d
         label --> l
         linewidth := 1
-        T[], T[]
+        T[]*internal_length_unit, T[]*internal_length_unit, T[]*internal_length_unit
     end 
     label := ""
     p.geometry
@@ -19,12 +22,15 @@ end
     seriestype --> :csg
     linecolor --> :grey
     seriescolor --> :grey
+    xunit --> internal_length_unit
+    yunit --> internal_length_unit
+    zunit --> internal_length_unit
     @series begin
         #add empty line so that label is shown with alpha = 1
-        seriestype := :path
+        seriestype := :path3d
         label --> "Semiconductor"
         linewidth := 1
-        T[], T[]
+        T[]*internal_length_unit, T[]*internal_length_unit, T[]*internal_length_unit
     end 
     label := ""
     sc.geometry
@@ -34,6 +40,9 @@ end
     seriestype --> :csg
     seriescolor --> contact.id
     linecolor --> contact.id
+    xunit --> internal_length_unit
+    yunit --> internal_length_unit
+    zunit --> internal_length_unit
     fillalpha --> 0.2
     l = contact.name != "" ? "$(contact.name) (id: $(contact.id))" : "Contact - id: $(contact.id)"
     @series begin
@@ -41,7 +50,7 @@ end
         seriestype := :path
         label --> l
         linewidth := 1
-        T[], T[]
+        T[]*internal_length_unit, T[]*internal_length_unit, T[]*internal_length_unit
     end 
     label := ""
     contact.geometry
@@ -50,6 +59,9 @@ end
 @recipe function f(det::SolidStateDetector; show_semiconductor = false, show_passives = true, n_samples = 40)
 
     show_normal --> false
+    xunit --> internal_length_unit
+    yunit --> internal_length_unit
+    zunit --> internal_length_unit
     
     plot_objects = []
     append!(plot_objects, det.contacts)


### PR DESCRIPTION
Previously, this syntax would not work
```julia
plot(sim.detector, xunit = u"mm", yunit = u"mm", zunit = u"mm", size = (500,500))
```
```
KeyError: key :unit not found
```

With this PR, this syntax will now also be supported
```julia
plot(sim.detector, xunit = u"mm", yunit = u"mm", zunit = u"mm", size = (500,500))
```
![image](https://github.com/JuliaPhysics/SolidStateDetectors.jl/assets/30291312/99dcf978-b7dc-49a5-b94a-e339309e79aa)

I also added the new syntax to the tutorial in the documentation, so that people can see it.

I also made sure that the `xunit = u"mm" ...` syntax works with all `ScalarPotentials`, with all `VolumePrimitives` and `SurfacePrimitives` and `LinePrimitives` as well as `Point`

It does **NOT** work with `CartesianVector` and it does not work with `Plane` (but the latter I think was never meant to be plotted, just used for computation --> I therefore included an error when trying to plot a `Plane`).