### PR TITLE
Improve handling of charge densities for passive objects

### DIFF
--- a/src/ChargeClustering/ChargeClustering.jl
+++ b/src/ChargeClustering/ChargeClustering.jl
@@ -21,7 +21,7 @@ function cluster_detector_hits(
     r_pos = similar(pos, 0)
 
     posunit = unit(PT)
-    ustripped_cradius = ustrip(uconvert(posunit, cluster_radius))
+    ustripped_cradius = ustrip(posunit, cluster_radius)
     
     for d_hits_nt in grouped
         d_hits = Table(d_hits_nt)

--- a/src/ConstructiveSolidGeometry/IO.jl
+++ b/src/ConstructiveSolidGeometry/IO.jl
@@ -58,7 +58,7 @@ end
 
 # parses dictionary entries of type Real or String to their value in internal units
 @inline _parse_value(::Type{T}, x::Real, unit::Unitful.Units) where {T} = T(to_internal_units(float(x) * unit))
-@inline _parse_value(::Type{T}, x::Quantity, unit::Unitful.Units) where {T} = T(ustrip(uconvert(unit, x)))
+@inline _parse_value(::Type{T}, x::Quantity, unit::Unitful.Units) where {T} = T(ustrip(unit, x))
 @inline _parse_value(::Type{T}, s::String, ::Unitful.Units) where {T} = T(to_internal_units(uparse(s)))
 @inline _parse_value(::Type{T}, a::AbstractVector, unit::Unitful.Units) where {T} = _parse_value.(T, a, unit)
 

--- a/src/ConstructiveSolidGeometry/Units.jl
+++ b/src/ConstructiveSolidGeometry/Units.jl
@@ -1,15 +1,15 @@
 const internal_length_unit    = u"m"
-const internal_angle_unit      = u"rad"
+const internal_angle_unit     = u"rad"
 
 _get_TDU(x::Quantity{T,D,U}) where {T,D,U} = T, D, U
 const LengthQuantity = Quantity{<:Real, Unitful.𝐋}
 const AngleQuantity = Quantity{<:Real, NoDims, <:Union{_get_TDU(1u"rad")[3], _get_TDU(1u"°")[3]}}
 
 to_internal_units(x::Real) = x
-to_internal_units(x::LengthQuantity) = ustrip(uconvert(internal_length_unit, x))
-to_internal_units(x::AngleQuantity) = ustrip(uconvert(internal_angle_unit, x))
-to_internal_units(x::Quantity{<:Real, Unitful.𝐋^(-3)}) = ustrip(uconvert(internal_length_unit^(-3), x)) # densities
-to_internal_units(x::Quantity{<:Real, Unitful.𝐋^(-4)}) = ustrip(uconvert(internal_length_unit^(-4), x)) # density gradients
+to_internal_units(x::LengthQuantity) = ustrip(internal_length_unit, x)
+to_internal_units(x::AngleQuantity)  = ustrip(internal_angle_unit, x)
+to_internal_units(x::Quantity{<:Real, Unitful.𝐋^(-3)}) = ustrip(internal_length_unit^(-3), x) # densities
+to_internal_units(x::Quantity{<:Real, Unitful.𝐋^(-4)}) = ustrip(internal_length_unit^(-4), x) # density gradients
 to_internal_units(x::AbstractArray) = to_internal_units.(x)
 
 from_internal_units(x::Real, unit::Unitful.Units{<:Any, Unitful.𝐋}) = uconvert(unit, x * internal_length_unit)

--- a/src/Event/Event.jl
+++ b/src/Event/Event.jl
@@ -309,7 +309,7 @@ function get_electron_and_hole_contribution(evt::Event{T}, sim::Simulation{T, S}
     
     @assert !ismissing(evt.drift_paths) "The charge drift is not yet simulated. Please use `drift_charges!(evt, sim)`!"
     
-    dt::T = T(ustrip(uconvert(u"ns", diff(evt.drift_paths[1].timestamps_e)[1]*u"s")))
+    dt::T = T(ustrip(u"ns", diff(evt.drift_paths[1].timestamps_e)[1]*u"s"))
     wp::Interpolations.Extrapolation{T, 3} = interpolated_scalarfield(sim.weighting_potentials[contact_id])
     signal_e::Vector{T} = zeros(T, length(maximum(map(p -> p.timestamps_e, evt.drift_paths))))
     signal_h::Vector{T} = zeros(T, length(maximum(map(p -> p.timestamps_h, evt.drift_paths))))

--- a/src/PlotRecipes/Potentials.jl
+++ b/src/PlotRecipes/Potentials.jl
@@ -7,7 +7,7 @@ function _get_potential_plot_information(::WeightingPotential{T})::Tuple{Symbol,
 end
 
 function _get_potential_plot_information(ecd::EffectiveChargeDensity)::Tuple{Symbol, Tuple{Quantity, Quantity}, String, Unitful.Units}
-    return (:inferno, extrema(ecd.data).*u"V * m", "Effective Charge Density", u"V * m")
+    return (:inferno, extrema(ecd.data).*u"V/m^2", "Effective Charge Density", u"V/m^2")
 end
 
 function _get_potential_plot_information(::PointTypes{T})::Tuple{Symbol, Tuple{T,T}, String, Unitful.Units} where {T}

--- a/src/Units.jl
+++ b/src/Units.jl
@@ -18,13 +18,13 @@ const internal_charge_density_unit = internal_charge_unit / internal_length_unit
 const external_charge_unit  = u"e_au" # elementary charge - from UnitfulAtomic.jl
 
 to_internal_units(x::Quantity{<:Real}) = throw(ArgumentError("Unit $(unit(x)) unknown to SolidStateDetectors.jl"))
-to_internal_units(x::Quantity{<:Real, dimension(internal_time_unit)})    = ustrip(uconvert(internal_time_unit,    x))
-to_internal_units(x::Quantity{<:Real, dimension(internal_voltage_unit)}) = ustrip(uconvert(internal_voltage_unit, x))
-to_internal_units(x::Quantity{<:Real, dimension(internal_efield_unit)})   = ustrip(uconvert(internal_efield_unit,  x))
-to_internal_units(x::Quantity{<:Real, dimension(internal_energy_unit)})  = ustrip(uconvert(internal_energy_unit,  x))
-to_internal_units(x::Quantity{<:Real, dimension(internal_charge_unit)})  = ustrip(uconvert(internal_charge_unit,  x))
-to_internal_units(x::Quantity{<:Real, dimension(internal_diffusion_unit)})  = ustrip(uconvert(internal_diffusion_unit,  x))
-to_internal_units(x::Quantity{<:Real, dimension(internal_charge_density_unit)})  = ustrip(uconvert(internal_charge_density_unit,  x))
+to_internal_units(x::Quantity{<:Real, dimension(internal_time_unit)})    = ustrip(internal_time_unit,    x)
+to_internal_units(x::Quantity{<:Real, dimension(internal_voltage_unit)}) = ustrip(internal_voltage_unit, x)
+to_internal_units(x::Quantity{<:Real, dimension(internal_efield_unit)})  = ustrip(internal_efield_unit,  x)
+to_internal_units(x::Quantity{<:Real, dimension(internal_energy_unit)})  = ustrip(internal_energy_unit,  x)
+to_internal_units(x::Quantity{<:Real, dimension(internal_charge_unit)})  = ustrip(internal_charge_unit,  x)
+to_internal_units(x::Quantity{<:Real, dimension(internal_diffusion_unit)})  = ustrip(internal_diffusion_unit,  x)
+to_internal_units(x::Quantity{<:Real, dimension(internal_charge_density_unit)})  = ustrip(internal_charge_density_unit,  x)
 
 from_internal_units(x::Real, unit::Unitful.Units{<:Any, dimension(internal_time_unit)})    = uconvert(unit, x * internal_time_unit)
 from_internal_units(x::Real, unit::Unitful.Units{<:Any, dimension(internal_voltage_unit)}) = uconvert(unit, x * internal_voltage_unit)

--- a/src/Units.jl
+++ b/src/Units.jl
@@ -12,7 +12,9 @@ const internal_voltage_unit = u"V"
 const internal_energy_unit  = u"eV"
 const internal_efield_unit  = internal_voltage_unit / internal_length_unit
 const internal_charge_unit  = u"C"
-const internal_diffusion_unit = u"m^2/s"
+const internal_diffusion_unit = internal_length_unit ^ 2 / internal_time_unit
+const internal_charge_density_unit = internal_charge_unit / internal_length_unit ^ 3
+
 const external_charge_unit  = u"e_au" # elementary charge - from UnitfulAtomic.jl
 
 to_internal_units(x::Quantity{<:Real, dimension(internal_time_unit)})    = ustrip(uconvert(internal_time_unit,    x))
@@ -21,6 +23,7 @@ to_internal_units(x::Quantity{<:Real, dimension(internal_efield_unit)})   = ustr
 to_internal_units(x::Quantity{<:Real, dimension(internal_energy_unit)})  = ustrip(uconvert(internal_energy_unit,  x))
 to_internal_units(x::Quantity{<:Real, dimension(internal_charge_unit)})  = ustrip(uconvert(internal_charge_unit,  x))
 to_internal_units(x::Quantity{<:Real, dimension(internal_diffusion_unit)})  = ustrip(uconvert(internal_diffusion_unit,  x))
+to_internal_units(x::Quantity{<:Real, dimension(internal_charge_density_unit)})  = ustrip(uconvert(internal_charge_density_unit,  x))
 
 from_internal_units(x::Real, unit::Unitful.Units{<:Any, dimension(internal_time_unit)})    = uconvert(unit, x * internal_time_unit)
 from_internal_units(x::Real, unit::Unitful.Units{<:Any, dimension(internal_voltage_unit)}) = uconvert(unit, x * internal_voltage_unit)

--- a/src/Units.jl
+++ b/src/Units.jl
@@ -17,6 +17,7 @@ const internal_charge_density_unit = internal_charge_unit / internal_length_unit
 
 const external_charge_unit  = u"e_au" # elementary charge - from UnitfulAtomic.jl
 
+to_internal_units(x::Quantity{<:Real}) = throw(ArgumentError("Unit $(unit(x)) unknown to SolidStateDetectors.jl"))
 to_internal_units(x::Quantity{<:Real, dimension(internal_time_unit)})    = ustrip(uconvert(internal_time_unit,    x))
 to_internal_units(x::Quantity{<:Real, dimension(internal_voltage_unit)}) = ustrip(uconvert(internal_voltage_unit, x))
 to_internal_units(x::Quantity{<:Real, dimension(internal_efield_unit)})   = ustrip(uconvert(internal_efield_unit,  x))

--- a/test/comparison_to_analytic_solutions.jl
+++ b/test/comparison_to_analytic_solutions.jl
@@ -95,9 +95,9 @@ end
 
     # Analytical solutions for the elements of the capacitance matrix:
     function c_ii(r1, r2, d; n = 10)
-        r1 = ustrip(uconvert(u"m", r1))
-        r2 = ustrip(uconvert(u"m", r2))
-        d  = ustrip(uconvert(u"m", d))
+        r1 = ustrip(u"m", r1)
+        r2 = ustrip(u"m", r2)
+        d  = ustrip(u"m", d)
         c = 0
         F = 4π*ϵ0 * 1u"m"
         u = acosh((d^2 - r1^2 - r2^2) / (2*r1*r2))
@@ -107,9 +107,9 @@ end
         uconvert(u"pF", F * r1 * r2 * sinh(u) * c)
     end
     function c_ij(r1, r2, d; n = 10)
-        r1 = ustrip(uconvert(u"m", r1))
-        r2 = ustrip(uconvert(u"m", r2))
-        d  = ustrip(uconvert(u"m", d))
+        r1 = ustrip(u"m", r1)
+        r2 = ustrip(u"m", r2)
+        d  = ustrip(u"m", d)
         c = 0
         F = 4π*ϵ0 * 1u"m"
         u = acosh((d^2 - r1^2 - r2^2) / (2*r1*r2))


### PR DESCRIPTION
# Changes in this PR

After this PR, 
- it is possible to pass a charge density with units in the config file/dict
- errors are thrown if an unknown unit is passed to SolidStateDetectors.jl in the config file/dict
- the effective charge densities are displayed with the current units (V/m² instead of V*m)

# Background information

I tried out if the fixed charge densities were implemented correctly because some people were reporting interesting behaviors of SSD when defining charged surfaces. I wrote a small config file to test if a (passive) charged sphere would result in the electric potential expected using Gauss's law.

[Config file "ChargedSphere.yaml"](https://github.com/JuliaPhysics/SolidStateDetectors.jl/files/12165026/ChargedSphere.txt):
```yaml
name: Charged Sphere
units:
  length: mm
  angle: deg
  potential: V
  temperature: K
grid:
  coordinates: cylindrical
  axes:
    r:
      to: 500
      boundaries: inf
    phi:
      from: 0
      to: 0
      boundaries: periodic
    z:
      from: -500
      to: 500
      boundaries:
        left: inf
        right: inf
medium: vacuum
detectors:
  - semiconductor:
      material: HPGe
      temperature: 78
      impurity_density:
        name: cylindrical
        z:
          init: 0
          gradient: 0
      geometry:
        sphere:
          r: 1
          origin: [0, 0, 1000]
    contacts:
      - material: HPGe
        id: 1
        potential: 0
        geometry:
          sphere:
            r: 1
            origin: [0, 0, 1000]
      - material: HPGe
        id: 2
        potential: 0
        geometry:
          sphere:
            r: 1
            origin: [0, 0, -1000]
    passives:
      - material: vacuum
        id: 1
        charge_density:
          name: constant
          value: 1e-18C/mm^3
        geometry:
          sphere:
            r: 20
```

Julia file:
```julia
using SolidStateDetectors
using Plots, Unitful

T = Float64
sim = Simulation{T}("ChargedSphere.yaml")
calculate_electric_potential!(sim, refinement_limits = [0.2,0.1,0.05,0.03,0.02,0.01,0.005])

plot(sim.electric_potential.grid[3].ticks, sim.electric_potential.data[1,1,:])
let p = sim.detector.passives[1]
    ρ = p.charge_density_model.ρ * u"C/m^3"
    ϵ = SolidStateDetectors.ϵ0 * u"F/m"
    R = p.geometry.r*u"m"
    ϕ(r) = uconvert(u"V", r < R ? ρ/(2*ϵ) * R^2 - ρ/(6*ϵ) * r^2 : ρ/(3*ϵ)*R^3 / r)
    plot!(-0.5:0.0001:0.5, r -> ustrip(u"V", ϕ(abs(r)*u"m")))
end
```
![image](https://github.com/JuliaPhysics/SolidStateDetectors.jl/assets/30291312/8e9ac5b0-8b19-45dc-b5a5-ba223078987f)


![image](https://github.com/JuliaPhysics/SolidStateDetectors.jl/assets/30291312/c277bbcb-f7d1-4e60-8184-15efa0d04168)



Plotting the effective charge density made me aware that `sim.q_eff_fix` is just the charge density divided by `ϵ`, 
which should give a unit of 
```math 
Q_\text{eff}^\text{imp} = \dfrac{\rho}{\epsilon} \Rightarrow \left[ Q_\text{eff}^\text{imp} \right] = \dfrac{\text{C}}{\text{m}^3} \cdot \dfrac{\text{m}}{\text{F}} = \dfrac{\text{V}}{\text{m}^2}
```
This agrees also well with the plot for the example shown above
```julia
maximum(sim.q_eff_fix.data)
```
```
112.94090667607486
```

```julia
let p = sim.detector.passives[1]
    ρ = p.charge_density_model.ρ * u"C/m^3"
    ϵ = SolidStateDetectors.ϵ0 * u"F/m"
    uconvert(u"V/m^2", ρ/ϵ)
end
```
```
112.9409066760748 V m^-2
```

That's why I updated the plot recipe for `q_eff_imp` and `q_eff_fix` to have the correct unit of V/m².

![image](https://github.com/JuliaPhysics/SolidStateDetectors.jl/assets/30291312/1ac7e74f-6882-4ea8-9afe-d70374186ae0)
