### PR TITLE
Reintroduce `Requires` dependency for `LegendHDF5IO`

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -21,6 +21,9 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
+      - name: Add LegendJuliaRegistry
+        run: julia -e 'using Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url = "https://github.com/JuliaRegistries/General")); Pkg.Registry.add(Pkg.RegistrySpec(url = "https://github.com/legend-exp/LegendJuliaRegistry"))'
+        shell: bash
       - uses: julia-actions/julia-downgrade-compat@v1
 #        if: ${{ matrix.version == '1.6' }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
+      - name: Add LegendJuliaRegistry
+        run: julia -e 'using Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url = "https://github.com/JuliaRegistries/General")); Pkg.Registry.add(Pkg.RegistrySpec(url = "https://github.com/legend-exp/LegendJuliaRegistry"))'
+        shell: bash
       - uses: julia-actions/julia-buildpkg@v1
         env:
           PYTHON: 'Conda'

--- a/Project.toml
+++ b/Project.toml
@@ -58,7 +58,7 @@ Interpolations = "0.14, 0.15"
 IntervalSets = "0.5, 0.6, 0.7"
 JSON = "0.21.2"
 KernelAbstractions = "0.8, 0.9"
-LaTeXStrings = "1"
+LaTeXStrings = "1.1"
 LightXML = "0.9"
 LinearAlgebra = "<0.0.1, 1"
 ParallelProcessingTools = "0.4"
@@ -80,13 +80,3 @@ Unitful = "1.11, 1.12, 1.13, 1.14, 1.15, 1.16, 1.17, 1.18, 1.19"
 UnitfulAtomic = "1"
 YAML = "0.3, 0.4"
 julia = "1.10"
-
-[extras]
-Geant4 = "559df036-b7a0-42fd-85df-7d5dd9d70f44"
-SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
-Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
-
-[targets]
-test = ["Test", "Unitful", "SpecialFunctions", "TimerOutputs", "Geant4"]

--- a/Project.toml
+++ b/Project.toml
@@ -26,6 +26,7 @@ ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 RadiationDetectorSignals = "bf2c0563-65cf-5db2-a620-ceb7de82658c"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
@@ -39,11 +40,9 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [weakdeps]
 Geant4 = "559df036-b7a0-42fd-85df-7d5dd9d70f44"
-LegendHDF5IO = "c9265ca6-b027-5446-b1a4-febfa8dd10b0"
 
 [extensions]
 SolidStateDetectorsGeant4Ext = "Geant4"
-SolidStateDetectorsLegendHDF5IOExt = "LegendHDF5IO"
 
 [compat]
 Adapt = "3, 4"
@@ -60,7 +59,6 @@ IntervalSets = "0.5, 0.6, 0.7"
 JSON = "0.21.2"
 KernelAbstractions = "0.8, 0.9"
 LaTeXStrings = "1"
-LegendHDF5IO = "0.1"
 LightXML = "0.9"
 LinearAlgebra = "<0.0.1, 1"
 ParallelProcessingTools = "0.4"
@@ -85,7 +83,6 @@ julia = "1.10"
 
 [extras]
 Geant4 = "559df036-b7a0-42fd-85df-7d5dd9d70f44"
-LegendHDF5IO = "c9265ca6-b027-5446-b1a4-febfa8dd10b0"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"

--- a/ext/SolidStateDetectorsLegendHDF5IOExt.jl
+++ b/ext/SolidStateDetectorsLegendHDF5IOExt.jl
@@ -2,7 +2,7 @@
 
 module SolidStateDetectorsLegendHDF5IOExt
 
-import LegendHDF5IO
+import ..LegendHDF5IO
 
 using SolidStateDetectors
 using SolidStateDetectors: RealQuantity, SSDFloat

--- a/src/IO/IO.jl
+++ b/src/IO/IO.jl
@@ -19,7 +19,6 @@ with a given `filename` using [LegendHDF5IO.jl](https://github.com/legend-exp/Le
 
 ## Example 
 ```julia
-using HDF5 
 using LegendHDF5IO
 using SolidStateDetectors
 sim = Simulation(SSD_examples[:InvertedCoax])
@@ -31,9 +30,8 @@ ssd_write("example_sim.h5", sim)
     If a file with `filename` already exists, it will be overwritten by this method.
 
 !!! note 
-    In order to use this method, the packages [HDF5.jl](https://github.com/JuliaIO/HDF5.jl) and 
-    [LegendHDF5IO.jl](https://github.com/legend-exp/LegendHDF5IO.jl) have to be
-    loaded before loading SolidStateDetectors.jl.
+    In order to use this method, the package [LegendHDF5IO.jl](https://github.com/legend-exp/LegendHDF5IO.jl) 
+    has to be loaded before loading SolidStateDetectors.jl.
 
 See also [`ssd_read`](@ref).
 """
@@ -52,16 +50,14 @@ using [LegendHDF5IO.jl](https://github.com/legend-exp/LegendHDF5IO.jl).
 
 ## Example 
 ```julia
-using HDF5 
 using LegendHDF5IO
 using SolidStateDetectors
 sim = ssd_read("example_sim.h5", Simulation)
 ```
 
 !!! note 
-    In order to use this method, the packages [HDF5.jl](https://github.com/JuliaIO/HDF5.jl) and 
-    [LegendHDF5IO.jl](https://github.com/legend-exp/LegendHDF5IO.jl) have to be
-    loaded before loading SolidStateDetectors.jl.
+    In order to use this method, the package [LegendHDF5IO.jl](https://github.com/legend-exp/LegendHDF5IO.jl) 
+    has to be loaded before loading SolidStateDetectors.jl.
 
 See also [`ssd_write`](@ref).
 """

--- a/src/SolidStateDetectors.jl
+++ b/src/SolidStateDetectors.jl
@@ -23,6 +23,7 @@ using ParallelProcessingTools
 using ProgressMeter
 using RadiationDetectorSignals
 using RecipesBase
+using Requires
 using Rotations
 using StaticArrays
 using StatsBase
@@ -113,5 +114,12 @@ include("IO/IO.jl")
 
 include("PlotRecipes/PlotRecipes.jl")
 export @P_str # protected strings to overwrite plot labels with units
+
+
+function __init__()
+    @require LegendHDF5IO ="c9265ca6-b027-5446-b1a4-febfa8dd10b0" begin
+        include("../ext/SolidStateDetectorsLegendHDF5IOExt.jl")
+    end
+end
 
 end # module

--- a/test/IO.jl
+++ b/test/IO.jl
@@ -1,0 +1,27 @@
+using LegendHDF5IO
+
+sim = Simulation(SSD_examples[:InvertedCoax])
+
+@testset "Conversion Simulation <--> NamedTuple" begin
+    timed_calculate_electric_potential!(sim, verbose = false)
+    nt = NamedTuple(sim)
+    @test sim == Simulation(nt)
+
+    timed_calculate_electric_field!(sim)
+    nt = NamedTuple(sim)
+    @test sim == Simulation(nt)
+
+    timed_calculate_weighting_potential!(sim, 1, verbose = false)
+    nt = NamedTuple(sim)
+    @test sim == Simulation(nt)
+
+    for i in findall(ismissing.(sim.weighting_potentials)) timed_calculate_weighting_potential!(sim, i, verbose = false) end
+    nt = NamedTuple(sim)
+    @test sim == Simulation(nt)
+end
+
+@testset "Test LegendHDF5IO" begin
+    @test_nowarn ssd_write("legendhdf5io_test.lh5", sim)
+    @test_logs (:warn, "Destination `legendhdf5io_test.lh5` already exists. Overwriting...") ssd_write("legendhdf5io_test.lh5", sim)
+    @test sim == ssd_read("legendhdf5io_test.lh5", Simulation)
+end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,17 @@
+[deps]
+Geant4 = "559df036-b7a0-42fd-85df-7d5dd9d70f44"
+LegendHDF5IO = "c9265ca6-b027-5446-b1a4-febfa8dd10b0"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+RadiationDetectorSignals = "bf2c0563-65cf-5db2-a620-ceb7de82658c"
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
+TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[compat]
+LegendHDF5IO = "0.1"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -362,29 +362,11 @@ end
 end
 
 @timed_testset "IO" begin
-    sim = Simulation(SSD_examples[:InvertedCoax])
-    
-    timed_calculate_electric_potential!(sim, verbose = false, device_array_type = device_array_type)
-    nt = NamedTuple(sim)
-    @test sim == Simulation(nt)
-    
-    timed_calculate_electric_field!(sim)
-    nt = NamedTuple(sim)
-    @test sim == Simulation(nt)
-
-    timed_calculate_weighting_potential!(sim, 1, verbose = false, device_array_type = device_array_type)
-    nt = NamedTuple(sim)
-    @test sim == Simulation(nt)
-
-    for i in findall(ismissing.(sim.weighting_potentials)) timed_calculate_weighting_potential!(sim, i, verbose = false, device_array_type = device_array_type) end
-    nt = NamedTuple(sim)
-    @test sim == Simulation(nt)
+    include("IO.jl")
 end 
 
-if Sys.WORD_SIZE == 64
 @timed_testset "Geant4 extension" begin
-    include("Geant4.jl")
-end
+    if Sys.WORD_SIZE == 64 include("Geant4.jl") end
 end
 
 display(testtimer())


### PR DESCRIPTION
As `LegendHDF5IO` is not registered in General or stdlib, we cannot release v0.10.0 with `LegendHDF5IO` in the `[weakdeps]`. A quick workaround is to reintroduce `Requires` to deal with this.

Long term plans could then be:
- register `LegendHDF5IO` or a part of it
- move the extension to `LegendHDF5IO`
- simply keeping the `Requires` dependency