### PR TITLE
Fix type piracy (`NamedTuple` and `Dict`)

### DIFF
--- a/src/Axes/DiscreteAxis.jl
+++ b/src/Axes/DiscreteAxis.jl
@@ -244,20 +244,20 @@ function searchsortednearest(ax::DiscreteAxis{T, :periodic, :periodic}, x::T)::I
 
 end
 
-function DiscreteAxis(nt::NamedTuple; unit = u"m/m")
+function DiscreteAxis(nt::NamedTuple; unit = Unitful.NoUnits)
     T = typeof(ustrip(nt.knots[1]))
-    knots::Vector{T} = convert(Vector{T}, ustrip.(uconvert.(unit, nt.knots)))
-    lep::T = ustrip(uconvert.(unit, nt.interval.left_boundary.endpoint ))
-    rep::T = ustrip(uconvert.(unit, nt.interval.right_boundary.endpoint))
+    knots::Vector{T} = convert(Vector{T}, ustrip.(unit, nt.knots))
+    lep::T = ustrip(unit, nt.interval.left_boundary.endpoint )
+    rep::T = ustrip(unit, nt.interval.right_boundary.endpoint)
     int = Interval{nt.interval.left_boundary.closedopen, nt.interval.right_boundary.closedopen}( lep, rep )
     return DiscreteAxis{T, nt.interval.left_boundary.boundaryhandling, nt.interval.right_boundary.boundaryhandling, typeof(int)}(
         int, knots
     )
 end
 
-Base.convert(T::Type{DiscreteAxis}, x::NamedTuple; unit = u"m/m") = T(x)
+Base.convert(T::Type{DiscreteAxis}, x::NamedTuple; unit = Unitful.NoUnits) = T(x, unit = unit)
 
-function NamedTuple(ax::DiscreteAxis{T, BL, BR}; unit = u"m/m") where {T, BL, BR}
+function NamedTuple(ax::DiscreteAxis{T, BL, BR}; unit = Unitful.NoUnits) where {T, BL, BR}
     int::Interval = ax.interval
     int_types::Tuple{Symbol, Symbol} = get_boundary_types(int)
     return (
@@ -277,7 +277,7 @@ function NamedTuple(ax::DiscreteAxis{T, BL, BR}; unit = u"m/m") where {T, BL, BR
     )
 end
 
-Base.convert(T::Type{NamedTuple}, x::DiscreteAxis; unit = u"m/m") = T(x)
+Base.convert(T::Type{NamedTuple}, x::DiscreteAxis; unit = Unitful.NoUnits) = T(x, unit = unit)
 
 function merge_closest_ticks!(v::AbstractVector{T}, n::Int = length(v); min_diff::T = T(1e-6)) where {T}
     n == 1 && return n

--- a/src/IO/IO.jl
+++ b/src/IO/IO.jl
@@ -1,10 +1,11 @@
 include("SigGenInterface.jl")
 include("ParseConfigFiles.jl")
 
-NamedTuple(::Missing) = (object = "missing",)
-NamedTuple(d::AbstractDict) = (dict_json_string = json(d),)
-Base.convert(T::Type{NamedTuple}, x::AbstractDict) = T(x)
-Dict(nt::NamedTuple) = JSON.parse(nt.dict_json_string)
+_namedtuple(x) = NamedTuple(x)
+_namedtuple(::Missing) = (object = "missing",)
+_namedtuple(d::AbstractDict) = (dict_json_string = json(d),)
+# Base.convert(::Type{NamedTuple}, x::AbstractDict) = _namedtuple(x)
+_dict(nt::NamedTuple) = JSON.parse(nt.dict_json_string)
 
 
 """

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -64,26 +64,26 @@ get_coordinate_system(::Simulation{T, CS}) where {T, CS} = CS
 function NamedTuple(sim::Simulation{T}) where {T <: SSDFloat}
     wpots_strings = ["WeightingPotential_$(contact.id)" for contact in sim.detector.contacts]
     nt = (
-        detector_json_string = NamedTuple(sim.config_dict),
-        electric_potential = NamedTuple(sim.electric_potential),
-        q_eff_imp = NamedTuple(sim.q_eff_imp),
-        imp_scale = NamedTuple(sim.imp_scale),
-        q_eff_fix = NamedTuple(sim.q_eff_fix),
-        ϵ_r = NamedTuple(sim.ϵ_r),
-        point_types = NamedTuple(sim.point_types),
-        electric_field = NamedTuple(sim.electric_field),
-        weighting_potentials = NamedTuple{Tuple(Symbol.(wpots_strings))}(NamedTuple.(sim.weighting_potentials))
+        detector_json_string = _namedtuple(sim.config_dict),
+        electric_potential = _namedtuple(sim.electric_potential),
+        q_eff_imp = _namedtuple(sim.q_eff_imp),
+        imp_scale = _namedtuple(sim.imp_scale),
+        q_eff_fix = _namedtuple(sim.q_eff_fix),
+        ϵ_r = _namedtuple(sim.ϵ_r),
+        point_types = _namedtuple(sim.point_types),
+        electric_field = _namedtuple(sim.electric_field),
+        weighting_potentials = NamedTuple{Tuple(Symbol.(wpots_strings))}(_namedtuple.(sim.weighting_potentials))
     )
     return nt
 end
 Base.convert(T::Type{NamedTuple}, x::Simulation) = T(x)
 
 function Simulation(nt::NamedTuple)
-    missing_tuple = NamedTuple(missing)
+    missing_tuple = _namedtuple(missing)
     if nt.electric_potential !== missing_tuple
         epot = ElectricPotential(nt.electric_potential)
         T = eltype(epot.data)
-        sim = Simulation{T}( Dict(nt.detector_json_string) )
+        sim = Simulation{T}( _dict(nt.detector_json_string) )
         sim.electric_potential = epot
         sim.q_eff_imp = EffectiveChargeDensity(nt.q_eff_imp)
         sim.q_eff_fix = EffectiveChargeDensity(nt.q_eff_fix)
@@ -104,7 +104,7 @@ function Simulation(nt::NamedTuple)
         sim.electric_field = haskey(nt, :electric_field) && nt.electric_field !== missing_tuple ? ElectricField(nt.electric_field) : missing
     else
         T = Float32
-        sim = Simulation{T}( Dict(nt.detector_json_string) )
+        sim = Simulation{T}( _dict(nt.detector_json_string) )
     end
     sim.weighting_potentials = if haskey(nt, :weighting_potentials) 
         [let wp = Symbol("WeightingPotential_$(contact.id)")

--- a/src/SolidStateDetector/Semiconductor.jl
+++ b/src/SolidStateDetector/Semiconductor.jl
@@ -57,7 +57,7 @@ function Semiconductor{T}(dict::AbstractDict, input_units::NamedTuple, outer_tra
     end
     charge_drift_model = if haskey(dict, "charge_drift_model") && haskey(dict["charge_drift_model"], "model")
         model = Symbol(dict["charge_drift_model"]["model"])
-        cdm = if model in names(SolidStateDetectors, all = true) && getfield(SolidStateDetectors, model) <: AbstractChargeDriftModel
+        cdm = if isdefined(SolidStateDetectors, model) && getfield(SolidStateDetectors, model) <: AbstractChargeDriftModel
             getfield(SolidStateDetectors, model){T}(dict["charge_drift_model"])
         else
             throw(ConfigFileError("There is no charge drift model called `$(dict["charge_drift_model"]["model"])`."))


### PR DESCRIPTION
Since v0.2.0, SolidStateDetectors.jl has been committing type piracy by defining `Dict(::NamedTuple)` and NamedTuple(::Dict)`. This came up when replacing `Dict` with `AbstractDict` in #412.

In order to avoid this type piracy, `_namedtuple` and `_dict` are introduced.
I hope I didn't miss any case here.