### PR TITLE
Minor update in painting algorithm for `CylindricalGrid`

### DIFF
--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/ConeMantle.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/ConeMantle.jl
@@ -230,6 +230,9 @@ function intersection(cm::ConeMantle{T,Tuple{T,T}}, l::Line{T}) where {T}
     end
     ints1 = obj_l.origin + λ1 * obj_l.direction 
     ints2 = obj_l.origin + λ2 * obj_l.direction 
+    # Could be reintroduced as sanity check
+    # ints1 = ints1 * ifelse(abs(ints1.z) <= cm.hZ, one(T), T(NaN))
+    # ints2 = ints2 * ifelse(abs(ints2.z) <= cm.hZ, one(T), T(NaN))
     return _transform_into_global_coordinate_system(ints1, cm), 
            _transform_into_global_coordinate_system(ints2, cm)
 end

--- a/src/PotentialCalculation/Painting.jl
+++ b/src/PotentialCalculation/Painting.jl
@@ -117,13 +117,13 @@ function paint!(point_types, potential, face::AbstractSurfacePrimitive{T}, geome
     eZ = CartesianVector{T}(0,0,1);
 
     widths_ax1 = diff(get_extended_ticks(grid[1]))
-    widths_ax2 = diff(get_extended_ticks(grid[2]))
+    # widths_ax2 = diff(get_extended_ticks(grid[2]))
     widths_ax3 = diff(get_extended_ticks(grid[3]))
     Δw_max_factor = T(1e-5)
     #= 
         Δw_max_factor is chosen by trying out different values for it. 
-        This value seems to be okay if the grid is not to unevenly spaced. 
-        But this can be secured via the `max_ratio`- and the `the max_tick_distance`-keywords.
+        This value seems to be okay if the grid is not too unevenly spaced. 
+        But this can be secured via the `max_ratio`- and the `max_tick_distance`-keywords.
         The critical parameter is `csgtol` inside the `in`-method, which is currently defined through 
         the widths of the voxel of the grid point next to the calculated intersection point.
         It would be probably better to turn this into an `NTuple{3,T}` and pass the widths of the voxel instead
@@ -176,7 +176,8 @@ function paint!(point_types, potential, face::AbstractSurfacePrimitive{T}, geome
                 i1 = searchsortednearest(ticks[1], pt_cyl[1])
                 csgtol = Δw_max_factor * max(
                     widths_ax1[i1], widths_ax1[i1+1],
-                    widths_ax2[i2], widths_ax2[i2+1],
+                    # skip φ (as done in the previous loop)
+                    # widths_ax2[i2], widths_ax2[i2+1]) 
                 ) 
                 if in(pt_cyl, grid) && abs(pt_cyl[2] - ticks[2][i2]) < T(0.1) && in(pt_car, geometry, csgtol)
                     point_types[i1, i2, i3] = zero(PointType)

--- a/test/test_real_detectors.jl
+++ b/test/test_real_detectors.jl
@@ -143,7 +143,6 @@ end
 end 
 @timed_testset "Simulate example detector: Toroidal" begin
     sim = Simulation{T}(SSD_examples[:CoaxialTorus])
-    SolidStateDetectors.apply_initial_state!(sim, ElectricPotential)
     timed_simulate!(sim, convergence_limit = 1e-5, device_array_type = device_array_type, refinement_limits = [0.2, 0.1, 0.05, 0.02, 0.01], 
         max_tick_distance = 0.5u"mm", verbose = false)
     evt = Event([CartesianPoint{T}(0.0075,0,0)])


### PR DESCRIPTION
The `csgtol` in the painting algorithm takes into account that grid points can be unevenly spaced in different dimensions. However, for 2D grids, this results in very weird results. Also, here we are comparing quantities in units of length with quantities in units of radians. I have removed the angle quantities from the `csgtol` check.