### PR TITLE
Update documentation regarding `LegendHDF5IO`

### DIFF
--- a/docs/src/man/IO.md
+++ b/docs/src/man/IO.md
@@ -24,21 +24,19 @@ sim = FileIO.load("<name-of-simulation.file>.jld", "Simulation")
 
 ## Saving output with HDF5
 
-One more compact way of saving simulation results is based on converting the output to a `NamedTuple` and saving it to a HDF5 file. This requires the [HDF5.jl](https://github.com/JuliaIO/HDF5.jl) package, as well as the (unregistered) service packages [LegendDataTypes.jl](https://github.com/legend-exp/LegendHDF5IO.jl) and [LegendHDF5IO.jl](https://github.com/legend-exp/LegendHDF5IO.jl).
+One more compact way of saving simulation results is based on converting the output to a `NamedTuple` and saving it to a HDF5 file. This requires the (unregistered) service packages [LegendDataTypes.jl](https://github.com/legend-exp/LegendHDF5IO.jl) and [LegendHDF5IO.jl](https://github.com/legend-exp/LegendHDF5IO.jl).
 
 Install the required packages once by running:
 ```julia
-using Pkg
+import Pkg
 Pkg.add(url="https://github.com/legend-exp/LegendDataTypes.jl.git")
 Pkg.add(url="https://github.com/legend-exp/LegendHDF5IO.jl.git")
-Pkg.add("HDF5")
 ```
 
 Simulation output can be written to a HDF5 file using [`ssd_write`](@ref):
 ```julia
-using HDF5
-using LegendHDF5IO
 using SolidStateDetectors 
+using LegendHDF5IO
 # ...
 
 ssd_write("<name-of-simulation-file>.h5", sim)
@@ -46,11 +44,10 @@ ssd_write("<name-of-simulation-file>.h5", sim)
 
 The data stored in the HDF5 file can be read using [`ssd_read`](@ref):
 ```julia
-using HDF5
-using LegendHDF5IO
 using SolidStateDetectors
+using LegendHDF5IO
 ssd_read("<name-of-simulation-file>.h5", Simulation)
 ```
 
 !!! note
-    All HDF5 related packages must be loaded **before** loading SolidStateDetectors.jl
+    `LegendHDF5IO` must be loaded **after** loading `SolidStateDetectors`!

--- a/src/IO/IO.jl
+++ b/src/IO/IO.jl
@@ -20,8 +20,8 @@ with a given `filename` using [LegendHDF5IO.jl](https://github.com/legend-exp/Le
 
 ## Example 
 ```julia
-using LegendHDF5IO
 using SolidStateDetectors
+using LegendHDF5IO
 sim = Simulation(SSD_examples[:InvertedCoax])
 simulate!(sim)
 ssd_write("example_sim.h5", sim)
@@ -32,7 +32,7 @@ ssd_write("example_sim.h5", sim)
 
 !!! note 
     In order to use this method, the package [LegendHDF5IO.jl](https://github.com/legend-exp/LegendHDF5IO.jl) 
-    has to be loaded before loading SolidStateDetectors.jl.
+    has to be loaded after loading SolidStateDetectors.jl.
 
 See also [`ssd_read`](@ref).
 """
@@ -51,14 +51,14 @@ using [LegendHDF5IO.jl](https://github.com/legend-exp/LegendHDF5IO.jl).
 
 ## Example 
 ```julia
-using LegendHDF5IO
 using SolidStateDetectors
+using LegendHDF5IO
 sim = ssd_read("example_sim.h5", Simulation)
 ```
 
 !!! note 
     In order to use this method, the package [LegendHDF5IO.jl](https://github.com/legend-exp/LegendHDF5IO.jl) 
-    has to be loaded before loading SolidStateDetectors.jl.
+    has to be loaded after loading SolidStateDetectors.jl.
 
 See also [`ssd_write`](@ref).
 """

--- a/src/MCEventsProcessing/MCEventsProcessing.jl
+++ b/src/MCEventsProcessing/MCEventsProcessing.jl
@@ -10,14 +10,13 @@ Simulates the waveforms for all events defined in `mcevents` for a given [`Simul
 2. determining the signal (waveforms) for each [`Contact`](@ref), 
     for which a [`WeightingPotential`](@ref) is specified in `sim.weighting_potentials`.
 
-
 ## Arguments
 * `mcevents::TypedTables.Table`: Table with information about events in the simulated setup.
 * `sim::Simulation{T}`: [`Simulation`](@ref) which defines the setup in which the charges in `mcevents` should drift.
 
-If [HDF5.jl](https://github.com/JuliaIO/HDF5.jl) is loaded, this function has additional arguments. 
+If [LegendHDF5IO.jl](https://github.com/legend-exp/LegendHDF5IO.jl) is loaded, this function has additional arguments. 
 
-## Additional Arguments (HDF5)
+## Additional Arguments (`LegendHDF5IO`)
 * `output_dir::AbstractString`: Directory where the HDF5 output file is saved.
 * `output_base_name::AbstractString`: Basename of the HDF5 output file, default is `"generated_waveforms"`.
 
@@ -29,7 +28,7 @@ If [HDF5.jl](https://github.com/JuliaIO/HDF5.jl) is loaded, this function has ad
 * `number_of_carriers::Int = 1`: Number of charge carriers to be used in the N-Body simulation of an energy deposition. 
 * `number_of_shells::Int = 1`: Number of shells around the `center` point of the energy deposition.
 * `verbose = false`: Activate or deactivate additional info output.
-* `chunk_n_physics_events::Int = 1000` (HDF5 only): Number of events that should be saved in a single HDF5 output file.
+* `chunk_n_physics_events::Int = 1000` (`LegendHDF5IO` only): Number of events that should be saved in a single HDF5 output file.
 
 ## Examples
 ```julia 
@@ -37,7 +36,7 @@ simulate_waveforms(mcevents, sim, Δt = 1u"ns", verbose = false)
 # => returns the input table `mcevents` with an additional column `waveform` in which the generated waveforms are stored
 ```
 ```julia 
-import HDF5
+using LegendHDF5IO
 simulate_waveforms(mcevents, sim, "output_dir", "my_basename", Δt = 1u"ns", verbose = false)
 # => simulates the charge drift and saves the output to "output_dir/my_basename_evts_xx.h5"
 ```


### PR DESCRIPTION
Recently, loading `LegendHDF5IO` before `SolidStateDetectors` would result in
```julia
┌ Warning: Error requiring `LegendHDF5IO` from `SolidStateDetectors`
│   exception =
│    LoadError: ConcurrencyViolationError("deadlock detected in loading SolidStateDetectors -> SolidStateDetectors")
```

However, all of this is fine if `SolidStateDetectors` is loaded before `LegendHDF5IO`.

In the documentation, we previously required all HDF5-related packages to be loaded before `SolidStateDetectors`. I updated the documentation such that we recommend loading them afterwards. Also, the package `HDF5` is no longer explicitly required.