### PR TITLE
Change default EM physics list to `G4EmStandardPhysics_option4`

### DIFF
--- a/ext/Geant4/g4jl_application.jl
+++ b/ext/Geant4/g4jl_application.jl
@@ -1,9 +1,9 @@
 struct SSDPhysics <: G4VUserPhysicsList
     function SSDPhysics(verbose)
         pl = G4VModularPhysicsList()
-        RegisterPhysics(pl, move!(G4DecayPhysics(verbose)))             # Default physics
-        RegisterPhysics(pl, move!(G4EmStandardPhysics(verbose)))        # EM physics
-        RegisterPhysics(pl, move!(G4RadioactiveDecayPhysics(verbose)))  # Radioactive decay
+        RegisterPhysics(pl, move!(G4DecayPhysics(verbose)))              # Default physics
+        RegisterPhysics(pl, move!(G4EmStandardPhysics_option4(verbose))) # EM physics
+        RegisterPhysics(pl, move!(G4RadioactiveDecayPhysics(verbose)))   # Radioactive decay
         return pl
     end
 end


### PR DESCRIPTION
In response to #397:
So far, not too many wrappers for physics lists are implemented in Geant4.jl,
so before supporting the custom choice of physics lists, let us stick to using `G4EmStandardPhysics_option4` as the default EM physics list.