### PR TITLE
Fix constructor of `BoggsChargeTrappingModel`

### DIFF
--- a/src/ChargeTrapping/ChargeTrapping.jl
+++ b/src/ChargeTrapping/ChargeTrapping.jl
@@ -98,15 +98,24 @@ function BoggsChargeTrappingModel{T}(config_dict::AbstractDict = Dict(); tempera
     meffe::T = 0.12
     meffh::T = 0.21
     temperature::T = _parse_value(T, temperature, internal_temperature_unit)
-    if haskey(config_dict, "parameters")
-        if haskey(config_dict, "nσe")   nσe =     _parse_value(T, config_dict["nσe"], internal_length_unit^-1) end
-        if haskey(config_dict, "nσe-1") nσe = inv(_parse_value(T, config_dict["nσe-1"], internal_length_unit)) end
-        if haskey(config_dict, "nσh")   nσh =     _parse_value(T, config_dict["nσh"], internal_length_unit^-1) end
-        if haskey(config_dict, "nσh-1") nσh = inv(_parse_value(T, config_dict["nσh-1"], internal_length_unit)) end
-        if haskey(config_dict, "meffe") meffe =   _parse_value(T, config_dict["meffe"], Unitful.NoUnits) end
-        if haskey(config_dict, "meffh") meffh =   _parse_value(T, config_dict["meffh"], Unitful.NoUnits) end
-        if haskey(config_dict, "temperature") temperature = _parse_value(T, config_dict["temperature"], internal_temperature_unit) end
+
+    if haskey(config_dict, "model") && !haskey(config_dict, "parameters")
+        throw(ConfigFileError("`BoggsChargeTrappingModel` does not have `parameters`"))
     end
+
+    parameters = haskey(config_dict, "parameters") ? config_dict["parameters"] : config_dict
+    
+    allowed_keys = ("nσe","nσe-1","nσh","nσh-1","meffe","meffh","temperature")
+    k = filter(k -> !(k in allowed_keys), keys(parameters))
+    !isempty(k) && @warn "The following keys will be ignored: $(k).\nAllowed keys are: $(allowed_keys)"
+
+    if haskey(parameters, "nσe")   nσe =     _parse_value(T, parameters["nσe"], internal_length_unit^-1) end
+    if haskey(parameters, "nσe-1") nσe = inv(_parse_value(T, parameters["nσe-1"], internal_length_unit)) end
+    if haskey(parameters, "nσh")   nσh =     _parse_value(T, parameters["nσh"], internal_length_unit^-1) end
+    if haskey(parameters, "nσh-1") nσh = inv(_parse_value(T, parameters["nσh-1"], internal_length_unit)) end
+    if haskey(parameters, "meffe") meffe =   _parse_value(T, parameters["meffe"], Unitful.NoUnits) end
+    if haskey(parameters, "meffh") meffh =   _parse_value(T, parameters["meffh"], Unitful.NoUnits) end
+    if haskey(parameters, "temperature") temperature = _parse_value(T, parameters["temperature"], internal_temperature_unit) end
     BoggsChargeTrappingModel{T}(nσe, nσh, meffe, meffh, temperature)
 end
 

--- a/src/ConstructiveSolidGeometry/Units.jl
+++ b/src/ConstructiveSolidGeometry/Units.jl
@@ -8,6 +8,7 @@ const AngleQuantity = Quantity{<:Real, NoDims, <:Union{_get_TDU(1u"rad")[3], _ge
 to_internal_units(x::Real) = x
 to_internal_units(x::LengthQuantity) = ustrip(internal_length_unit, x)
 to_internal_units(x::AngleQuantity)  = ustrip(internal_angle_unit, x)
+to_internal_units(x::Quantity{<:Real, Unitful.𝐋^(-1)}) = ustrip(internal_length_unit^(-1), x) # charge trapping
 to_internal_units(x::Quantity{<:Real, Unitful.𝐋^(-3)}) = ustrip(internal_length_unit^(-3), x) # densities
 to_internal_units(x::Quantity{<:Real, Unitful.𝐋^(-4)}) = ustrip(internal_length_unit^(-4), x) # density gradients
 to_internal_units(x::AbstractArray) = to_internal_units.(x)

--- a/test/test_charge_drift_models.jl
+++ b/test/test_charge_drift_models.jl
@@ -42,6 +42,34 @@ end
     signalsum *= inv(ustrip(SolidStateDetectors._convert_internal_energy_to_external_charge(sim.detector.semiconductor.material)))
     @info signalsum
     @test signalsum < T(1.99)
+
+    config_dict = SolidStateDetectors.parse_config_file(SSD_examples[:InvertedCoax])
+    @testset "Parse config file 1" begin
+        config_dict["detectors"][1]["semiconductor"]["charge_trapping_model"] = Dict(
+            "model" => "Boggs",
+            "parameters" => Dict(
+                "nσe" => "0.001cm^-1",
+                "nσh" => "0.0005cm^-1",
+                "temperature" => "78K"
+            )
+        )
+        simA = @test_nowarn Simulation{T}(config_dict)
+        @test simA.detector.semiconductor.charge_trapping_model isa BoggsChargeTrappingModel{T}
+    end
+    @testset "Parse config file 2" begin
+        config_dict["detectors"][1]["semiconductor"]["charge_trapping_model"] = Dict(
+            "model" => "Boggs",
+            "parameters" => Dict(
+                "nσe-1" => "500cm",
+                "nσh-1" => "500cm",
+                "meffe" => 0.1,
+                "meffh" => 0.2,
+                "temperature" => "100K"
+            )
+        )
+        simB = @test_nowarn Simulation{T}(config_dict)
+        @test simB.detector.semiconductor.charge_trapping_model isa BoggsChargeTrappingModel{T}
+    end
 end
 
 @timed_testset "Test completeness of charge drift models" begin

--- a/test/test_charge_drift_models.jl
+++ b/test/test_charge_drift_models.jl
@@ -55,6 +55,9 @@ end
         )
         simA = @test_nowarn Simulation{T}(config_dict)
         @test simA.detector.semiconductor.charge_trapping_model isa BoggsChargeTrappingModel{T}
+        @test simA.detector.semiconductor.charge_trapping_model.nσe == T(0.1)
+        @test simA.detector.semiconductor.charge_trapping_model.nσh == T(0.05)
+        @test simA.detector.semiconductor.charge_trapping_model.temperature == T(78)
     end
     @testset "Parse config file 2" begin
         config_dict["detectors"][1]["semiconductor"]["charge_trapping_model"] = Dict(
@@ -69,6 +72,12 @@ end
         )
         simB = @test_nowarn Simulation{T}(config_dict)
         @test simB.detector.semiconductor.charge_trapping_model isa BoggsChargeTrappingModel{T}
+        @test simB.detector.semiconductor.charge_trapping_model.nσe == T(0.2)
+        @test simB.detector.semiconductor.charge_trapping_model.nσh == T(0.2)
+        @test simB.detector.semiconductor.charge_trapping_model.meffe == T(0.1)
+        @test simB.detector.semiconductor.charge_trapping_model.meffh == T(0.2)
+        @test simB.detector.semiconductor.charge_trapping_model.temperature == T(100)
+
     end
 end
 


### PR DESCRIPTION
Previously, the constructor of `BoggsChargeDriftModel` would just completely ignore the section with the `parameters`.
Now, they are properly parsed.

The constructor can now take two sorts of dictionaries:
```
model: Boggs
parameters:
  # ...
```
and just
```
# ...
```
The latter might be convenient when defining the `BoggsChargeDriftModel` in code, e.g. `BoggsChargeDriftModel{T}(Dict("nσe-1" => "1000cm"))` and ensures that this PR is non-breaking (this is what the previous method did).