### PR TITLE
Bugfix in `has_volume` in Geant4 extension

### DIFF
--- a/ext/Geant4/io_gdml.jl
+++ b/ext/Geant4/io_gdml.jl
@@ -119,7 +119,7 @@ end
 function has_volume(e::Cone{T,<:Any,TR}, v::Bool = false) where {T, TR}    
     rmin1, rmax1, rmin2, rmax2 = parse_cone_radius(e)
     
-    if rmin1 >= rmax1 || rmin2 >= rmax2
+    if rmin1 > rmax1 || rmin2 > rmax2 || (rmin1 == rmax1 && rmin2 == rmax2)
         v && @warn "Cone: The outer radii must be strictly bigger than the inner radii"
         return false
     elseif e.hZ <= 0

--- a/ext/Geant4/io_gdml.jl
+++ b/ext/Geant4/io_gdml.jl
@@ -152,8 +152,8 @@ function has_volume(e::Torus, v::Bool = false)
         v && @warn "Torus: Tube radius must be a positive number"
         return false
     end
-    if e.r_torus <= 0
-        v && @warn "Torus: Torus radius must be a positive number"
+    if e.r_torus < 0
+        v && @warn "Torus: Torus radius cannot be negative"
         return false
     end
     return true


### PR DESCRIPTION
The `has_volume` method for `Cone` in the Geant4 extension needs a small fix.
If e.g. `rmin1 < rmax1` and `rmin2 == rmax2`,  `has_volume` would wrongfully return `false`. 
We only expect `false` if both `(rmin1 == rmax1 && rmin2 == rmax2)`