### PR TITLE
Allow user to refine an already simulated potential

### DIFF
--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -829,6 +829,7 @@ function _calculate_potential!( sim::Simulation{T, CS}, potential_type::UnionAll
         paint_contacts::Bool = true,
         verbose::Bool = true,
         device_array_type::Type{<:AbstractArray} = Array,
+        initialize::Bool = true
     )::Nothing where {T <: SSDFloat, CS <: AbstractCoordinateSystem}
 
     begin # preperations
@@ -836,6 +837,9 @@ function _calculate_potential!( sim::Simulation{T, CS}, potential_type::UnionAll
         convergence_limit::T = T(convergence_limit)
         isEP::Bool = potential_type == ElectricPotential
         isWP::Bool = !isEP
+        if !initialize
+            grid = isEP ? sim.electric_potential.grid : sim.weighting_potentials[contact_id].grid
+        end
         if ismissing(grid)
             grid = Grid(sim, for_weighting_potential = isWP, max_tick_distance = max_tick_distance, max_distance_ratio = max_distance_ratio)
         end
@@ -926,26 +930,27 @@ function _calculate_potential!( sim::Simulation{T, CS}, potential_type::UnionAll
             )
         end
     end
-    if isEP
-        apply_initial_state!(sim, potential_type, grid; not_only_paint_contacts, paint_contacts)
-        update_till_convergence!( sim, potential_type, convergence_limit,
-                                  n_iterations_between_checks = n_iterations_between_checks,
-                                  max_n_iterations = max_n_iterations,
-                                  depletion_handling = depletion_handling,
-                                  device_array_type = device_array_type,
-                                  use_nthreads = guess_nt ? _guess_optimal_number_of_threads_for_SOR(size(sim.electric_potential.grid), max_nthreads[1], CS) : max_nthreads[1],
-                                  sor_consts = sor_consts )
-    else
-        apply_initial_state!(sim, potential_type, contact_id, grid; not_only_paint_contacts, paint_contacts, depletion_handling)
-        update_till_convergence!( sim, potential_type, contact_id, convergence_limit,
+    if initialize 
+        if isEP
+            apply_initial_state!(sim, potential_type, grid; not_only_paint_contacts, paint_contacts)
+            update_till_convergence!( sim, potential_type, convergence_limit,
                                     n_iterations_between_checks = n_iterations_between_checks,
                                     max_n_iterations = max_n_iterations,
                                     depletion_handling = depletion_handling,
                                     device_array_type = device_array_type,
-                                    use_nthreads = guess_nt ? _guess_optimal_number_of_threads_for_SOR(size(sim.weighting_potentials[contact_id].grid), max_nthreads[1], CS) : max_nthreads[1],
+                                    use_nthreads = guess_nt ? _guess_optimal_number_of_threads_for_SOR(size(sim.electric_potential.grid), max_nthreads[1], CS) : max_nthreads[1],
                                     sor_consts = sor_consts )
+        else
+            apply_initial_state!(sim, potential_type, contact_id, grid; not_only_paint_contacts, paint_contacts, depletion_handling)
+            update_till_convergence!( sim, potential_type, contact_id, convergence_limit,
+                                        n_iterations_between_checks = n_iterations_between_checks,
+                                        max_n_iterations = max_n_iterations,
+                                        depletion_handling = depletion_handling,
+                                        device_array_type = device_array_type,
+                                        use_nthreads = guess_nt ? _guess_optimal_number_of_threads_for_SOR(size(sim.weighting_potentials[contact_id].grid), max_nthreads[1], CS) : max_nthreads[1],
+                                        sor_consts = sor_consts )
+        end
     end
-
     # refinement_counter::Int = 1
     if refine
         for iref in 1:n_refinement_steps


### PR DESCRIPTION
If user wants to refine an existing simulation, they can do so by using the `initialize = false` keyword. See example below.
```julia
using SolidStateDetectors
using BenchmarkTools

T = Float32
sim = Simulation{T}(SSD_examples[:InvertedCoax])
calculate_electric_potential!(sim, refinement_limits = [0.2], depletion_handling = true)
```
Simulation: Public Inverted Coax
Electric Potential Calculation
Bias voltage: 3500.0 V
φ symmetry: Detector is φ-symmetric -> 2D computation.
Precision: Float32
Device: CPU
Max. CPU Threads: 1
Coordinate system: Cylindrical
N Refinements: -> 1
Convergence limit: 1.0e-7  => 0.00035 V
Initial grid size: (24, 1, 20)

Grid size: (30, 1, 30) - using 1 threads now
```julia
calculate_electric_potential!(sim, refinement_limits = [0.1], depletion_handling = true, initialize = false)
```
Simulation: Public Inverted Coax
Electric Potential Calculation
Bias voltage: 3500.0 V
φ symmetry: Detector is φ-symmetric -> 2D computation.
Precision: Float32
Device: CPU
Max. CPU Threads: 1
Coordinate system: Cylindrical
N Refinements: -> 1
Convergence limit: 1.0e-7  => 0.00035 V
Initial grid size: (30, 1, 30)

Grid size: (40, 1, 50) - using 1 threads now
Clearly the initial grid for the second refinement is the result of the first calculation. The computation time also spreads out over both computations. See computation time below for simulating in one step vs 2 steps
```julia
@btime calculate_electric_potential!(sim, refinement_limits = [0.2, 0.1], depletion_handling = true, verbose = false)
```
128.599 ms (1239795 allocations: 291.36 MiB)
```julia
@btime calculate_electric_potential!(sim, refinement_limits = [0.2], depletion_handling = true, verbose = false)
```
71.188 ms (756028 allocations: 136.88 MiB)
```julia
@btime calculate_electric_potential!(sim, refinement_limits = [0.1], depletion_handling = true, verbose = false, initialize = false)
```
22.563 ms (180071 allocations: 61.19 MiB)