### PR TITLE
Bug fix in `parse_material` in `Geant4` extension

### DIFF
--- a/ext/Geant4/io_gdml.jl
+++ b/ext/Geant4/io_gdml.jl
@@ -460,9 +460,9 @@ end
     elseif material == "Aluminium" return "G4_Al"
     elseif material == "liquid Argon" return "G4_lAr"
     elseif material == "Copper" return "G4_Cu"
-    elseif material == "PEN" return "G4_PEN"
-    elseif material == "PTFE" return "G4_PTFE"
-    elseif material == "CdZnTe" return "G4_CdZnTe"
+    elseif material == "Polyethylene Naphthalate" return "G4_PEN"
+    elseif material == "Polytetrafluorethylen" return "G4_PTFE"
+    elseif material == "Cadmium zinc telluride" return "G4_CdZnTe"
     end
     throw("Material characteristics for \"$(material)\" not defined yet")
 end

--- a/test/Geant4.jl
+++ b/test/Geant4.jl
@@ -6,6 +6,15 @@ using Unitful
 
 T = Float32
 
+@testset "Parse materials in Geant4 extension" begin
+    parse_material = Base.get_extension(SolidStateDetectors, :SolidStateDetectorsGeant4Ext).parse_material
+    for (m,material) in SolidStateDetectors.material_properties
+        @testset "$(m)" begin
+            @test_nowarn parse_material(material.name)
+        end
+    end
+end
+
 @testset "Define particle sources" begin
 
     # Isotropic emission when no direction is passed


### PR DESCRIPTION
Introduced in #392, spotted in #420:
The material names in `parse_material` need to match the names given in `MaterialProperties.jl`.
This was not the case for `PEN`, `PTFE` and `CdZnTe`.
This should be fixed now.

