### PR TITLE
Changed parameters of `has_volume` function

### DIFF
--- a/ext/SolidStateDetectorsGeant4Ext.jl
+++ b/ext/SolidStateDetectorsGeant4Ext.jl
@@ -41,7 +41,7 @@ function Geant4.G4JLDetector(sim::SolidStateDetectors.Simulation, output_filenam
     create_volume(x_structure, "sc", parse_material(sim.detector.semiconductor.material.name))
     # Parse contacts
     for (i, contact) in enumerate(sim.detector.contacts)
-        if has_volume(contact.geometry, 1, "ct$(i)_", verbose)
+        if has_volume(contact.geometry, verbose)
             parse_geometry(contact.geometry, x_solids, x_define, 1, "ct$(i)_", verbose)
             create_volume(x_structure, "ct$(i)", parse_material(contact.material.name))
         end
@@ -49,7 +49,7 @@ function Geant4.G4JLDetector(sim::SolidStateDetectors.Simulation, output_filenam
     # Parse passives
     if !ismissing(sim.detector.passives)
         for (i, passive) in enumerate(sim.detector.passives)
-            if has_volume(passive.geometry, 1, "pv$(i)_", verbose)
+            if has_volume(passive.geometry, verbose)
                 parse_geometry(passive.geometry, x_solids, x_define, 1, "pv$(i)_", verbose)
                 create_volume(x_structure, "pv$(i)", parse_material(passive.material.name))
             end
@@ -66,7 +66,7 @@ function Geant4.G4JLDetector(sim::SolidStateDetectors.Simulation, output_filenam
     add_to_world(z, x_define, sim.detector.semiconductor.geometry, "sc")
     # Append contacts to physical volume
     for (i, contact) in enumerate(sim.detector.contacts)
-        if has_volume(contact.geometry, 1, "ct$(i)_", verbose)
+        if has_volume(contact.geometry, verbose)
             z = new_child(x_wd_vol, "physvol")
             add_to_world(z, x_define, contact.geometry, "ct$(i)")
         end
@@ -74,7 +74,7 @@ function Geant4.G4JLDetector(sim::SolidStateDetectors.Simulation, output_filenam
     # Append passives to physical volume
     if !ismissing(sim.detector.passives)
         for (i, passive) in enumerate(sim.detector.passives)
-            if has_volume(passive.geometry, 1, "pv$(i)_", verbose)
+            if has_volume(passive.geometry, verbose)
                 z = new_child(x_wd_vol, "physvol")
                 add_to_world(z, x_define, passive.geometry, "pv$(i)")
             end

--- a/ext/io_gdml.jl
+++ b/ext/io_gdml.jl
@@ -17,10 +17,10 @@ using LightXML
 @inline parse_origin(e::AbstractConstructiveGeometry) = parse_origin(e.a)
 
 # Returns rotation matrix for Primitive relative to standard basis
-@inline function parse_rotation(e::AbstractVolumePrimitive) = rotation(e)
+@inline parse_rotation(e::AbstractVolumePrimitive) = rotation(e)
 
 # Returns rotation matrix for leftmost Primitive in geometry tree
-@inline function parse_rotation(e::AbstractConstructiveGeometry) = parse_rotation(e.a)
+@inline parse_rotation(e::AbstractConstructiveGeometry) = parse_rotation(e.a)
 
 
 # Add <position> to <define> section, referenced in the geometry definition (in <solids>) via the name
@@ -93,79 +93,79 @@ end
 
 
 # Checks whether given geometry object has required dimension values (zero volume not supported in Geant4)
-function has_volume(e::Box, id::Integer, pf::AbstractString, v::Bool)
+function has_volume(e::Box, v::Bool = false)
     if e.hX > 0 && e.hY > 0 && e.hZ > 0
         return true
     else
-        v && @warn "Box $(pf * string(id)): All dimensions must be positive"
+        v && @warn "Box: All dimensions must be positive"
         return false
     end
 end
 
-function has_volume(e::Cone{T,<:Any,TR}, id::Integer, pf::AbstractString, v::Bool) where {T, TR <: Union{T, Tuple{T,T}}}
+function has_volume(e::Cone{T,<:Any,TR}, v::Bool = false) where {T, TR <: Union{T, Tuple{T,T}}}
     rmin, rmax = parse_tube_radius(e)
     
     if rmin >= rmax
-        v && @warn "Cone $(pf * string(id)): Outer radius must be strictly bigger than inner radius"
+        v && @warn "Cone: Outer radius must be strictly bigger than inner radius"
         return false
     elseif e.hZ <= 0
-        v && @warn "Cone $(pf * string(id)): The height must be a positive number"
+        v && @warn "Cone: The height must be a positive number"
         return false
     end
 
     return true
 end
 
-function has_volume(e::Cone{T,<:Any,TR}, id::Integer, pf::AbstractString, v::Bool) where {T, TR}    
+function has_volume(e::Cone{T,<:Any,TR}, v::Bool = false) where {T, TR}    
     rmin1, rmax1, rmin2, rmax2 = parse_cone_radius(e)
     
     if rmin1 >= rmax1 || rmin2 >= rmax2
-        v && @warn "Cone $(pf * string(id)): The outer radii must be strictly bigger than the inner radii"
+        v && @warn "Cone: The outer radii must be strictly bigger than the inner radii"
         return false
     elseif e.hZ <= 0
-        v && @warn "Cone $(pf * string(id)): The height must be a positive number"
+        v && @warn "Cone: The height must be a positive number"
         return false
     else 
         return true
     end
 end
 
-function has_volume(e::Ellipsoid{T,<:Any,T}, id::Integer, pf::AbstractString, v::Bool) where {T}
+function has_volume(e::Ellipsoid{T,<:Any,T}, v::Bool = false) where {T}
     if e.r <= 0
-        v && @warn "Ellipsoid $(pf * string(id)): Radius must be a positive number"
+        v && @warn "Ellipsoid: Radius must be a positive number"
         return false
     else
         return true
     end
 end
 
-function has_volume(e::Torus, id::Integer, pf::AbstractString, v::Bool)
+function has_volume(e::Torus, v::Bool = false)
     if isa(e.r_tube, Tuple)
         if e.r_tube[1] >= e.r_tube[2]
-            v && @warn "Torus $(pf * string(id)): Outer tube radius must be bigger than the inner tube radius"
+            v && @warn "Torus: Outer tube radius must be bigger than the inner tube radius"
             return false
         elseif e.r_tube[1] < 0 || e.r_tube[2] < 0
-            v && @warn "Torus $(pf * string(id)): Inner tube radius must be non-negative, Outer tube radius must be positive"
+            v && @warn "Torus: Inner tube radius must be non-negative, Outer tube radius must be positive"
             return false
         end
     elseif e.r_tube <= 0
-        v && @warn "Torus $(pf * string(id)): Tube radius must be a positive number"
+        v && @warn "Torus: Tube radius must be a positive number"
         return false
     end
     if e.r_torus <= 0
-        v && @warn "Torus $(pf * string(id)): Torus radius must be a positive number"
+        v && @warn "Torus: Torus radius must be a positive number"
         return false
     end
     return true
 end
 
-function has_volume(e::RegularPrism, id::Integer, pf::AbstractString, v::Bool)
+function has_volume(e::RegularPrism, v::Bool = false)
     if e.r <= 0
-        v && @warn "Prism: $(pf * string(id)): Radius of prism must be a positive number"
+        v && @warn "Prism: Radius of prism must be a positive number"
         return false
     end
     if e.hZ <= 0
-        v && @warn "Prism: $(pf * string(id)): Height of prism must be a positive number"
+        v && @warn "Prism: Height of prism must be a positive number"
         return false
     end
     return true
@@ -173,8 +173,8 @@ end
 
 
 # Check whether Boolean solid has any volume at all
-function has_volume(e::AbstractConstructiveGeometry, id::Integer, pf::AbstractString, v::Bool)
-    return has_volume(e.a, 2 * id, pf, v) || has_volume(e.b, 2 * id + 1, pf, v)
+function has_volume(e::AbstractConstructiveGeometry, v::Bool = false)
+    return has_volume(e.a, v) || has_volume(e.b, v)
 end
 
 
@@ -191,8 +191,8 @@ end
 function parse_geometry(e::AbstractConstructiveGeometry, x_solids::XMLElement, x_define::XMLElement, id::Integer, pf::AbstractString, v::Bool)::Nothing
     # If composite geometry contains children with zero volume, omit its geometry definition
     # Omit the construction of a Boolean solid if some children have zero volume
-    hva = has_volume(e.a, 2 * id, pf, v)
-    hvb = has_volume(e.b, 2 * id + 1, pf, v)
+    hva = has_volume(e.a, v)
+    hvb = has_volume(e.b, v)
     if hva && hvb
         parse_geometry(e.a, x_solids, x_define, 2 * id, pf, v)
         parse_geometry(e.b, x_solids, x_define, 2 * id + 1, pf, v)
@@ -227,7 +227,7 @@ function parse_geometry(e::AbstractConstructiveGeometry, x_solids::XMLElement, x
 end
 
 function parse_geometry(e::Box, x_solids::XMLElement, x_define::XMLElement, id::Integer, pf::AbstractString, v::Bool)::Nothing
-    if has_volume(e, id, pf, v)
+    if has_volume(e, v)
         y = new_child(x_solids, "box")
         set_attributes(y, OrderedDict(
             "name" => pf * string(id),
@@ -244,7 +244,7 @@ end
 @inline parse_φ(::Type{T}, φ::T) where {T} = (φ, string(SolidStateDetectors.internal_angle_unit))
 @inline parse_φ(::Type, φ) = throw(AssertionError("Cone: the type of φ is unexpected"))
 function parse_geometry(e::Cone{T,<:Any, TR}, x_solids::XMLElement, x_define::XMLElement, id::Integer, pf::AbstractString, v::Bool)::Nothing where {T, TR <: Union{T, Tuple{T,T}}}
-    if has_volume(e, id, pf, v)
+    if has_volume(e, v)
     
         y = new_child(x_solids, "tube")
 
@@ -266,7 +266,7 @@ function parse_geometry(e::Cone{T,<:Any, TR}, x_solids::XMLElement, x_define::XM
 end
 
 function parse_geometry(e::Cone{T,<:Any,TR, <:Any}, x_solids::XMLElement, x_define::XMLElement, id::Integer, pf::AbstractString, v::Bool)::Nothing where {T, TR <: Union{Tuple{Tuple{T}, Tuple{T}}, Tuple{Tuple{T, T}, Tuple{T, T}}}}
-    if has_volume(e, id, pf, v)
+    if has_volume(e, v)
     
         y = new_child(x_solids, "cone")
         
@@ -290,7 +290,7 @@ function parse_geometry(e::Cone{T,<:Any,TR, <:Any}, x_solids::XMLElement, x_defi
 end
 
 function parse_geometry(e::Ellipsoid{T,<:Any, TR, Nothing, Nothing}, x_solids::XMLElement, x_define::XMLElement, id::Integer, pf::AbstractString, v::Bool)::Nothing where {T, TR}
-    if has_volume(e, id, pf, v)
+    if has_volume(e, v)
        
         y = new_child(x_solids, "orb")
         
@@ -317,7 +317,7 @@ end
 # @inline parse_θ(::Type{T}, θ::Nothing) where {T} = (T(0), T(360), "deg")
 # @inline parse_θ(::Type{T}, θ::Tuple{T, T}) where {T} = throw(AssertionError("Torus: θ values are currently not supported"))
 function parse_geometry(e::Torus, x_solids::XMLElement, x_define::XMLElement, id::Integer, pf::AbstractString, v::Bool)::Nothing
-    if has_volume(e, id, pf, v)
+    if has_volume(e, v)
         y = new_child(x_solids, "torus")
         # phi, aunit = parse_φ(T, e.φ)
         # theta1, theta2, aunit = parse_θ(T, e.θ)
@@ -346,7 +346,7 @@ end
 
 
 function parse_geometry(e::RegularPrism{T, <:Any, N}, x_solids::XMLElement, x_define::XMLElement, id::Integer, pf::AbstractString, v::Bool)::Nothing where {T, N}
-    if has_volume(e, id, pf, v)
+    if has_volume(e, v)
         y = new_child(x_solids, "polyhedra")
         
         r = e.r
@@ -373,9 +373,6 @@ function parse_geometry(e::RegularPrism{T, <:Any, N}, x_solids::XMLElement, x_de
         ))
     end
 end
-
-
-
 
 
 function parse_geometry(e::World{T, 3, Cylindrical}, x_solids::XMLElement, x_define::XMLElement, id::Integer, pf::AbstractString, v::Bool)::Nothing where {T}


### PR DESCRIPTION
As requested in my last pull request, the parameters of the `has_volume` function were changed to make the function more general and less related to the Geant4 functionality.

The function is now and was previously parametrized as follows:
```Julia
function has_volume(e::AbstractGeometry, v::Bool = false)                            # New
function has_volume(e::AbstractGeometry, id::Integer, pf::AbstractString, v::Bool)   # Old
```

Before the changes, the ID and the prefix for the specific part of the detector were also used as parameters to make the warning messages more informative. This was very Geant4-specific and if we are planning to incorporate the function into other parts of SolidStateDetectors.jl, it's desirable to make it as general as possible.