### PR TITLE
Implemented basic function to run Geant4 simulation

### DIFF
--- a/ext/Geant4/g4jl_application.jl
+++ b/ext/Geant4/g4jl_application.jl
@@ -124,7 +124,7 @@ function SSDGenerator(source::SolidStateDetectors.IsotopeSource;  kwargs...)
 
     function _gen(evt::G4Event, data::GeneratorData)::Nothing
         if isnothing(data.particle)  # late initialize (after physics processes)
-            data.particle = GetIon(source.Z, source.A, source.excitEnergy)
+            data.particle = GetIon(source.Z, source.A, Float64(source.excitEnergy))
             SetParticleDefinition(data.gun, data.particle)
             SetParticleCharge(data.gun, source.ionCharge)
         end

--- a/ext/SolidStateDetectorsGeant4Ext.jl
+++ b/ext/SolidStateDetectorsGeant4Ext.jl
@@ -23,7 +23,7 @@ include(joinpath(@__DIR__, "Geant4", "io_gdml.jl"))
 include(joinpath(@__DIR__, "Geant4", "g4jl_application.jl"))
 
 # Given an SSD simulation object, create corresponding GDML file to desired location
-function Geant4.G4JLDetector(sim::SolidStateDetectors.Simulation, output_filename::String = "tmp.gdml"; verbose::Bool = true)
+function Geant4.G4JLDetector(sim::SolidStateDetectors.Simulation, output_filename::String = "tmp.gdml"; verbose::Bool = true, save_gdml::Bool = false)
     # Create basis for GDML file
     x_doc = XMLDocument()
     x_root = create_root(x_doc, "gdml")
@@ -94,11 +94,11 @@ function Geant4.G4JLDetector(sim::SolidStateDetectors.Simulation, output_filenam
     detector = @suppress_out Geant4.G4JLDetectorGDML(output_filename)
     
     verbose && @warn "Temporary file $(output_filename) will be deleted."
-    rm(output_filename)
+    !save_gdml && rm(output_filename)
     detector 
 end
 
-function Geant4.G4JLDetector(input_filename::String, output_filename::String = "tmp.gdml"; verbose::Bool = true)
+function Geant4.G4JLDetector(input_filename::String, output_filename::String = "tmp.gdml"; verbose::Bool = true, save_gdml::Bool = false)
     if endswith(input_filename, ".gdml")
         @suppress_out Geant4.G4JLDetectorGDML(input_filename)
     else

--- a/ext/SolidStateDetectorsGeant4Ext.jl
+++ b/ext/SolidStateDetectorsGeant4Ext.jl
@@ -165,13 +165,12 @@ function SolidStateDetectors.run_geant4_simulation(app::G4JLApplication, number_
     
     evtno = 1
     while evtno <= number_of_events
-        out = missing
-        while ismissing(out) || isempty(out)      
+        out = DetectorHit[]
+        while isempty(out)      
             @suppress_out beamOn(app,1)
             out = app.sdetectors["SensitiveDetector"][1].data.detectorHits
-            out = out[findall(!iszero, out.edep)]
+            filter!(hit -> !iszero(hit.edep), out)
             out.evtno .= evtno
-	   
         end
         append!(evts, out)
         evtno += 1

--- a/src/MCEventsProcessing/MCEventsProcessing.jl
+++ b/src/MCEventsProcessing/MCEventsProcessing.jl
@@ -153,3 +153,4 @@ function _generate_waveform( drift_paths::Vector{<:EHDriftPath{T}}, charges::Vec
 end
 
 
+function run_geant4_simulation end

--- a/src/MCEventsProcessing/MCEventsProcessing.jl
+++ b/src/MCEventsProcessing/MCEventsProcessing.jl
@@ -153,4 +153,22 @@ function _generate_waveform( drift_paths::Vector{<:EHDriftPath{T}}, charges::Vec
 end
 
 
+"""
+    run_geant4_simulation( app::Geant4.G4JLApplication, number_of_events::Int)
+
+Simulates the given `Geant4.G4JLApplication` until `number_of_events` events with non-zero energy depositions have been generated.
+
+## Arguments
+* `app::Geant4.G4JLApplication`: Contains information about the detector setup and the particle source.
+* `number_of_events::Int`: The amount of events inside of the detector that should be recorded.
+
+## Examples
+```julia 
+run_geant4_simulation(app, 1000)
+# => returns all events in a `TypedTables.Table` with the fields `evtno`, `detno`, `thit, `edep` and `pos`
+```
+!!! note 
+    Since the function is running until enough events have been collected, setups in which an event
+        is impossible (e.g. due to incorrect source placement or orientation), will run indefinitely. 
+"""
 function run_geant4_simulation end

--- a/src/SolidStateDetectors.jl
+++ b/src/SolidStateDetectors.jl
@@ -71,6 +71,7 @@ export ElectricFieldChargeDriftModel, ADLChargeDriftModel
 export get_active_volume, is_depleted, estimate_depletion_voltage
 export calculate_stored_energy, calculate_mutual_capacitance, calculate_capacitance_matrix
 export simulate_waveforms
+export run_geant4_simulation
 export Simulation, simulate!
 export Event, drift_charges!
 export add_baseline_and_extend_tail


### PR DESCRIPTION
Added the function `run_geant4_simulation`, which allows the user to perform Geant4 simulations based on a given `G4JLApplication` and the amount of events that should be generated (`number_of_events`).

### Example: Generating 1000 interaction events from an electron source
In the following example, an electron emitting source is placed next to some detector (defined by the file `"detector_configuration.yaml"`). 
```julia
using SolidStateDetectors
using Geant4
using Unitful
sim = Simulation("detector_configuration.yaml")
source = MonoenergeticSource("e-", 1000u"keV", CartesianPoint(0.1, 0, 0), CartesianVector(-1, 0, 0))
application = G4JLApplication(sim, source)
events = run_geant4_simulation(application, 1000)
```
The returned value from the function has the type `TypedTables.Table` and contains all the events as a `DetectorHit` object (see [RadiationDetectorSignals.jl](https://github.com/JuliaPhysics/RadiationDetectorSignals.jl/blob/c837ec29d67de08d7b0491550886ef3eb726d854/src/detector_hits.jl#L16) for reference). 