### PR TITLE
Adapt precision type of `G4JLApplication` to `Simulation`

### DIFF
--- a/ext/SolidStateDetectorsGeant4Ext.jl
+++ b/ext/SolidStateDetectorsGeant4Ext.jl
@@ -152,8 +152,10 @@ function Geant4.G4JLApplication(
     kwargs...
 )
 
+    T = sim isa SolidStateDetectors.Simulation ? SolidStateDetectors.get_precision_type(sim) : Float32
+
     SensitiveDetector = G4JLSensitiveDetector(
-        "SensitiveDetector", SDData{Float32}();           # SD name and associated data are mandatory
+        "SensitiveDetector", SDData{T}();           # SD name and associated data are mandatory
         processhits_method=_processHits,    # process hist method (also mandatory)
         initialize_method=_initialize,      # intialize method
         endofevent_method=_endOfEvent       # end of event method


### PR DESCRIPTION
If a `G4JLApplication` is created from a `Simulation{T}`, the precision type `T` is also used for the output energies and positions.  This PR might not cover all cases yet, but the one reported in #436.

```julia
wf = simulate_waveforms(events[1:100], sim, Δt = 1u"ns", max_nsteps = 2000)
plot(wf[1:20].waveform, label = "")
```
```
[ Info: Detector has 2 contacts
[ Info: Table has 100 physics events (4152 single charge depositions).
Progress: 100%|█████████████████████████████████████████| Time: 0:00:13
[ Info: Generating waveforms...
```
![image](https://github.com/user-attachments/assets/772e998e-9054-4bb7-8bda-449fe185edee)
