### PR TITLE
Replace `RealQuantity` with `Unitful.RealOrRealQuantity`

### DIFF
--- a/src/Event/Event.jl
+++ b/src/Event/Event.jl
@@ -56,12 +56,12 @@ end
 
 function Event(locations::Vector{<:AbstractCoordinatePoint{T}}, energies::Vector{<:RealQuantity}, N::Int; 
                particle_type::Type{PT} = Gamma, number_of_shells::Int = 2,
-               radius::Vector{<:RealQuantity{T}} = radius_guess.(T.(to_internal_units.(energies)), particle_type)
+               radius::Vector{<:RealQuantity} = radius_guess.(T.(to_internal_units.(energies)), particle_type)
               )::Event{T} where {T <: SSDFloat, PT <: ParticleType}
     
     return Event(broadcast(i -> 
                 NBodyChargeCloud(locations[i], energies[i], N, particle_type, 
-                radius = radius[i], number_of_shells = number_of_shells),
+                radius = T(to_internal_units(radius[i])), number_of_shells = number_of_shells),
            eachindex(locations)))
 end
 

--- a/src/PlotRecipes/Potentials.jl
+++ b/src/PlotRecipes/Potentials.jl
@@ -60,7 +60,7 @@ end
 
 @recipe function f(sp::ScalarPotential{T,3,Cylindrical}; r = missing, φ = missing, z = missing, contours_equal_potential = false, full_det = false) where {T <: SSDFloat}
 
-    gradient::Symbol, clims::Tuple{MaybeWithUnits{T},MaybeWithUnits{T}}, name::String, punit::Unitful.Units = _get_potential_plot_information(sp)
+    gradient::Symbol, clims::Tuple{RealQuantity, RealQuantity}, name::String, punit::Unitful.Units = _get_potential_plot_information(sp)
 
     if !(sp.grid[2][end] - sp.grid[2][1] ≈ 2π) sp = get_2π_potential(sp, n_points_in_φ = 72) end
 

--- a/src/SolidStateDetectors.jl
+++ b/src/SolidStateDetectors.jl
@@ -75,6 +75,7 @@ export Event, drift_charges!
 export add_baseline_and_extend_tail
 export NBodyChargeCloud
 
+using Unitful: RealOrRealQuantity as RealQuantity
 const SSDFloat = Union{Float16, Float32, Float64}
 
 include("examples.jl")

--- a/src/Units.jl
+++ b/src/Units.jl
@@ -93,12 +93,6 @@ function construct_units(config_file_dict::AbstractDict)::UnitTuple
     return UnitTuple(dunits)
 end
 
-
-
-const MaybeWithUnits{T} = Union{T, Quantity{<:T}}
-const RealQuantity = MaybeWithUnits{<:Real}
-
-
 DetectorHitEvents = TypedTables.Table{
     <:NamedTuple{
         (:evtno, :detno, :thit, :edep, :pos),


### PR DESCRIPTION
Closes #404 .

Side note: `SolidStateDetectors.RealQuantity` still works, so this is not a breaking change (except for getting rid of `MaybeWithUnits{T}` which we were not really using).
