### PR TITLE
Add alias `deg` for `°` in `ConstructiveSolidGeometry`

### DIFF
--- a/src/ConstructiveSolidGeometry/ConstructiveSolidGeometry.jl
+++ b/src/ConstructiveSolidGeometry/ConstructiveSolidGeometry.jl
@@ -118,4 +118,15 @@ module ConstructiveSolidGeometry
     # Plotting
     include("plotting/plotting.jl")
 
+    # define the alias "deg" for ° --> this will also allow to use deg in config files
+    # u"deg" will be defined when explicitly calling
+    # using SolidStateDetectors.ConstructiveSolidGeometry
+    const deg = Unitful.°
+
+    Unitful.register(ConstructiveSolidGeometry)
+    const localunits = Unitful.basefactors
+    function __init__()
+        merge!(Unitful.basefactors, localunits)
+        Unitful.register(ConstructiveSolidGeometry)
+    end
 end


### PR DESCRIPTION
This will define `u”deg“` when explicitly calling `using SolidStateDetectors.ConstructiveSolidGeometry` and otherwise allow users to use ”deg“ as string in config dicts and files when just defining geometries (just in the CSG cosmos, without the need of any SSD functionality).
This could become interesting if we might wanna export CSG to a separate module.