### PR TITLE
Add support for simulation for dead layer-Step2: DiffusionModelTiedWithDrifting

### DIFF
--- a/ext/SolidStateDetectorsLegendHDF5IOExt.jl
+++ b/ext/SolidStateDetectorsLegendHDF5IOExt.jl
@@ -34,7 +34,8 @@ function SolidStateDetectors.simulate_waveforms( mcevents::TypedTables.Table, si
                              self_repulsion::Bool = false,
                              number_of_carriers::Int = 1,
                              number_of_shells::Int = 1,
-                             verbose = false) where {T <: SSDFloat}
+                             verbose = false,
+                             killdrift_while_nofield::Bool = true ) where {T <: SSDFloat}
     n_total_physics_events = length(mcevents)
     Δtime = T(to_internal_units(Δt)) 
     n_contacts = length(sim.detector.contacts)
@@ -48,7 +49,7 @@ function SolidStateDetectors.simulate_waveforms( mcevents::TypedTables.Table, si
     for evtrange in evt_ranges
         ofn = joinpath(output_dir, "$(output_base_name)_evts_$(nfmt(first(evtrange)))-$(nfmt(last(evtrange))).h5")
         @info "Now simulating $(evtrange) and storing it in\n\t \"$ofn\""
-        mcevents_sub = simulate_waveforms(mcevents[evtrange], sim; Δt, max_nsteps, diffusion, self_repulsion, number_of_carriers, number_of_shells, verbose)
+        mcevents_sub = simulate_waveforms(mcevents[evtrange], sim; Δt, max_nsteps, diffusion, self_repulsion, number_of_carriers, number_of_shells, verbose, killdrift_while_nofield)
       
         LegendHDF5IO.lh5open(ofn, "w") do h5f
             LegendHDF5IO.writedata(h5f.data_store, "generated_waveforms", mcevents_sub)

--- a/ext/SolidStateDetectorsLegendHDF5IOExt.jl
+++ b/ext/SolidStateDetectorsLegendHDF5IOExt.jl
@@ -35,7 +35,7 @@ function SolidStateDetectors.simulate_waveforms( mcevents::TypedTables.Table, si
                              number_of_carriers::Int = 1,
                              number_of_shells::Int = 1,
                              verbose = false,
-                             killdrift_while_nofield::Bool = true ) where {T <: SSDFloat}
+                             end_drift_when_no_field::Bool = true ) where {T <: SSDFloat}
     n_total_physics_events = length(mcevents)
     Δtime = T(to_internal_units(Δt)) 
     n_contacts = length(sim.detector.contacts)
@@ -49,7 +49,7 @@ function SolidStateDetectors.simulate_waveforms( mcevents::TypedTables.Table, si
     for evtrange in evt_ranges
         ofn = joinpath(output_dir, "$(output_base_name)_evts_$(nfmt(first(evtrange)))-$(nfmt(last(evtrange))).h5")
         @info "Now simulating $(evtrange) and storing it in\n\t \"$ofn\""
-        mcevents_sub = simulate_waveforms(mcevents[evtrange], sim; Δt, max_nsteps, diffusion, self_repulsion, number_of_carriers, number_of_shells, verbose, killdrift_while_nofield)
+        mcevents_sub = simulate_waveforms(mcevents[evtrange], sim; Δt, max_nsteps, diffusion, self_repulsion, number_of_carriers, number_of_shells, verbose, end_drift_when_no_field)
       
         LegendHDF5IO.lh5open(ofn, "w") do h5f
             LegendHDF5IO.writedata(h5f.data_store, "generated_waveforms", mcevents_sub)

--- a/src/ChargeDrift/ChargeDrift.jl
+++ b/src/ChargeDrift/ChargeDrift.jl
@@ -99,7 +99,7 @@ function _set_to_zero_vector!(v::Vector{CartesianVector{T}})::Nothing where {T <
 end
 
 function _add_fieldvector_drift!(step_vectors::Vector{CartesianVector{T}}, current_pos::Vector{CartesianPoint{T}}, done::Vector{Bool}, 
-    electric_field::Interpolations.Extrapolation{<:StaticVector{3}, 3}, det::SolidStateDetector{T}, ::Type{S}, end_drift_when_no_field::Bool)::Nothing where {T, S}
+    electric_field::Interpolations.Extrapolation{<:StaticVector{3}, 3}, det::SolidStateDetector{T}, ::Type{S}, end_drift_when_no_field::Bool = true)::Nothing where {T, S}
     for n in eachindex(step_vectors)
        if !done[n]
            step_vectors[n] += get_velocity_vector(electric_field, _convert_point(current_pos[n], S))

--- a/src/ChargeDrift/ChargeDrift.jl
+++ b/src/ChargeDrift/ChargeDrift.jl
@@ -118,7 +118,7 @@ function _add_fieldvector_diffusion!(step_vectors::Vector{CartesianVector{T}}, d
     end
     nothing 
 end
-function _add_fieldvector_diffusion_TiedWithMobility!(step_vectors::Vector{CartesianVector{T}}, done::Vector{Bool}, Δt::T, calculate_mobility::Function, current_pos::Vector{CartesianPoint{T}}, crystal_temperature::T, ::Type{CC})::Nothing where {T <: SSDFloat, CC <: ChargeCarrier}
+function _add_fieldvector_diffusion!(step_vectors::Vector{CartesianVector{T}}, done::Vector{Bool}, Δt::T, calculate_mobility::Function, current_pos::Vector{CartesianPoint{T}}, crystal_temperature::T, ::Type{CC})::Nothing where {T <: SSDFloat, CC <: ChargeCarrier}
     for n in eachindex(step_vectors)
         if done[n] continue end
 
@@ -320,8 +320,7 @@ function _drift_charge!(
         _add_fieldvector_drift!(step_vectors, current_pos, done, electric_field, det, S, end_drift_when_no_field)
         self_repulsion && _add_fieldvector_selfrepulsion!(step_vectors, current_pos, done, charges, ϵ_r)
         _get_driftvectors!(step_vectors, done, Δt, det.semiconductor.charge_drift_model, current_pos, CC)
-        diffusion && !use_mobility_tied_diffusion && _add_fieldvector_diffusion!(step_vectors, done, diffusion_length)
-        diffusion && use_mobility_tied_diffusion && _add_fieldvector_diffusion_TiedWithMobility!(step_vectors, done, Δt, det.semiconductor.charge_drift_model.calculate_mobility, current_pos, crystal_temperature, CC)
+        diffusion && (use_mobility_tied_diffusion ? _add_fieldvector_diffusion!(step_vectors, done, Δt, det.semiconductor.charge_drift_model.calculate_mobility, current_pos, crystal_temperature, CC) : _add_fieldvector_diffusion!(step_vectors, done, diffusion_length))
         _modulate_driftvectors!(step_vectors, current_pos, det.virtual_drift_volumes)
         _check_and_update_position!(step_vectors, current_pos, done, normal, drift_path, timestamps, istep, det, grid, point_types, startpos, Δt, verbose)
         if all(done) break end

--- a/src/Event/Event.jl
+++ b/src/Event/Event.jl
@@ -154,6 +154,7 @@ Calculates the electron and hole drift paths for the given [`Event`](@ref) and [
 * `diffusion::Bool = false`: Activate or deactive diffusion of charge carriers via random walk.
 * `self_repulsion::Bool = false`: Activate or deactive self-repulsion of charge carriers of the same type.
 * `verbose = true`: Activate or deactivate additional info output.
+* `killdrift_while_nofield::Bool = true`: Activate or deactive drifting termination when the electric field is exactly zero.
 
 ## Example 
 ```julia 
@@ -163,9 +164,9 @@ drift_charges!(evt, sim, Δt = 1u"ns", verbose = false)
 !!! note
     Using values with units for `Δt` requires the package [Unitful.jl](https://github.com/PainterQubits/Unitful.jl).
 """
-function drift_charges!(evt::Event{T}, sim::Simulation{T}; max_nsteps::Int = 1000, Δt::RealQuantity = 5u"ns", diffusion::Bool = false, self_repulsion::Bool = false, verbose::Bool = true)::Nothing where {T <: SSDFloat}
+function drift_charges!(evt::Event{T}, sim::Simulation{T}; max_nsteps::Int = 1000, Δt::RealQuantity = 5u"ns", diffusion::Bool = false, self_repulsion::Bool = false, verbose::Bool = true, killdrift_while_nofield::Bool = true)::Nothing where {T <: SSDFloat}
     !in(evt, sim.detector) && move_charges_inside_semiconductor!(evt, sim.detector, verbose = verbose)
-    evt.drift_paths = drift_charges(sim, evt.locations, evt.energies, Δt = Δt, max_nsteps = max_nsteps, diffusion = diffusion, self_repulsion = self_repulsion, verbose = verbose)
+    evt.drift_paths = drift_charges(sim, evt.locations, evt.energies, Δt = Δt, max_nsteps = max_nsteps, diffusion = diffusion, self_repulsion = self_repulsion, verbose = verbose, killdrift_while_nofield = killdrift_while_nofield)
     nothing
 end
 function get_signal!(evt::Event{T}, sim::Simulation{T}, contact_id::Int; Δt::RealQuantity = 5u"ns")::Nothing where {T <: SSDFloat}
@@ -236,6 +237,7 @@ The output is stored in `evt.drift_paths` and `evt.waveforms`.
 * `diffusion::Bool = false`: Activate or deactive diffusion of charge carriers via random walk.
 * `self_repulsion::Bool = false`: Activate or deactive self-repulsion of charge carriers of the same type.
 * `verbose = true`: Activate or deactivate additional info output.
+* `killdrift_while_nofield::Bool = true`: Activate or deactive drifting termination when the electric field is exactly zero.
 
 ## Example 
 ```julia
@@ -244,8 +246,8 @@ simulate!(evt, sim, Δt = 1u"ns", verbose = false)
 
 See also [`drift_charges!`](@ref) and [`get_signals!`](@ref).
 """
-function simulate!(evt::Event{T}, sim::Simulation{T}; max_nsteps::Int = 1000, Δt::RealQuantity = 5u"ns", diffusion::Bool = false, self_repulsion::Bool = false, verbose::Bool = true)::Nothing where {T <: SSDFloat}
-    drift_charges!(evt, sim, max_nsteps = max_nsteps, Δt = Δt, diffusion = diffusion, self_repulsion = self_repulsion, verbose = verbose)
+function simulate!(evt::Event{T}, sim::Simulation{T}; max_nsteps::Int = 1000, Δt::RealQuantity = 5u"ns", diffusion::Bool = false, self_repulsion::Bool = false, verbose::Bool = true, killdrift_while_nofield::Bool = true)::Nothing where {T <: SSDFloat}
+    drift_charges!(evt, sim, max_nsteps = max_nsteps, Δt = Δt, diffusion = diffusion, self_repulsion = self_repulsion, verbose = verbose, killdrift_while_nofield = killdrift_while_nofield )
     get_signals!(evt, sim, Δt = Δt)
     nothing
 end

--- a/src/Event/Event.jl
+++ b/src/Event/Event.jl
@@ -154,7 +154,7 @@ Calculates the electron and hole drift paths for the given [`Event`](@ref) and [
 * `diffusion::Bool = false`: Activate or deactive diffusion of charge carriers via random walk.
 * `self_repulsion::Bool = false`: Activate or deactive self-repulsion of charge carriers of the same type.
 * `verbose = true`: Activate or deactivate additional info output.
-* `killdrift_while_nofield::Bool = true`: Activate or deactive drifting termination when the electric field is exactly zero.
+* `end_drift_when_no_field::Bool = true`: Activate or deactive drifting termination when the electric field is exactly zero.
 
 ## Example 
 ```julia 
@@ -164,9 +164,9 @@ drift_charges!(evt, sim, Δt = 1u"ns", verbose = false)
 !!! note
     Using values with units for `Δt` requires the package [Unitful.jl](https://github.com/PainterQubits/Unitful.jl).
 """
-function drift_charges!(evt::Event{T}, sim::Simulation{T}; max_nsteps::Int = 1000, Δt::RealQuantity = 5u"ns", diffusion::Bool = false, self_repulsion::Bool = false, verbose::Bool = true, killdrift_while_nofield::Bool = true)::Nothing where {T <: SSDFloat}
+function drift_charges!(evt::Event{T}, sim::Simulation{T}; max_nsteps::Int = 1000, Δt::RealQuantity = 5u"ns", diffusion::Bool = false, self_repulsion::Bool = false, verbose::Bool = true, end_drift_when_no_field::Bool = true)::Nothing where {T <: SSDFloat}
     !in(evt, sim.detector) && move_charges_inside_semiconductor!(evt, sim.detector, verbose = verbose)
-    evt.drift_paths = drift_charges(sim, evt.locations, evt.energies, Δt = Δt, max_nsteps = max_nsteps, diffusion = diffusion, self_repulsion = self_repulsion, verbose = verbose, killdrift_while_nofield = killdrift_while_nofield)
+    evt.drift_paths = drift_charges(sim, evt.locations, evt.energies, Δt = Δt, max_nsteps = max_nsteps, diffusion = diffusion, self_repulsion = self_repulsion, verbose = verbose, end_drift_when_no_field = end_drift_when_no_field)
     nothing
 end
 function get_signal!(evt::Event{T}, sim::Simulation{T}, contact_id::Int; Δt::RealQuantity = 5u"ns")::Nothing where {T <: SSDFloat}
@@ -237,7 +237,7 @@ The output is stored in `evt.drift_paths` and `evt.waveforms`.
 * `diffusion::Bool = false`: Activate or deactive diffusion of charge carriers via random walk.
 * `self_repulsion::Bool = false`: Activate or deactive self-repulsion of charge carriers of the same type.
 * `verbose = true`: Activate or deactivate additional info output.
-* `killdrift_while_nofield::Bool = true`: Activate or deactive drifting termination when the electric field is exactly zero.
+* `end_drift_when_no_field::Bool = true`: Activate or deactive drifting termination when the electric field is exactly zero.
 
 ## Example 
 ```julia
@@ -246,8 +246,8 @@ simulate!(evt, sim, Δt = 1u"ns", verbose = false)
 
 See also [`drift_charges!`](@ref) and [`get_signals!`](@ref).
 """
-function simulate!(evt::Event{T}, sim::Simulation{T}; max_nsteps::Int = 1000, Δt::RealQuantity = 5u"ns", diffusion::Bool = false, self_repulsion::Bool = false, verbose::Bool = true, killdrift_while_nofield::Bool = true)::Nothing where {T <: SSDFloat}
-    drift_charges!(evt, sim, max_nsteps = max_nsteps, Δt = Δt, diffusion = diffusion, self_repulsion = self_repulsion, verbose = verbose, killdrift_while_nofield = killdrift_while_nofield )
+function simulate!(evt::Event{T}, sim::Simulation{T}; max_nsteps::Int = 1000, Δt::RealQuantity = 5u"ns", diffusion::Bool = false, self_repulsion::Bool = false, verbose::Bool = true, end_drift_when_no_field::Bool = true)::Nothing where {T <: SSDFloat}
+    drift_charges!(evt, sim, max_nsteps = max_nsteps, Δt = Δt, diffusion = diffusion, self_repulsion = self_repulsion, verbose = verbose, end_drift_when_no_field = end_drift_when_no_field )
     get_signals!(evt, sim, Δt = Δt)
     nothing
 end

--- a/src/MCEventsProcessing/MCEventsProcessing.jl
+++ b/src/MCEventsProcessing/MCEventsProcessing.jl
@@ -29,6 +29,7 @@ If [LegendHDF5IO.jl](https://github.com/legend-exp/LegendHDF5IO.jl) is loaded, t
 * `number_of_shells::Int = 1`: Number of shells around the `center` point of the energy deposition.
 * `verbose = false`: Activate or deactivate additional info output.
 * `chunk_n_physics_events::Int = 1000` (`LegendHDF5IO` only): Number of events that should be saved in a single HDF5 output file.
+* `killdrift_while_nofield::Bool = true`: Activate or deactive drifting termination when the electric field is exactly zero.
 
 ## Examples
 ```julia 
@@ -53,7 +54,8 @@ function simulate_waveforms( mcevents::TypedTables.Table, sim::Simulation{T};
                              self_repulsion::Bool = false,
                              number_of_carriers::Int = 1,
                              number_of_shells::Int = 1,
-                             verbose::Bool = false ) where {T <: SSDFloat}
+                             verbose::Bool = false,
+                             killdrift_while_nofield::Bool = true ) where {T <: SSDFloat}
     n_total_physics_events = length(mcevents)
     Δtime = T(to_internal_units(Δt)) 
     n_contacts = length(sim.detector.contacts)
@@ -71,7 +73,7 @@ function simulate_waveforms( mcevents::TypedTables.Table, sim::Simulation{T};
 
     # First simulate drift paths
     drift_paths_and_edeps = _simulate_charge_drifts(mcevents, sim, Δt, max_nsteps, electric_field, 
-        diffusion, self_repulsion, number_of_carriers, number_of_shells, verbose)
+        diffusion, self_repulsion, number_of_carriers, number_of_shells, verbose, killdrift_while_nofield)
     drift_paths = map(x -> vcat([vcat(ed...) for ed in x[1]]...), drift_paths_and_edeps)
     edeps = map(x -> vcat([vcat(ed...) for ed in x[2]]...), drift_paths_and_edeps)
     # now iterate over contacts and generate the waveform for each contact
@@ -127,13 +129,14 @@ function _simulate_charge_drifts( mcevents::TypedTables.Table, sim::Simulation{T
                                   self_repulsion::Bool,
                                   number_of_carriers::Int, 
                                   number_of_shells::Int,
-                                  verbose::Bool ) where {T <: SSDFloat}
+                                  verbose::Bool,
+                                  killdrift_while_nofield::Bool ) where {T <: SSDFloat}
     @showprogress map(mcevents) do phyevt
         locations, edeps = _convertEnergyDepsToChargeDeps(phyevt.pos, phyevt.edep, sim.detector; number_of_carriers, number_of_shells)
         drift_paths = map( i -> _drift_charges(sim.detector, sim.electric_field.grid, sim.point_types, 
                 VectorOfArrays(locations[i]), VectorOfArrays(edeps[i]),
                 electric_field, T(Δt.val) * unit(Δt), max_nsteps = max_nsteps, 
-                diffusion = diffusion, self_repulsion = self_repulsion, verbose = verbose
+                diffusion = diffusion, self_repulsion = self_repulsion, verbose = verbose, killdrift_while_nofield = killdrift_while_nofield
             ),
             eachindex(edeps)            
         )

--- a/src/MaterialProperties/MaterialProperties.jl
+++ b/src/MaterialProperties/MaterialProperties.jl
@@ -31,7 +31,8 @@ material_properties[:HPGe] = (
     ml = 1.64,
     mt = 0.0819,
     De = 101u"cm^2/s",
-    Dh = 49u"cm^2/s"
+    Dh = 49u"cm^2/s",
+    DT = 78u"K" # Temperature in Einstein's relation for diffusion calculation
 )
 
 # These values might just be approximations

--- a/src/MaterialProperties/MaterialProperties.jl
+++ b/src/MaterialProperties/MaterialProperties.jl
@@ -31,8 +31,7 @@ material_properties[:HPGe] = (
     ml = 1.64,
     mt = 0.0819,
     De = 101u"cm^2/s",
-    Dh = 49u"cm^2/s",
-    DT = 78u"K" # Temperature in Einstein's relation for diffusion calculation
+    Dh = 49u"cm^2/s"
 )
 
 # These values might just be approximations

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -1201,10 +1201,10 @@ end
 @deprecate apply_charge_drift_model!(args...; kwargs...) calculate_drift_fields!(args...; kwargs...)
 
 function drift_charges( sim::Simulation{T}, starting_positions::VectorOfArrays{CartesianPoint{T}}, energies::VectorOfArrays{T};
-                        Δt::RealQuantity = 5u"ns", max_nsteps::Int = 1000, diffusion::Bool = false, self_repulsion::Bool = false, verbose::Bool = true, killdrift_while_nofield::Bool = true )::Vector{EHDriftPath{T}} where {T <: SSDFloat}
+                        Δt::RealQuantity = 5u"ns", max_nsteps::Int = 1000, diffusion::Bool = false, self_repulsion::Bool = false, verbose::Bool = true, end_drift_when_no_field::Bool = true )::Vector{EHDriftPath{T}} where {T <: SSDFloat}
     return _drift_charges(   sim.detector, sim.point_types.grid, sim.point_types, starting_positions, energies, 
                              interpolated_vectorfield(sim.electric_field), Δt, 
-                             max_nsteps = max_nsteps, diffusion = diffusion, self_repulsion = self_repulsion, verbose = verbose, killdrift_while_nofield = killdrift_while_nofield)
+                             max_nsteps = max_nsteps, diffusion = diffusion, self_repulsion = self_repulsion, verbose = verbose, end_drift_when_no_field = end_drift_when_no_field)
 end
 
 function get_signal(sim::Simulation{T, CS}, drift_paths::Vector{EHDriftPath{T}}, energy_depositions::Vector{T}, contact_id::Int; Δt::TT = T(5) * u"ns") where {T <: SSDFloat, CS, TT}

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -1201,10 +1201,10 @@ end
 @deprecate apply_charge_drift_model!(args...; kwargs...) calculate_drift_fields!(args...; kwargs...)
 
 function drift_charges( sim::Simulation{T}, starting_positions::VectorOfArrays{CartesianPoint{T}}, energies::VectorOfArrays{T};
-                        Δt::RealQuantity = 5u"ns", max_nsteps::Int = 1000, diffusion::Bool = false, self_repulsion::Bool = false, verbose::Bool = true )::Vector{EHDriftPath{T}} where {T <: SSDFloat}
+                        Δt::RealQuantity = 5u"ns", max_nsteps::Int = 1000, diffusion::Bool = false, self_repulsion::Bool = false, verbose::Bool = true, killdrift_while_nofield::Bool = true )::Vector{EHDriftPath{T}} where {T <: SSDFloat}
     return _drift_charges(   sim.detector, sim.point_types.grid, sim.point_types, starting_positions, energies, 
                              interpolated_vectorfield(sim.electric_field), Δt, 
-                             max_nsteps = max_nsteps, diffusion = diffusion, self_repulsion = self_repulsion, verbose = verbose)
+                             max_nsteps = max_nsteps, diffusion = diffusion, self_repulsion = self_repulsion, verbose = verbose, killdrift_while_nofield = killdrift_while_nofield)
 end
 
 function get_signal(sim::Simulation{T, CS}, drift_paths::Vector{EHDriftPath{T}}, energy_depositions::Vector{T}, contact_id::Int; Δt::TT = T(5) * u"ns") where {T <: SSDFloat, CS, TT}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -53,6 +53,10 @@ end
     include("test_boule_impurity_densities.jl")
 end
 
+@timed_testset "Test position-dependent diffusion" begin
+    include("test_diffusion.jl")
+end
+
 @timed_testset "Geant4 extension" begin
     if Sys.WORD_SIZE == 64 include("test_geant4.jl") end
 end

--- a/test/test_diffusion.jl
+++ b/test/test_diffusion.jl
@@ -18,22 +18,22 @@ T = Float32
 
     # if calculate_mobility gives a zero mobility, nothing should happen
     calculate_mobility(pt::CartesianPoint{T}, ::Type{Hole}) where {T} = zero(T)
-    SolidStateDetectors._add_fieldvector_diffusion_TiedWithMobility!(step_vectors, done, Δt, calculate_mobility, current_pos, crystal_temperature, Hole)
+    SolidStateDetectors._add_fieldvector_diffusion!(step_vectors, done, Δt, calculate_mobility, current_pos, crystal_temperature, Hole)
     @test all(iszero.(step_vectors))  
     calculate_mobility(pt::CartesianPoint{T}, ::Type{Electron}) where {T} = zero(T)
-    SolidStateDetectors._add_fieldvector_diffusion_TiedWithMobility!(step_vectors, done, Δt, calculate_mobility, current_pos, crystal_temperature, Electron)
+    SolidStateDetectors._add_fieldvector_diffusion!(step_vectors, done, Δt, calculate_mobility, current_pos, crystal_temperature, Electron)
     @test all(iszero.(step_vectors))
     
     # if the mobility is set to some position-independent value, then we know what the length of the expected step_vectors should be
     μ0 = T(5.0 + rand() * 5.0)
     calculate_mobility_constant(pt::CartesianPoint{T}, ::Type{Hole}) where {T} = μ0
-    SolidStateDetectors._add_fieldvector_diffusion_TiedWithMobility!(step_vectors, done, Δt, calculate_mobility_constant, current_pos, crystal_temperature, Hole)
+    SolidStateDetectors._add_fieldvector_diffusion!(step_vectors, done, Δt, calculate_mobility_constant, current_pos, crystal_temperature, Hole)
     D0 = μ0 * crystal_temperature * SolidStateDetectors.kB / SolidStateDetectors.elementary_charge
     @test all(isapprox.(norm.(step_vectors), sqrt(6 * D0 * Δt), rtol = 0.01))
     step_vectors = zeros(CartesianVector{T}, N) # reset step vectors
     
     # use a position-dependent mobility
     calculate_mobility_pos(pt::CartesianPoint{T}, ::Type{Hole}) where {T} = pt.z
-    SolidStateDetectors._add_fieldvector_diffusion_TiedWithMobility!(step_vectors, done, Δt, calculate_mobility_pos, current_pos, crystal_temperature, Hole)
+    SolidStateDetectors._add_fieldvector_diffusion!(step_vectors, done, Δt, calculate_mobility_pos, current_pos, crystal_temperature, Hole)
     @test all(isapprox.(norm.(step_vectors).^2 ./ (6 * Δt) * SolidStateDetectors.elementary_charge / (crystal_temperature * SolidStateDetectors.kB), zs, rtol = 0.01))
 end

--- a/test/test_diffusion.jl
+++ b/test/test_diffusion.jl
@@ -1,0 +1,39 @@
+using SolidStateDetectors
+using SolidStateDetectors: Electron, Hole
+using LinearAlgebra
+using Test
+
+T = Float32
+
+@testset "Test position-dependent diffusion" begin
+    
+    N = 10
+    done = fill(false, N)
+    Δt = T(1e-9)
+    zs = 1:10
+    current_pos = CartesianPoint{T}.(0, 0, zs)
+    crystal_temperature = T(78)
+    
+    step_vectors = zeros(CartesianVector{T}, N)
+
+    # if calculate_mobility gives a zero mobility, nothing should happen
+    calculate_mobility(pt::CartesianPoint{T}, ::Type{Hole}) where {T} = zero(T)
+    SolidStateDetectors._add_fieldvector_diffusion_TiedWithMobility!(step_vectors, done, Δt, calculate_mobility, current_pos, crystal_temperature, Hole)
+    @test all(iszero.(step_vectors))  
+    calculate_mobility(pt::CartesianPoint{T}, ::Type{Electron}) where {T} = zero(T)
+    SolidStateDetectors._add_fieldvector_diffusion_TiedWithMobility!(step_vectors, done, Δt, calculate_mobility, current_pos, crystal_temperature, Electron)
+    @test all(iszero.(step_vectors))
+    
+    # if the mobility is set to some position-independent value, then we know what the length of the expected step_vectors should be
+    μ0 = T(5.0 + rand() * 5.0)
+    calculate_mobility_constant(pt::CartesianPoint{T}, ::Type{Hole}) where {T} = μ0
+    SolidStateDetectors._add_fieldvector_diffusion_TiedWithMobility!(step_vectors, done, Δt, calculate_mobility_constant, current_pos, crystal_temperature, Hole)
+    D0 = μ0 * crystal_temperature * SolidStateDetectors.kB / SolidStateDetectors.elementary_charge
+    @test all(isapprox.(norm.(step_vectors), sqrt(6 * D0 * Δt), rtol = 0.01))
+    step_vectors = zeros(CartesianVector{T}, N) # reset step vectors
+    
+    # use a position-dependent mobility
+    calculate_mobility_pos(pt::CartesianPoint{T}, ::Type{Hole}) where {T} = pt.z
+    SolidStateDetectors._add_fieldvector_diffusion_TiedWithMobility!(step_vectors, done, Δt, calculate_mobility_pos, current_pos, crystal_temperature, Hole)
+    @test all(isapprox.(norm.(step_vectors).^2 ./ (6 * Δt) * SolidStateDetectors.elementary_charge / (crystal_temperature * SolidStateDetectors.kB), zs, rtol = 0.01))
+end


### PR DESCRIPTION
Changes:
1. Comment out the `done[n] = (step_vectors[n] == CartesianVector{T}(0,0,0))` in the `_add_fieldvector_drift!`function to test the diffusion, and for future dead layer simulation
2. Add diffusion model tied with drifting through Einstein's relation
> Method to use this new model: use custom drifting model and define a `calculate_mobility` function

Test:
Construct a z-linear mobility model (z=0-10 mm, mu=0-4.2 m^2/V/s) and kill the drifting. Put charge at r = 5 mm, z = 10-90% of max z (=10mm). The size of the carrier group will be positively correlated with z:
![diffusion_DifferentCoef_GroupSigma](https://github.com/user-attachments/assets/44036bd2-0285-4171-a815-fddc49aba96a)


Test code:
```julia
using StatsBase
using Plots
using Pkg
Pkg.develop(path="./SolidStateDetectors.jl")
using SolidStateDetectors
using Revise
using Unitful

T = Float32
sim = Simulation{T}(SSD_examples[:TrueCoaxial])
det_z=T(10/1000) # m
det_r=T(10/1000) # m
sim.detector = SolidStateDetector(sim.detector, contact_id = 1, contact_potential = 0)
calculate_electric_potential!(sim)
calculate_electric_field!(sim)


# define the drifting function
# stop the drifting to demonstrate the diffusion 
# use constant zero for drifting, while using z-linear mu for diffusion
using SolidStateDetectors: SSDFloat, AbstractChargeDriftModel
using SolidStateDetectors: Electron, Hole, ChargeCarrier
struct CustomChargeDriftModel{T <: SSDFloat} <: AbstractChargeDriftModel{T} 
    det_z::T
    calculate_mobility::Function
end
using StaticArrays
function SolidStateDetectors.getVe(fv::SVector{3, T}, cdm::CustomChargeDriftModel, current_pos::CartesianPoint{T})::SVector{3, T} where {T <: SSDFloat}
    mu0=0
    return -fv*mu0
end
function SolidStateDetectors.getVh(fv::SVector{3, T}, cdm::CustomChargeDriftModel, current_pos::CartesianPoint{T})::SVector{3, T} where {T <: SSDFloat}
    mu0=0
    return fv*mu0
end
function calculate_mobility(current_pos::CartesianPoint{T}, CC::Type{Hole}, det_z::T = det_z)
    current_pos[3]/det_z*4.2 # in m2/V/s
end
function calculate_mobility(current_pos::CartesianPoint{T}, CC::Type{Electron}, det_z::T = det_z)
    current_pos[3]/det_z*4.2 # in m2/V/s
end
charge_drift_model = CustomChargeDriftModel{T}(det_z, calculate_mobility)
sim.detector = SolidStateDetector(sim.detector, charge_drift_model)


sigma_list = []
startz_list = (0.1:0.1:0.9)*det_z
for startz in startz_list
    start= [det_r/2,0,T(startz)]
    nbcc = NBodyChargeCloud(CartesianPoint{T}(start), 100u"keV", 100, radius = T(0))
    evt = Event(nbcc)
    simulate!(evt, sim, diffusion = true, max_nsteps = 100)
    end_position_list=[]
    for path in evt.drift_paths
        push!(end_position_list, path.h_path[end])
    end
    end_position_list = permutedims(reduce(hcat, end_position_list))
    push!(sigma_list, std(end_position_list[:,1]))
end
p=plot(startz_list*1000, sigma_list*1000)
plot!(xlabel = "z / mm", legend=false, ylabel = "\$\\sigma\$ / mm", title="Group size (100 carriers), after 100 ns", size = (700,500))
```