### PR TITLE
Exclude surface points when determining the depletion voltage

### DIFF
--- a/src/ScalarPotentials/PointTypes.jl
+++ b/src/ScalarPotentials/PointTypes.jl
@@ -103,7 +103,7 @@ is_depleted(sim.point_types)
 ```
 """
 is_depleted(point_types::PointTypes)::Bool = 
-    !any(b -> undepleted_bit & b > 0, point_types.data)
+    !any(b -> bulk_bit > 0 && undepleted_bit & b > 0, point_types.data)
 
 
 """


### PR DESCRIPTION
In some calculations, some surface points of detectors are unphysically marked as undepleted, resulting in unrealistically high depletion voltages. They should be excluded when checking for depletion.