### PR TITLE
GDML geometry parsing for composite rotations and Torus + Prism, bugfix in IO.jl

### DIFF
--- a/ext/SolidStateDetectorsGeant4Ext.jl
+++ b/ext/SolidStateDetectorsGeant4Ext.jl
@@ -41,7 +41,7 @@ function Geant4.G4JLDetector(sim::SolidStateDetectors.Simulation, output_filenam
     create_volume(x_structure, "sc", parse_material(sim.detector.semiconductor.material.name))
     # Parse contacts
     for (i, contact) in enumerate(sim.detector.contacts)
-        if has_volume(contact.geometry, x_solids, x_define, 1, "ct$(i)_", verbose, parse = false)
+        if has_volume(contact.geometry, 1, "ct$(i)_", verbose)
             parse_geometry(contact.geometry, x_solids, x_define, 1, "ct$(i)_", verbose)
             create_volume(x_structure, "ct$(i)", parse_material(contact.material.name))
         end
@@ -49,7 +49,7 @@ function Geant4.G4JLDetector(sim::SolidStateDetectors.Simulation, output_filenam
     # Parse passives
     if !ismissing(sim.detector.passives)
         for (i, passive) in enumerate(sim.detector.passives)
-            if has_volume(passive.geometry, x_solids, x_define, 1, "pv$(i)_", verbose, parse = false)
+            if has_volume(passive.geometry, 1, "pv$(i)_", verbose)
                 parse_geometry(passive.geometry, x_solids, x_define, 1, "pv$(i)_", verbose)
                 create_volume(x_structure, "pv$(i)", parse_material(passive.material.name))
             end
@@ -66,7 +66,7 @@ function Geant4.G4JLDetector(sim::SolidStateDetectors.Simulation, output_filenam
     add_to_world(z, x_define, sim.detector.semiconductor.geometry, "sc")
     # Append contacts to physical volume
     for (i, contact) in enumerate(sim.detector.contacts)
-        if has_volume(contact.geometry, x_solids, x_define, 1, "ct$(i)_", verbose, parse = false)
+        if has_volume(contact.geometry, 1, "ct$(i)_", verbose)
             z = new_child(x_wd_vol, "physvol")
             add_to_world(z, x_define, contact.geometry, "ct$(i)")
         end
@@ -74,7 +74,7 @@ function Geant4.G4JLDetector(sim::SolidStateDetectors.Simulation, output_filenam
     # Append passives to physical volume
     if !ismissing(sim.detector.passives)
         for (i, passive) in enumerate(sim.detector.passives)
-            if has_volume(passive.geometry, x_solids, x_define, 1, "pv$(i)_", verbose, parse = false)
+            if has_volume(passive.geometry, 1, "pv$(i)_", verbose)
                 z = new_child(x_wd_vol, "physvol")
                 add_to_world(z, x_define, passive.geometry, "pv$(i)")
             end

--- a/ext/io_gdml.jl
+++ b/ext/io_gdml.jl
@@ -17,10 +17,10 @@ using LightXML
 @inline parse_origin(e::AbstractConstructiveGeometry) = parse_origin(e.a)
 
 # Returns rotation matrix for Primitive relative to standard basis
-@inline function parse_rotation(e::AbstractVolumePrimitive) = rotation(e)
+@inline parse_rotation(e::AbstractVolumePrimitive) = rotation(e)
 
 # Returns rotation matrix for leftmost Primitive in geometry tree
-@inline function parse_rotation(e::AbstractConstructiveGeometry) = parse_rotation(e.a)
+@inline parse_rotation(e::AbstractConstructiveGeometry) = parse_rotation(e.a)
 
 
 # Add <position> to <define> section, referenced in the geometry definition (in <solids>) via the name

--- a/ext/io_gdml.jl
+++ b/ext/io_gdml.jl
@@ -10,21 +10,17 @@ using Rotations
 using LightXML
 
 
-# position relative to origin of a primitive is stored in its parameters
+# Returns position vector for Primitive relative to origin
 @inline parse_origin(e::AbstractVolumePrimitive) = origin(e)
 
-# position relative to the origin of a boolean solid is defined as position of
-# the leftmost child in the tree structure
+# Returns position vector for leftmost Primitive in geometry tree
 @inline parse_origin(e::AbstractConstructiveGeometry) = parse_origin(e.a)
 
-# Returns rotation matrix for the Primitive or the leftmost child in the tree
-@inline function parse_rotation(e::AbstractVolumePrimitive)
-    return rotation(e)
-end
+# Returns rotation matrix for Primitive relative to standard basis
+@inline function parse_rotation(e::AbstractVolumePrimitive) = rotation(e)
 
-@inline function parse_rotation(e::AbstractConstructiveGeometry)
-    return parse_rotation(e.a)
-end
+# Returns rotation matrix for leftmost Primitive in geometry tree
+@inline function parse_rotation(e::AbstractConstructiveGeometry) = parse_rotation(e.a)
 
 
 # Add <position> to <define> section, referenced in the geometry definition (in <solids>) via the name

--- a/ext/materials.xml
+++ b/ext/materials.xml
@@ -18,7 +18,7 @@
     <element name="G4_Galactic" Z="1" formula="Galactic">
       <atom value="1.01" unit="g/mole"/>
     </element>
-    <material name="Vacuum" state="gas">
+    <material name="G4_Vacuum" state="gas">
       <D value="1e-25" unit="g/cm3"/>
       <fraction n="1" ref="G4_Galactic"/>
     </material>


### PR DESCRIPTION
Implemented correct geometry parsing for more complicated objects with composite rotations and more exotic geometries involving Tori and Prisms. Also, a problem was fixed regarding the YAML file parsing.

In GDML, relative rotations between linked geometrical objects have to be defined via the Euler angles (as opposed to CSG, where ultimately, only the rotation matrix of each Volume Primitive is stored). These angles are computed by determining the relative rotation matrix of the two respective volumes.

Given the rotation matrices $R_1$ and $R_2$ (for volume $V_1$ and $V_2$, respectively), the rotation of the second volume relative to the rotation of the first volume is $R^{-1}_1R_2$. Since we are working with rotation matrices, inversion is always possible and the inverse of the matrix $R_1$ simply corresponds to the transposed matrix.

---
While testing the newly implemented features, a bug in the SSD code became present, regarding the geometry parsing of nested transformations. The problem became present whenever more than one transformation (translation/rotation) was consecutively used as a separate block. For example, consider the following segment that may appear in the geometry description:
```YAML
translate:      # Ignored
    rotate:     # Parsed correctly
        ...
    ...
```
When parsing a geometry of that kind, only the outer transformation was applied previously, resulting in a geometry without the rotation. With the changes to `IO.jl`, all nested transformations should now work fine.