### PR TITLE
Completed Geant4 materials list

### DIFF
--- a/ext/Geant4/io_gdml.jl
+++ b/ext/Geant4/io_gdml.jl
@@ -460,6 +460,9 @@ end
     elseif material == "Aluminium" return "G4_Al"
     elseif material == "liquid Argon" return "G4_lAr"
     elseif material == "Copper" return "G4_Cu"
+    elseif material == "PEN" return "G4_PEN"
+    elseif material == "PTFE" return "G4_PTFE"
+    elseif material == "CdZnTe" return "G4_CdZnTe"
     end
     throw("Material characteristics for \"$(material)\" not defined yet")
 end

--- a/ext/Geant4/materials.xml
+++ b/ext/Geant4/materials.xml
@@ -1,25 +1,67 @@
 <materials>
-    <material name="G4_Al" Z="13" >
+    <material name="G4_Al" Z="13">
         <D value="2.699" />
         <atom value="26.982" />
     </material>
     <material name="G4_Ge" Z="32">
-        <D value="5.323"/>
-        <atom value="72.630"/>
+        <D value="5.323" />
+        <atom value="72.630" />
     </material>
     <material name="G4_Si" Z="14">
-        <D value="2.329"/>
-        <atom value="28.085"/>
+        <D value="2.329" />
+        <atom value="28.085" />
     </material>
     <material name="G4_Cu" Z="29">
-        <D value="8.960"/>
-        <atom value="63.546"/>
+        <D value="8.960" />
+        <atom value="63.546" />
     </material>
     <element name="G4_Galactic" Z="1" formula="Galactic">
-      <atom value="1.01" unit="g/mole"/>
+        <atom value="1.01" unit="g/mole" />
     </element>
     <material name="G4_Vacuum" state="gas">
-      <D value="1e-25" unit="g/cm3"/>
-      <fraction n="1" ref="G4_Galactic"/>
+        <D value="1e-25" unit="g/cm3" />
+        <fraction n="1" ref="G4_Galactic" />
+    </material>
+
+    <element name="G4_H" Z="1">
+        <atom value="1.00794" />
+    </element>
+    <element name="G4_C" Z="6">
+        <atom value="12.0107" />
+    </element>
+    <element name="G4_O" Z="8">
+        <atom value="15.9994" />
+    </element>
+    <element name="G4_F" Z="9">
+        <atom value="18.9984032" />
+    </element>
+    <element name="G4_Cd" Z="48">
+        <atom value="112.411" />
+    </element>
+    <element name="G4_Zn" Z="30">
+        <atom value="65.38" />
+    </element>
+    <element name="G4_Te" Z="52">
+        <atom value="127.6" />
+    </element>
+
+    <material name="G4_PEN" formula="C14H10O4">
+        <D value="1.37" unit="g/cm3" />
+        <fraction n="0.7043" ref="G4_C" />
+        <fraction n="0.0505" ref="G4_H" />
+        <fraction n="0.2452" ref="G4_O" />
+    </material>
+
+    <material name="G4_PTFE" formula="C2F4">
+        <D value="2.2" unit="g/cm3" />
+        <fraction n="0.2402" ref="G4_C" />
+        <fraction n="0.7598" ref="G4_F" />
+    </material>
+
+    <material name="G4_CdZnTe" formula="Cd0.9Zn0.1Te">
+        <D value="5.78" unit="g/cm3" />
+        <fraction n="0.41" ref="G4_Cd" /> 
+        <fraction n="0.047" ref="G4_Zn" />
+        <fraction n="0.543" ref="G4_Te" />
     </material>
 </materials>

--- a/ext/Geant4/materials.xml
+++ b/ext/Geant4/materials.xml
@@ -47,9 +47,9 @@
 
     <material name="G4_PEN" formula="C14H10O4">
         <D value="1.37" unit="g/cm3" />
-        <fraction n="0.7043" ref="G4_C" />
-        <fraction n="0.0505" ref="G4_H" />
-        <fraction n="0.2452" ref="G4_O" />
+        <fraction n="0.6942" ref="G4_C" />
+        <fraction n="0.0416" ref="G4_H" />
+        <fraction n="0.2642" ref="G4_O" />
     </material>
 
     <material name="G4_PTFE" formula="C2F4">
@@ -60,8 +60,8 @@
 
     <material name="G4_CdZnTe" formula="Cd0.9Zn0.1Te">
         <D value="5.78" unit="g/cm3" />
-        <fraction n="0.41" ref="G4_Cd" /> 
-        <fraction n="0.047" ref="G4_Zn" />
-        <fraction n="0.543" ref="G4_Te" />
+        <fraction n="0.4300" ref="G4_Cd" /> 
+        <fraction n="0.0278" ref="G4_Zn" />
+        <fraction n="0.5422" ref="G4_Te" />
     </material>
 </materials>


### PR DESCRIPTION
Defined the physical properties for PEN, PTFE and CdZnTe.
Now, all elements that are available in SolidStateDetectors.jl can also be used to perform Geant4 simulations.

The `fraction` field in each of the compound materials denotes the relative mass of the element in terms of the total mass of each molecule. The fractions for each material are calculated in the following way:

- PEN (C<sub>14</sub>H<sub>10</sub>O<sub>4</sub>)
  - C: $\frac{14 \cdot 12.0107}{14 \cdot 12.0107 + 10 \cdot 1.00794 + 4 \cdot 15.9994}\approx 0.6942$
  - H: $\frac{10 \cdot 1.00794}{14 \cdot 12.0107 + 10 \cdot 1.00794 + 4 \cdot 15.9994}\approx 0.0416$
  - O: $\frac{4 \cdot 15.9994}{14 \cdot 12.0107 + 10 \cdot 1.00794 + 4 \cdot 15.9994}\approx 0.2642$
- PTFE (C<sub>2</sub>F<sub>4</sub>)
  - C: $\frac{2 \cdot 12.0107 }{2 \cdot 12.0107 + 4 \cdot 18.9994}\approx 0.2402$
  - F: $\frac{4 \cdot 18.9994}{2 \cdot 12.0107 + 4 \cdot 18.9994}\approx 0.7598$
- CdZnTe (Cd<sub>0.9</sub>Zn<sub>0.1</sub>Te)
  - Cd: $\frac{0.9\cdot 112.411}{0.9\cdot 112.411 + 0.1 \cdot65.38 + 127.6}\approx 0.4300$
  - Zn: $\frac{0.1 \cdot65.38}{0.9\cdot 112.411 + 0.1 \cdot65.38 + 127.6}\approx 0.0278$
  - Te: $\frac{127.6}{0.9\cdot 112.411 + 0.1 \cdot65.38 + 127.6}\approx 0.5422$