### PR TITLE
Implement charge trapping models

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -3,11 +3,13 @@ on:
   pull_request:
     branches:
       - main
+      - dev
     paths-ignore:
       - 'docs/**'
   push:
     branches:
       - main
+      - dev
     paths-ignore:
       - 'docs/**'
 jobs:
@@ -22,10 +24,9 @@ jobs:
         with:
           version: ${{ matrix.version }}
       - name: Add LegendJuliaRegistry
-        run: julia -e 'using Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url = "https://github.com/JuliaRegistries/General")); Pkg.Registry.add(Pkg.RegistrySpec(url = "https://github.com/legend-exp/LegendJuliaRegistry"))'
+        run: julia -e 'using Pkg; Pkg.Registry.add("General"); Pkg.Registry.add(Pkg.RegistrySpec(url = "https://github.com/legend-exp/LegendJuliaRegistry"))'
         shell: bash
       - uses: julia-actions/julia-downgrade-compat@v1
-#        if: ${{ matrix.version == '1.6' }}
         with:
           skip: Pkg,TOML
       - uses: julia-actions/julia-buildpkg@v1

--- a/examples/example_config_files/public_ivc_trapping_config.yaml
+++ b/examples/example_config_files/public_ivc_trapping_config.yaml
@@ -1,0 +1,159 @@
+name: Public Inverted Coax
+units:
+  length: mm
+  angle: deg
+  potential: V
+  temperature: K
+grid:
+  coordinates: cylindrical
+  axes:
+    r:
+      to: 40
+      boundaries: inf
+    phi:
+      from: 0
+      to: 0
+      boundaries: periodic
+    z:
+      from: -10
+      to: 90
+      boundaries:
+        left: inf
+        right: inf
+# grid:
+#   coordinates: cartesian
+#   axes:
+#     x:
+#       from: -40
+#       to: 40
+#       boundaries:
+#         left: inf
+#         right: inf
+#     y:
+#       from: -40
+#       to: 40
+#       boundaries:
+#         left: inf
+#         right: inf
+#     z:
+#       from: -10
+#       to: 90
+#       boundaries:
+#         left: inf
+#         right: inf
+medium: vacuum
+detectors:
+  - semiconductor:
+      material: HPGe
+      temperature: 78
+      impurity_density:
+        name: cylindrical
+        r:
+          init: 0
+          gradient: 0
+        z:
+          init: -1e7
+          gradient: -1e5
+      charge_drift_model:
+        include: ADLChargeDriftModel/drift_velocity_config.yaml
+      charge_trapping_model:
+        model: Boggs
+        parameters:
+          nσe-1: 1020cm
+          nσh-1: 2040cm
+      geometry:
+        difference:
+          - tube:
+              r: 35
+              h: 80
+              origin:
+                z: 40
+          - cone:
+              r:
+                bottom:
+                  from: 35
+                  to: 36
+                top:
+                  from: 23.71
+                  to: 36
+              h: 64
+              origin:
+                z: 52
+          - tube:
+              r: 5
+              h: 80
+              origin:
+                z: 65
+    contacts:
+      - material: HPGe
+        id: 1
+        potential: 0
+        geometry:
+          tube:
+            r: 3
+            h: 2
+            origin:
+              z: 1
+      - material: HPGe
+        id: 2
+        potential: 3500
+        geometry:
+          union:
+            - tube:
+                r:
+                  from: 15
+                  to: 35
+                h: 0
+            - tube:
+                r:
+                  from: 35
+                  to: 35
+                h: 20
+                origin:
+                  z: 10
+            - cone:
+                r:
+                  bottom:
+                    from: 35
+                    to: 35
+                  top:
+                    from: 24.42
+                    to: 24.42
+                h: 60
+                origin:
+                  z: 50
+            - tube:
+                r:
+                  from: 5
+                  to: 24.42
+                h: 0
+                origin:
+                  z: 80
+            - tube:
+                r:
+                    from: 5
+                    to: 5
+                h: 55
+                origin:
+                  z: 52.5
+            - tube:
+                r: 5
+                h: 0
+                origin:
+                  z: 25
+surroundings:
+  - material: HPGe
+    name: Passivation Layer
+    geometry:
+      tube:
+        r: 
+          from: 4
+          to: 14
+        h: 0.1
+        origin:
+          - 0
+          - 0
+          - -0.05
+    charge_density:
+      name: constant
+      value: 0 # Reasonable density: +2e-11 # => 2*10⁻¹1 C/m⁻³

--- a/src/ChargeTrapping/ChargeTrapping.jl
+++ b/src/ChargeTrapping/ChargeTrapping.jl
@@ -92,7 +92,7 @@ end
 
 
 BoggsChargeTrappingModel(args...; T::Type{<:SSDFloat}, kwargs...) = BoggsChargeTrappingModel{T}(args...; kwargs...)
-function BoggsChargeTrappingModel{T}(config_dict::AbstractDict; temperature::RealQuantity = T(78)) where {T <: SSDFloat}
+function BoggsChargeTrappingModel{T}(config_dict::AbstractDict = Dict(); temperature::RealQuantity = T(78)) where {T <: SSDFloat}
     nσe::T = ustrip(u"m^-1", inv(1020u"cm"))
     nσh::T = ustrip(u"m^-1", inv(2040u"cm"))
     meffe::T = 0.12

--- a/src/ChargeTrapping/ChargeTrapping.jl
+++ b/src/ChargeTrapping/ChargeTrapping.jl
@@ -45,13 +45,14 @@ NoChargeTrappingModel{T}(config_dict::AbstractDict; kwargs...) where {T <: SSDFl
 """
     struct BoggsChargeTrappingModel{T <: SSDFloat} <: AbstractChargeTrappingModel{T}
         
-Charge trapping model presented in [Steve Boggs (2023)](https://doi.org/10.1016/j.nima.2023.168756).
+Charge trapping model presented in [Boggs _et al._ (2023)](https://doi.org/10.1016/j.nima.2023.168756).
 
 ## Fields
-* `nσe::T`: Trapping product for electrons.
-* `nσh::T`: Trapping product for holes.
-* `temperature::T`: Temperature of the crystal.
+* `nσe::T`: Trapping product for electrons (default: `(nσe)^-1 = 1020cm`).
+* `nσh::T`: Trapping product for holes (default: `(nσh)^-1 = 2040cm`).
+* `temperature::T`: Temperature of the crystal (default: `78K`).
 
+See also [Charge Trapping Models](@ref).
 """
 struct BoggsChargeTrappingModel{T <: SSDFloat} <: AbstractChargeTrappingModel{T} 
     nσe::T  # in m^-1

--- a/src/ChargeTrapping/ChargeTrapping.jl
+++ b/src/ChargeTrapping/ChargeTrapping.jl
@@ -1,0 +1,88 @@
+abstract type AbstractChargeTrappingModel{T <: SSDFloat} end
+
+function _calculate_signal( 
+        ::AbstractChargeTrappingModel{T},
+        path::AbstractVector{CartesianPoint{T}}, 
+        pathtimestamps::AbstractVector{T}, 
+        charge::T,          
+        wpot::Interpolations.Extrapolation{T, 3}, 
+        S::CoordinateSystemType
+    ) where {T <: SSDFloat}
+    throw("For the chosen charge trapping model, no method for `_calculate_signal` is implemented.")
+end
+
+
+"""
+    struct NoChargeTrappingModel{T <: SSDFloat} <: AbstractChargeTrappingModel{T}
+        
+Charge trapping model, in which no charges are trapped during the charge drift.
+
+This model is the default when no charge trapping model is defined in the configuration file.
+"""
+struct NoChargeTrappingModel{T <: SSDFloat} <: AbstractChargeTrappingModel{T} end
+
+function _calculate_signal( 
+        ::NoChargeTrappingModel{T}, 
+        path::AbstractVector{CartesianPoint{T}}, 
+        pathtimestamps::AbstractVector{T}, 
+        charge::T,          
+        wpot::Interpolations.Extrapolation{T, 3}, 
+        S::CoordinateSystemType
+    )::Vector{T} where {T <: SSDFloat}
+
+    tmp_signal::Vector{T} = Vector{T}(undef, length(pathtimestamps))
+    @inbounds for i in eachindex(tmp_signal)
+        tmp_signal[i] = get_interpolation(wpot, path[i], S)::T * charge
+    end
+
+    tmp_signal
+end
+
+
+"""
+    struct BoggsChargeTrappingModel{T <: SSDFloat} <: AbstractChargeTrappingModel{T}
+        
+Charge trapping model presented in [Steve Boggs (2023)](https://doi.org/10.1016/j.nima.2023.168756).
+
+## Fields
+* `nσe::T`: Trapping product for electrons.
+* `nσh::T`: Trapping product for holes.
+* `Temp::T`: Temperature of the crystal.
+
+"""
+Parameters.@with_kw struct BoggsChargeTrappingModel{T <: SSDFloat} <: AbstractChargeTrappingModel{T} 
+    nσe::T = ustrip(u"m^-1", inv(1020u"cm"))
+    nσh::T = ustrip(u"m^-1", inv(2040u"cm"))
+    Temp::T = T(80)
+end
+
+function _calculate_signal( 
+        ctm::BoggsChargeTrappingModel{T}, 
+        path::AbstractVector{CartesianPoint{T}}, 
+        pathtimestamps::AbstractVector{T}, 
+        charge::T,          
+        wpot::Interpolations.Extrapolation{T, 3}, 
+        S::CoordinateSystemType
+    )::Vector{T} where {T <: SSDFloat}
+
+    vth::T = sqrt(3 * kB * ctm.Temp / (ifelse(charge > 0, 0.21, 0.12) * me)) # in m/s
+    nσ::T = ifelse(charge > 0, ctm.nσh, ctm.nσe)
+    tmp_signal::Vector{T} = Vector{T}(undef, length(pathtimestamps))
+
+    running_sum::T = zero(T)
+    q::T = charge
+    @inbounds for i in eachindex(tmp_signal)
+        Δldrift::T = (i > 1) ? norm(path[i] .- path[i-1]) : zero(T)
+        Δl::T = Δldrift > 0 ? hypot(Δldrift, vth * (pathtimestamps[i] - pathtimestamps[i-1])) : zero(T)
+        Δq::T = q * nσ * Δl
+        q -= Δq
+        w::T = i > 1 ? get_interpolation(wpot, path[i], S) : zero(T)
+        running_sum += w * Δq
+        tmp_signal[i] = running_sum + w * q
+    end
+
+    tmp_signal
+end
+
+
+

--- a/src/Event/Event.jl
+++ b/src/Event/Event.jl
@@ -314,16 +314,17 @@ function get_electron_and_hole_contribution(evt::Event{T}, sim::Simulation{T, S}
     signal_e::Vector{T} = zeros(T, length(maximum(map(p -> p.timestamps_e, evt.drift_paths))))
     signal_h::Vector{T} = zeros(T, length(maximum(map(p -> p.timestamps_h, evt.drift_paths))))
 
+    ctm = sim.detector.semiconductor.charge_trapping_model
     for i in eachindex(evt.drift_paths)
         energy = flatview(evt.energies)[i]
         
         dp_e::Vector{CartesianPoint{T}} = evt.drift_paths[i].e_path
         dp_e_t::Vector{T} = evt.drift_paths[i].timestamps_e
-        add_signal!(signal_e, dp_e_t, dp_e, dp_e_t, T(-1)*energy, wp, S)
+        add_signal!(signal_e, dp_e_t, dp_e, dp_e_t, -energy, wp, S, ctm)
         
         dp_h::Vector{CartesianPoint{T}} = evt.drift_paths[i].h_path
         dp_h_t::Vector{T} = evt.drift_paths[i].timestamps_h
-        add_signal!(signal_h, dp_h_t, dp_h, dp_h_t, energy, wp, S)
+        add_signal!(signal_h, dp_h_t, dp_h, dp_h_t, energy, wp, S, ctm)
     end
     unitless_energy_to_charge = _convert_internal_energy_to_external_charge(sim.detector.semiconductor.material)
     return (electron_contribution = RDWaveform(range(zero(T) * u"ns", step = dt * u"ns", length = length(signal_e)), signal_e * unitless_energy_to_charge),

--- a/src/MaterialProperties/MaterialProperties.jl
+++ b/src/MaterialProperties/MaterialProperties.jl
@@ -1,8 +1,10 @@
 # This file is a part of SolidStateDetectors.jl, licensed under the MIT License (MIT).
 
-
-const elementary_charge = Float64(1.602176487e-19)
-const ϵ0  = Float64(8.8541878176e-12)
+# Maybe not strip the units at some point?
+const elementary_charge = Float64(ustrip(u"C", Unitful.q))
+const ϵ0 = Float64(ustrip(u"F/m", Unitful.ϵ0))
+const kB = Float64(ustrip(u"J/K", Unitful.k))
+const me = Float64(ustrip(u"kg", Unitful.me))
 
 const material_properties = Dict{Symbol, NamedTuple}()
 

--- a/src/SignalGeneration/SignalGeneration.jl
+++ b/src/SignalGeneration/SignalGeneration.jl
@@ -21,10 +21,11 @@ function add_signal!(
         pathtimestamps::AbstractVector{T}, 
         charge::T,          
         wpot::Interpolations.Extrapolation{T, 3}, 
-        S::CoordinateSystemType
+        S::CoordinateSystemType,
+        ctm::AbstractChargeTrappingModel{T} = NoChargeTrappingModel{T}()
     )::Nothing where {T <: SSDFloat}
 
-    tmp_signal::Vector{T} = _calculate_signal(NoChargeTrappingModel{T}(), path, pathtimestamps, charge, wpot, S)
+    tmp_signal::Vector{T} = _calculate_signal(ctm, path, pathtimestamps, charge, wpot, S)
     itp = interpolate!( (pathtimestamps,), tmp_signal, Gridded(Linear()))
     t_max::T = last(pathtimestamps)
     i_max::Int = searchsortedlast(timestamps, t_max)
@@ -36,15 +37,17 @@ function add_signal!(
 end
 
 
-function add_signal!(signal::AbstractVector{T}, timestamps::AbstractVector{T}, path::EHDriftPath{T}, charge::T, wpot::Interpolations.Extrapolation{T, 3}, S::CoordinateSystemType)::Nothing where {T <: SSDFloat}
-    add_signal!(signal, timestamps, path.e_path, path.timestamps_e, -charge, wpot, S) # electrons induce negative charge
-    add_signal!(signal, timestamps, path.h_path, path.timestamps_h,  charge, wpot, S)
+function add_signal!(signal::AbstractVector{T}, timestamps::AbstractVector{T}, path::EHDriftPath{T}, charge::T, 
+        wpot::Interpolations.Extrapolation{T, 3}, S::CoordinateSystemType, ctm::AbstractChargeTrappingModel{T} = NoChargeTrappingModel{T}())::Nothing where {T <: SSDFloat}
+    add_signal!(signal, timestamps, path.e_path, path.timestamps_e, -charge, wpot, S, ctm) # electrons induce negative charge
+    add_signal!(signal, timestamps, path.h_path, path.timestamps_h,  charge, wpot, S, ctm)
     nothing
 end
 
-function add_signal!(signal::AbstractVector{T}, timestamps::AbstractVector{<:RealQuantity}, paths::Vector{<:EHDriftPath{T}}, charges::Vector{T}, wpot::Interpolations.Extrapolation{T, 3}, S::CoordinateSystemType)::Nothing where {T <: SSDFloat}
+function add_signal!(signal::AbstractVector{T}, timestamps::AbstractVector{<:RealQuantity}, paths::Vector{<:EHDriftPath{T}}, charges::Vector{T}, 
+        wpot::Interpolations.Extrapolation{T, 3}, S::CoordinateSystemType, ctm::AbstractChargeTrappingModel{T} = NoChargeTrappingModel{T}())::Nothing where {T <: SSDFloat}
     for ipath in eachindex(paths)
-        add_signal!(signal, timestamps, paths[ipath], charges[ipath], wpot, S)
+        add_signal!(signal, timestamps, paths[ipath], charges[ipath], wpot, S, ctm)
     end
     nothing
 end

--- a/src/SignalGeneration/SignalGeneration.jl
+++ b/src/SignalGeneration/SignalGeneration.jl
@@ -14,12 +14,17 @@ end
 end
 
 
-function add_signal!(signal::AbstractVector{T}, timestamps::AbstractVector{T}, path::Vector{CartesianPoint{T}}, pathtimestamps::AbstractVector{T}, charge::T, 
-                        wpot::Interpolations.Extrapolation{T, 3}, S::CoordinateSystemType)::Nothing where {T <: SSDFloat}
-    tmp_signal = Vector{T}(undef, length(pathtimestamps))
-    @inbounds for i in eachindex(tmp_signal)
-        tmp_signal[i] = get_interpolation(wpot, path[i], S)::T * charge
-    end
+function add_signal!(
+        signal::AbstractVector{T}, 
+        timestamps::AbstractVector{T}, 
+        path::AbstractVector{CartesianPoint{T}}, 
+        pathtimestamps::AbstractVector{T}, 
+        charge::T,          
+        wpot::Interpolations.Extrapolation{T, 3}, 
+        S::CoordinateSystemType
+    )::Nothing where {T <: SSDFloat}
+
+    tmp_signal::Vector{T} = _calculate_signal(NoChargeTrappingModel{T}(), path, pathtimestamps, charge, wpot, S)
     itp = interpolate!( (pathtimestamps,), tmp_signal, Gridded(Linear()))
     t_max::T = last(pathtimestamps)
     i_max::Int = searchsortedlast(timestamps, t_max)

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -1210,8 +1210,8 @@ function get_signal(sim::Simulation{T, CS}, drift_paths::Vector{EHDriftPath{T}},
     wpot::Interpolations.Extrapolation{T, 3} = interpolated_scalarfield(sim.weighting_potentials[contact_id])
     timestamps = _common_timestamps( drift_paths, dt )
     signal::Vector{T} = zeros(T, length(timestamps))
-    add_signal!(signal, timestamps, drift_paths, energy_depositions, wpot, CS)
-    unitless_energy_to_charge = unitless_energy_to_charge = _convert_internal_energy_to_external_charge(sim.detector.semiconductor.material)
+    add_signal!(signal, timestamps, drift_paths, energy_depositions, wpot, CS, sim.detector.semiconductor.charge_trapping_model)
+    unitless_energy_to_charge = _convert_internal_energy_to_external_charge(sim.detector.semiconductor.material)
     return RDWaveform( range(zero(T) * unit(Δt), step = T(ustrip(Δt)) * unit(Δt), length = length(signal)), signal * unitless_energy_to_charge)
 end
 

--- a/src/SolidStateDetector/SolidStateDetector.jl
+++ b/src/SolidStateDetector/SolidStateDetector.jl
@@ -35,19 +35,25 @@ struct SolidStateDetector{T,SC,CT,PT,VDM} <: AbstractConfig{T}
     SolidStateDetector{T}(n::AbstractString,s::SC,c::C,p::P,v::VDM) where {T,SC,C,P,VDM}= new{T,SC,C,P,VDM}(n,s,c,p,v)
 end
 
-function SolidStateDetector(det::SolidStateDetector{T,SC,CT,PT,VDM}, impurity_density::AbstractImpurityDensity{T}) where {T,SC,CT,PT,VDM}
+function SolidStateDetector(det::SolidStateDetector{T}, impurity_density::AbstractImpurityDensity{T}) where {T <: SSDFloat}
     sc = Semiconductor(det.semiconductor, impurity_density)
     SolidStateDetector{T}(
         det.name, sc, det.contacts, det.passives, det.virtual_drift_volumes    
     )
 end
-function SolidStateDetector(det::SolidStateDetector{T,SC,CT,PT,VDM}, chargedriftmodel::AbstractChargeDriftModel{T}) where {T,SC,CT,PT,VDM}
-    sc = Semiconductor(det.semiconductor, chargedriftmodel)
+function SolidStateDetector(det::SolidStateDetector{T}, charge_drift_model::AbstractChargeDriftModel{T}) where {T <: SSDFloat}
+    sc = Semiconductor(det.semiconductor, charge_drift_model)
     SolidStateDetector{T}(
         det.name, sc, det.contacts, det.passives, det.virtual_drift_volumes    
     )
 end
-function SolidStateDetector(det::SolidStateDetector{T,SC,CT,PT,VDM}; contact_id::Int, contact_potential::Real) where {T,SC,CT,PT,VDM}
+function SolidStateDetector(det::SolidStateDetector{T}, charge_trapping_model::AbstractChargeTrappingModel{T}) where {T <: SSDFloat}
+    sc = Semiconductor(det.semiconductor, charge_trapping_model)
+    SolidStateDetector{T}(
+        det.name, sc, det.contacts, det.passives, det.virtual_drift_volumes    
+    )
+end
+function SolidStateDetector(det::SolidStateDetector{T}; contact_id::Int, contact_potential::Real) where {T <: SSDFloat}
     oc = det.contacts[contact_id]
     nc = Contact(T(contact_potential), oc.material, oc.id, oc.name, oc.geometry )
     contacts = [c.id == contact_id ? nc : c for c in det.contacts]

--- a/src/SolidStateDetectors.jl
+++ b/src/SolidStateDetectors.jl
@@ -52,7 +52,6 @@ import Clustering
 import Distributions
 import IntervalSets
 import OrderedCollections
-import Parameters
 import Tables
 import TypedTables
 

--- a/src/SolidStateDetectors.jl
+++ b/src/SolidStateDetectors.jl
@@ -69,6 +69,7 @@ export ElectricPotential, PointTypes, EffectiveChargeDensity, DielectricDistribu
 export apply_initial_state!
 export calculate_electric_potential!, calculate_weighting_potential!, calculate_electric_field!, calculate_drift_fields!
 export ElectricFieldChargeDriftModel, ADLChargeDriftModel
+export NoChargeTrappingModel, BoggsChargeTrappingModel
 export get_active_volume, is_depleted, estimate_depletion_voltage
 export calculate_stored_energy, calculate_mutual_capacitance, calculate_capacitance_matrix
 export simulate_waveforms

--- a/src/SolidStateDetectors.jl
+++ b/src/SolidStateDetectors.jl
@@ -52,6 +52,7 @@ import Clustering
 import Distributions
 import IntervalSets
 import OrderedCollections
+import Parameters
 import Tables
 import TypedTables
 
@@ -92,6 +93,7 @@ include("Config/Config.jl")
 include("ChargeDensities/ChargeDensities.jl")
 include("ImpurityDensities/ImpurityDensities.jl")
 include("ChargeDriftModels/ChargeDriftModels.jl")
+include("ChargeTrapping/ChargeTrapping.jl")
 include("SolidStateDetector/DetectorGeometries.jl")
 
 include("ScalarPotentials/ScalarPotential.jl")

--- a/src/Units.jl
+++ b/src/Units.jl
@@ -15,6 +15,7 @@ const internal_charge_unit  = u"C"
 const internal_mobility_unit = u"m^2/(V*s)"
 const internal_diffusion_unit = internal_length_unit ^ 2 / internal_time_unit
 const internal_charge_density_unit = internal_charge_unit / internal_length_unit ^ 3
+const internal_temperature_unit = u"K"
 
 const external_charge_unit  = u"e_au" # elementary charge - from UnitfulAtomic.jl
 
@@ -27,6 +28,7 @@ to_internal_units(x::Quantity{<:Real, dimension(internal_charge_unit)})  = ustri
 to_internal_units(x::Quantity{<:Real, dimension(internal_mobility_unit)})  = ustrip(internal_mobility_unit,  x)
 to_internal_units(x::Quantity{<:Real, dimension(internal_diffusion_unit)})  = ustrip(internal_diffusion_unit,  x)
 to_internal_units(x::Quantity{<:Real, dimension(internal_charge_density_unit)})  = ustrip(internal_charge_density_unit,  x)
+to_internal_units(x::Quantity{<:Real, dimension(internal_temperature_unit)})     = ustrip(internal_temperature_unit,  x)
 
 from_internal_units(x::Real, unit::Unitful.Units{<:Any, dimension(internal_time_unit)})    = uconvert(unit, x * internal_time_unit)
 from_internal_units(x::Real, unit::Unitful.Units{<:Any, dimension(internal_voltage_unit)}) = uconvert(unit, x * internal_voltage_unit)
@@ -35,6 +37,7 @@ from_internal_units(x::Real, unit::Unitful.Units{<:Any, dimension(internal_energ
 from_internal_units(x::Real, unit::Unitful.Units{<:Any, dimension(internal_charge_unit)})  = uconvert(unit, x * internal_charge_unit)
 from_internal_units(x::Real, unit::Unitful.Units{<:Any, dimension(internal_mobility_unit)})  = uconvert(unit, x * internal_mobility_unit)
 from_internal_units(x::Real, unit::Unitful.Units{<:Any, dimension(internal_diffusion_unit)})  = uconvert(unit, x * internal_diffusion_unit)
+from_internal_units(x::Real, unit::Unitful.Units{<:Any, dimension(internal_temperature_unit)}) = uconvert(unit, x * internal_temperature_unit)
 
 # Internal function for now: We should also fano noise here (optionally)
 _convert_internal_energy_to_external_charge(material) = inv(to_internal_units(material.E_ionisation)) * external_charge_unit

--- a/src/examples.jl
+++ b/src/examples.jl
@@ -27,6 +27,7 @@ const SSD_examples = Dict{Symbol,String}([
     :TwoSpheresCapacitor                     => joinpath(get_path_to_example_config_files(), "two_spheres_capacitor.yaml"),
     :InvertedCoax                            => joinpath(get_path_to_example_config_files(), "public_ivc_config.yaml"),
     :InvertedCoaxInCryostat                  => joinpath(get_path_to_example_config_files(), "ivc_splitted_config/public_ivc_cryostat_config.yaml"),
+    :InvertedCoaxTrapping                    => joinpath(get_path_to_example_config_files(), "public_ivc_trapping_config.yaml"),
     :Coax                                    => joinpath(get_path_to_example_config_files(), "public_Coax_config.yaml"),
     :BEGe                                    => joinpath(get_path_to_example_config_files(), "public_SegBEGe_config.yaml"),
     :CGD                                     => joinpath(get_path_to_example_config_files(), "public_CGD_config.yaml"),


### PR DESCRIPTION
In this PR, the `Semiconductor` is extended by another field (`charge_trapping_model`), which (for now) is passed to `add_signal!` to include the effects of charge trapping.

So far, there are
* `NoChargeTrappingModel`: ignore charge trapping --> same results as before.
* `BoggsChargeTrappingModel`: Charge trapping model based on [Boggs _et al._ (2023)](https://doi.org/10.1016/j.nima.2023.168756).

In the future, `ChargeTrappingModels` might also be passed to `drift_charges!`, in case they should influence the charge drift itself and not just the signal development afterwards.