### PR TITLE
Update is_depleted

### DIFF
--- a/src/ScalarPotentials/PointTypes.jl
+++ b/src/ScalarPotentials/PointTypes.jl
@@ -103,7 +103,7 @@ is_depleted(sim.point_types)
 ```
 """
 is_depleted(point_types::PointTypes)::Bool = 
-    !any(b -> bulk_bit > 0 && undepleted_bit & b > 0, point_types.data)
+    !any(b -> bulk_bit & b > 0 && undepleted_bit & b > 0, point_types.data)
 
 
 """

--- a/src/Simulation/DepletionVoltage.jl
+++ b/src/Simulation/DepletionVoltage.jl
@@ -64,10 +64,13 @@ function estimate_depletion_voltage(sim::Simulation{T},
     Umax::T = maximum(broadcast(c -> c.potential, sim.detector.contacts));
     contact_id::Int = determine_bias_voltage_contact_id(sim.detector),
     tolerance::AbstractFloat = 1e-1,
-    verbose::Bool = true) where {T <: AbstractFloat}
+    verbose::Bool = true,
+    check_for_depletion = true) where {T <: AbstractFloat}
 
     @assert !ismissing(sim.point_types) "Please calculate the electric potential first using `calculate_electric_potential!(sim)`"
-    @assert is_depleted(sim.point_types) "This method only works for fully depleted simulations. Please increase the potentials in the configuration file to a greater value."
+    if check_for_depletion
+        @assert is_depleted(sim.point_types) "This method only works for fully depleted simulations. Please increase the potentials in the configuration file to a greater value."
+    end
     @assert Umax * Umin ≥ 0 "The voltage range needs to be positive or negative. Please adjust the voltage range."
     @assert abs(Umax - Umin) > tolerance "Umax - Umin < tolerance. Please change Umin, Umax or tolerance." 
 


### PR DESCRIPTION
`is_depleted` currently does not check if a grid point is bulk type. This was updated to correctly determine if the detector is depleted based only on points in the bulk. 

This was causing `estimate_depletion_voltage` to fail for many clearly fully depleted examples. The checking of depletion in this function was also made optional if the user makes their own checks beforehand. 