### PR TITLE
SSD --> GDML parser: change parsing of the world

### DIFF
--- a/ext/Geant4/io_gdml.jl
+++ b/ext/Geant4/io_gdml.jl
@@ -387,7 +387,7 @@ function parse_geometry(e::World{T, 3, Cylindrical}, x_solids::XMLElement, x_def
         "name" => name,
         "rmin" => zero(T),
         "rmax" => rmax,
-        "z" => z,
+        "z" => 2*z,
         "startphi" => zero(T),
         "deltaphi" => T(360),
         "lunit" => SolidStateDetectors.internal_length_unit,
@@ -405,9 +405,9 @@ function parse_geometry(e::World{T, 3, Cartesian}, x_solids::XMLElement, x_defin
     name = pf * string(id)
     set_attributes(w, OrderedDict(
         "name" => name,
-        "x" => x,
-        "y" => y,
-        "z" => z,
+        "x" => 2*x,
+        "y" => 2*y,
+        "z" => 2*z,
         "lunit" => SolidStateDetectors.internal_length_unit
     ))
     


### PR DESCRIPTION
It seems like, when translating a `Simulation` object to GDML, the world would not be correctly parsed.
While the world width is determined correctly, it seems to be always centered around 0.
In some cases (for example, the example inverted coaxial detector), this would lead to artifacts of reduced event rates in some parts of the detector:

```julia
using Geant4
using SolidStateDetectors
using Unitful
using Plots

sim = Simulation(SSD_examples[:InvertedCoax])
source = MonoenergeticSource("gamma", 2.615u"MeV", CartesianPoint(0.05,0,0.05), CartesianVector(-1,0,0), 30u"°")
app = G4JLApplication(sim, source)

evts = run_geant4_simulation(app, 100_000)
clustered = SolidStateDetectors.cluster_detector_hits(evts, 0.5u"mm")
let p = SolidStateDetectors.flatview(clustered.pos)
    histogram2d(getindex.(p,1), getindex.(p,3), bins = (-35:1:35, 0:1:80))
    plot!(sim.detector, st = :slice, x = 0, full_det = true, size = (500,500), label = "", fmt = :png)
end
```
![Geant4_before_cartesian](https://github.com/user-attachments/assets/76477121-2aa1-4462-ae4c-fcab067eecb2)

One quick fix for now would be to double the world size in the Geant4 simulation, which is done is this PR:
![Geant4_after_cartesian](https://github.com/user-attachments/assets/eab883fc-2aa5-405c-9686-3f0c14c6e0b0)
