### PR TITLE
Use inplace-memory interpolation for cylindrical ScalarPotential

### DIFF
--- a/src/ElectricField/ElectricField.jl
+++ b/src/ElectricField/ElectricField.jl
@@ -180,7 +180,7 @@ end
 function interpolated_scalarfield(spot::ScalarPotential{T, 3, Cylindrical}) where {T}
     @inbounds knots = spot.grid.axes[1].ticks, cat(spot.grid.axes[2].ticks,T(2π),dims=1), spot.grid.axes[3].ticks
     ext_data = cat(spot.data, spot.data[:,1:1,:], dims=2)
-    i = interpolate(knots, ext_data, Gridded(Linear()))
+    i = interpolate!(knots, ext_data, Gridded(Linear()))
     vector_field_itp = extrapolate(i, (Interpolations.Line(), Periodic(), Interpolations.Line()))
     return vector_field_itp
 end


### PR DESCRIPTION
Seems like changing `interpolate` to `interpolate!` was forgotten for cylindrical `ScalarPotentials`  in the commit 679273f.
This change speeds up the signal generation significantly.