### PR TITLE
Update MaterialProperties.jl

### DIFF
--- a/src/MaterialProperties/MaterialProperties.jl
+++ b/src/MaterialProperties/MaterialProperties.jl
@@ -42,7 +42,9 @@ material_properties[:Si] = (
     ρ = 2.3290u"g*cm^-3",
     name = "Silicon",
     mt = 0.98,
-    ml = 0.19
+    ml = 0.19,
+    De = 39u"cm^2/s",
+    Dh = 12u"cm^2/s"
 )
 
 material_properties[:Al] = (


### PR DESCRIPTION
When using diffusion with Si material it gives error because De and Dh are missing in the material properties file.  Taking values from; 
https://sites.ecse.rpi.edu/~schubert/Educational-resources/Materials-Semiconductors-Si-and-Ge.pdf