### PR TITLE
Boule impurity models

### DIFF
--- a/src/ImpurityDensities/BouleImpurityDensities/BouleImpurityDensities.jl
+++ b/src/ImpurityDensities/BouleImpurityDensities/BouleImpurityDensities.jl
@@ -1,10 +1,2 @@
-"""
-Boule impurity densities are meant to be used when the impurity density is defined in the boule coordinates, where the z-axis is aligned with the boule growth direction. 
-
-Different models are provided. In each the field `det_z0` is the z-coordinate of the detector origin in boule coordinates. The z-direction of the detector is opposite to the z-direction of the boule coordinates.
-
-In this matter the detector impurities are automatically determined from those of the boule, depending on `det_z0`.
-"""
-
 include("LinBouleImpurityDensity.jl")
 include("LinExpBouleImpurityDensity.jl")

--- a/src/ImpurityDensities/BouleImpurityDensities/BouleImpurityDensities.jl
+++ b/src/ImpurityDensities/BouleImpurityDensities/BouleImpurityDensities.jl
@@ -1,0 +1,10 @@
+"""
+Boule impurity densities are meant to be used when the impurity density is defined in the boule coordinates, where the z-axis is aligned with the boule growth direction. 
+
+Different models are provided. In each the field `det_z0` is the z-coordinate of the detector origin in boule coordinates. The z-direction of the detector is opposite to the z-direction of the boule coordinates.
+
+In this matter the detector impurities are automatically determined from those of the boule, depending on `det_z0`.
+"""
+
+include("LinBouleImpurityDensity.jl")
+include("LinExpBouleImpurityDensity.jl")

--- a/src/ImpurityDensities/BouleImpurityDensities/LinBouleImpurityDensity.jl
+++ b/src/ImpurityDensities/BouleImpurityDensities/LinBouleImpurityDensity.jl
@@ -1,0 +1,23 @@
+"""
+    struct LinBouleImpurityDensity{T <: SSDFloat} <: AbstractImpurityDensity{T}
+
+Impurity density model which assumes a linear gradient in impurity density in z.
+ 
+## Fields
+* `a:T`: impurity density values at the boule origin.
+* `b::T`: linear slope in `z` direction.
+* `det_z0::T`: z coordinate of the detector origin in boule coordinates. The z-dirrection of the detector is opposite to the z-direction of the boule coordinates.
+"""
+
+struct LinBouleImpurityDensity{T <: SSDFloat} <: AbstractImpurityDensity{T}
+    # a + b*z
+    a::T
+    b::T 
+    det_z0::T
+end
+
+function get_impurity_density(idm::LinBouleImpurityDensity, pt::AbstractCoordinatePoint{T})::T where {T}
+    cpt = CartesianPoint(pt)
+    z = cpt[3]
+    idm.a .+ idm.b * (idm.det_z0 .- z)
+end

--- a/src/ImpurityDensities/BouleImpurityDensities/LinBouleImpurityDensity.jl
+++ b/src/ImpurityDensities/BouleImpurityDensities/LinBouleImpurityDensity.jl
@@ -1,16 +1,16 @@
 """
     struct LinBouleImpurityDensity{T <: SSDFloat} <: AbstractImpurityDensity{T}
 
+a + b*z
 Impurity density model which assumes a linear gradient in impurity density in z.
  
 ## Fields
 * `a:T`: impurity density values at the boule origin.
 * `b::T`: linear slope in `z` direction.
-* `det_z0::T`: z coordinate of the detector origin in boule coordinates. The z-dirrection of the detector is opposite to the z-direction of the boule coordinates.
+* `det_z0::T`: z coordinate of the detector origin in boule coordinates. The z-direction of the detector is opposite to the z-direction of the boule coordinates.
 """
 
 struct LinBouleImpurityDensity{T <: SSDFloat} <: AbstractImpurityDensity{T}
-    # a + b*z
     a::T
     b::T 
     det_z0::T
@@ -19,5 +19,5 @@ end
 function get_impurity_density(idm::LinBouleImpurityDensity, pt::AbstractCoordinatePoint{T})::T where {T}
     cpt = CartesianPoint(pt)
     z = cpt[3]
-    idm.a .+ idm.b * (idm.det_z0 .- z)
+    idm.a + idm.b * (idm.det_z0 - z)
 end

--- a/src/ImpurityDensities/BouleImpurityDensities/LinExpBouleImpurityDensity.jl
+++ b/src/ImpurityDensities/BouleImpurityDensities/LinExpBouleImpurityDensity.jl
@@ -1,19 +1,19 @@
 """
     struct LinExpBouleImpurityDensity{T <: SSDFloat} <: AbstractImpurityDensity{T}
 
+a + b*z + c*exp((z-L)/tau)
 Impurity density model which assumes a linear + exponential component in impurity density in z.
- 
+
 ## Fields
 * `a:T`: impurity density values at the boule origin.
 * `b::T`: linear slope in `z` direction.
 * `c::T`: exponential coefficient.
 * `L::T`: exponential offset.
 * `tau::T`: exponential scale factor.
-* `det_z0::T`: z coordinate of the detector origin in boule coordinates. The z-dirrection of the detector is opposite to the z-direction of the boule coordinates.
+* `det_z0::T`: z coordinate of the detector origin in boule coordinates. The z-direction of the detector is opposite to the z-direction of the boule coordinates.
 """
 
 struct LinExpBouleImpurityDensity{T <: SSDFloat} <: AbstractImpurityDensity{T}
-    # a + b*z + c*exp((z-L)/tau) -> needs at least 4 points
     a::T
     b::T 
     c::T 
@@ -25,5 +25,5 @@ end
 function get_impurity_density(idm::LinExpBouleImpurityDensity, pt::AbstractCoordinatePoint{T})::T where {T}
     cpt = CartesianPoint(pt)
     z = cpt[3]
-    idm.a .+ idm.b * (idm.det_z0 .- z) .+ idm.c * exp.((idm.det_z0 .- z .- idm.L)/idm.tau)
+    idm.a + idm.b * (idm.det_z0 - z) + idm.c * exp((idm.det_z0 - z - idm.L)/idm.tau)
 end

--- a/src/ImpurityDensities/BouleImpurityDensities/LinExpBouleImpurityDensity.jl
+++ b/src/ImpurityDensities/BouleImpurityDensities/LinExpBouleImpurityDensity.jl
@@ -1,0 +1,29 @@
+"""
+    struct LinBouleImpurityDensity{T <: SSDFloat} <: AbstractImpurityDensity{T}
+
+Impurity density model which assumes a linear gradient in impurity density in z.
+ 
+## Fields
+* `a:T`: impurity density values at the boule origin.
+* `b::T`: linear slope in `z` direction.
+* `c::T`: exponential coefficient.
+* `L::T`: exponential offset.
+* `tau::T`: exponential scale factor.
+* `det_z0::T`: z coordinate of the detector origin in boule coordinates. The z-dirrection of the detector is opposite to the z-direction of the boule coordinates.
+"""
+
+struct LinExpBouleImpurityDensity{T} <: AbstractImpurityDensity{T}
+    # a + b*z + c*exp((z-L)/tau) -> needs at least 4 points
+    a::T
+    b::T 
+    c::T 
+    L::T
+    tau::T
+    det_z0::T
+end
+
+function get_impurity_density(idm::LinExpBouleImpurityDensity, pt::AbstractCoordinatePoint{T})::T where {T}
+    cpt = CartesianPoint(pt)
+    z = cpt[3]
+    idm.a .+ idm.b * (idm.det_z0 .- z) .+ idm.c * exp.((idm.det_z0 .- z .- idm.L)/idm.tau)
+end

--- a/src/ImpurityDensities/BouleImpurityDensities/LinExpBouleImpurityDensity.jl
+++ b/src/ImpurityDensities/BouleImpurityDensities/LinExpBouleImpurityDensity.jl
@@ -1,7 +1,7 @@
 """
-    struct LinBouleImpurityDensity{T <: SSDFloat} <: AbstractImpurityDensity{T}
+    struct LinExpBouleImpurityDensity{T <: SSDFloat} <: AbstractImpurityDensity{T}
 
-Impurity density model which assumes a linear gradient in impurity density in z.
+Impurity density model which assumes a linear + exponential component in impurity density in z.
  
 ## Fields
 * `a:T`: impurity density values at the boule origin.
@@ -12,7 +12,7 @@ Impurity density model which assumes a linear gradient in impurity density in z.
 * `det_z0::T`: z coordinate of the detector origin in boule coordinates. The z-dirrection of the detector is opposite to the z-direction of the boule coordinates.
 """
 
-struct LinExpBouleImpurityDensity{T} <: AbstractImpurityDensity{T}
+struct LinExpBouleImpurityDensity{T <: SSDFloat} <: AbstractImpurityDensity{T}
     # a + b*z + c*exp((z-L)/tau) -> needs at least 4 points
     a::T
     b::T 

--- a/src/ImpurityDensities/ImpurityDensities.jl
+++ b/src/ImpurityDensities/ImpurityDensities.jl
@@ -40,3 +40,4 @@ include("ConstantImpurityDensity.jl")
 include("LinearImpurityDensity.jl")
 include("CylindricalImpurityDensity.jl")
 
+include("BouleImpurityDensities/BouleImpurityDensities.jl")

--- a/src/ImpurityDensities/ImpurityDensities.jl
+++ b/src/ImpurityDensities/ImpurityDensities.jl
@@ -15,10 +15,6 @@ Boule impurity densities are meant to be used when the impurity density is defin
 
 Different models are provided. In each the field `det_z0` is the z-coordinate of the detector origin in boule coordinates. The z-direction of the detector is opposite to the z-direction of the boule coordinates.
 
-## Examples
-* [`LinBouleImpurityDensity`](@ref)
-* [`LinExpBouleImpurityDensity`](@ref)
-
 In this matter the detector impurities are automatically determined from those of the boule, depending on `det_z0`.
 
 !!! note

--- a/src/ImpurityDensities/ImpurityDensities.jl
+++ b/src/ImpurityDensities/ImpurityDensities.jl
@@ -11,6 +11,16 @@ For each impurity density, there should be a method
 * [`LinearImpurityDensity`](@ref)
 * [`CylindricalImpurityDensity`](@ref)
 
+Boule impurity densities are meant to be used when the impurity density is defined in the boule coordinates, where the z-axis is aligned with the boule growth direction. 
+
+Different models are provided. In each the field `det_z0` is the z-coordinate of the detector origin in boule coordinates. The z-direction of the detector is opposite to the z-direction of the boule coordinates.
+
+## Examples
+* [`LinBouleImpurityDensity`](@ref)
+* [`LinExpBouleImpurityDensity`](@ref)
+
+In this matter the detector impurities are automatically determined from those of the boule, depending on `det_z0`.
+
 !!! note
     The sign of the impurity density is important. It is taken into account in the conversion to a charge density
     and, thus, defines where the semiconductor is n-type or p-type. 

--- a/src/SolidStateDetectors.jl
+++ b/src/SolidStateDetectors.jl
@@ -77,6 +77,7 @@ export Simulation, simulate!
 export Event, drift_charges!
 export add_baseline_and_extend_tail
 export NBodyChargeCloud
+export LinearImpurityDensity, LinBouleImpurityDensity, LinExpBouleImpurityDensity
 
 using Unitful: RealOrRealQuantity as RealQuantity
 const SSDFloat = Union{Float16, Float32, Float64}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,6 +49,10 @@ end
     include("test_refine_existing_potential.jl")
 end
 
+@timed_testset "Test boule impurity densities" begin
+    include("test_boule_impurity_densities.jl")
+end
+
 @timed_testset "Geant4 extension" begin
     if Sys.WORD_SIZE == 64 include("test_geant4.jl") end
 end

--- a/test/test_boule_impurity_densities.jl
+++ b/test/test_boule_impurity_densities.jl
@@ -21,5 +21,7 @@ T = Float32
     idm = LinExpBouleImpurityDensity{T}(boule_ρ0, boule_gradient, boule_c, boule_L, boule_tau, det_z0)
     sim.detector = SolidStateDetector(sim.detector, idm)
 
+    det_ρ0 = SolidStateDetectors.get_impurity_density(sim.detector.semiconductor.impurity_density_model, CylindricalPoint{T}(0,0,0))
+    
     @test det_ρ0 == boule_ρ0 + boule_gradient * det_z0 + boule_c * exp((det_z0 - boule_L)/boule_tau)
 end

--- a/test/test_boule_impurity_densities.jl
+++ b/test/test_boule_impurity_densities.jl
@@ -1,0 +1,25 @@
+using SolidStateDetectors
+using Test
+
+T = Float32
+
+@timed_testset "Test boule impurity densities" begin
+    sim = Simulation{T}("BEGe_01.yaml")
+    det_z0 = T(0.12)
+    boule_ρ0 = T(-1e16)
+    boule_gradient = T(-1e17)
+    idm = LinBouleImpurityDensity{T}(boule_ρ0, boule_gradient, det_z0)
+    sim.detector = SolidStateDetector(sim.detector, idm)
+
+    det_ρ0 = SolidStateDetectors.get_impurity_density(sim.detector.semiconductor.impurity_density_model, CylindricalPoint{T}(0,0,0))
+
+    @test det_ρ0 == boule_ρ0 + boule_gradient * det_z0
+
+    boule_c = T(-2e15)
+    boule_L = T(0.05)
+    boule_tau = T(0.03)
+    idm = LinExpBouleImpurityDensity{T}(boule_ρ0, boule_gradient, boule_c, boule_L, boule_tau, det_z0)
+    sim.detector = SolidStateDetector(sim.detector, idm)
+
+    @test det_ρ0 == boule_ρ0 + boule_gradient * det_z0 + boule_c * exp((det_z0 - boule_L)/boule_tau)
+end


### PR DESCRIPTION
Added Impurity models `LinBouleImpurityDensity` and `LinExpBouleImpurityDensity` for cases when user whats to define an impurity model for the boule and then place the detector in a certain location `det_z0`. These are placed in a separate folder to distinguish from those that use models based on detector coordinates.
See documentation:
```
"""
Boule impurity densities are meant to be used when the impurity density is defined in the boule coordinates, where the z-axis is aligned with the boule growth direction. 

Different models are provided. In each the field `det_z0` is the z-coordinate of the detector origin in boule coordinates. The z-direction of the detector is opposite to the z-direction of the boule coordinates.

In this matter the detector impurities are automatically determined from those of the boule, depending on `det_z0`.
"""
```
```julia
det_z0 = 0.12
boule_ρ0 = -1e16
idm = LinBouleImpurityDensity{T}(boule_ρ0, -1e17, det_z0)

sim = Simulation{T}(SSD_examples[:InvertedCoax])
sim.detector = SolidStateDetector(sim.detector, idm)

points = broadcast(z -> SolidStateDetectors.CylindricalPoint{T}(0,0,z/1000), 0:80)
ρ = broadcast(p -> SolidStateDetectors.get_impurity_density(sim.detector.semiconductor.impurity_density_model, p), points);

plot(getproperty.(points, :z)*u"m", ρ*u"m^-3", xunit = u"mm", yunit = u"cm^-3", legend = false)
```
<img width="596" alt="Screenshot 2025-04-02 at 14 34 58" src="https://github.com/user-attachments/assets/be7422ff-d12b-4ac9-9fbf-b441927274d8" />
