### PR TITLE
Add support for simulation for dead layer-Step3: ConstantLifetimeChargeTrappingModel

### DIFF
--- a/examples/example_config_files/public_TrueCoaxial.yaml
+++ b/examples/example_config_files/public_TrueCoaxial.yaml
@@ -32,14 +32,29 @@ detectors:
       value: 1e8cm^-3
     charge_drift_model:
       include: ADLChargeDriftModel/drift_velocity_config.yaml
+    charge_trapping_model:
+      model: ConstantLifetime
+      parameters:
+        τh: 1ms
+        τe: 1ms
+        τh_inactive: 80ns
+        τe_inactive: 80ns
+      inactive_layer_geometry:
+        tube:
+          r:
+            from: 9.0
+            to: 10.0
+          h: 10.0
+          origin:
+            z: 5.0
     geometry:
-      cone:
+      tube:
         r:
           from: 1.0
           to: 10.0
-        h: 10 
+        h: 10.0
         origin:
-          z: 5
+          z: 5.0
   contacts:
     - name: "P+"
       id: 1
@@ -49,10 +64,10 @@ detectors:
         tube:
           r:
             from: 0.5
-            to: 1
-          h: 10
+            to: 1.0
+          h: 10.0
           origin:
-            z: 5
+            z: 5.0
     - name: "N+"
       id: 2
       material: HPGe
@@ -61,7 +76,7 @@ detectors:
         tube:
           r:
             from: 10.0
-            to: 10.5
-          h: 10.
+            to: 10.0
+          h: 10.0
           origin:
-            z: 5
+            z: 5.0

--- a/src/SolidStateDetectors.jl
+++ b/src/SolidStateDetectors.jl
@@ -68,7 +68,7 @@ export ElectricPotential, PointTypes, EffectiveChargeDensity, DielectricDistribu
 export apply_initial_state!
 export calculate_electric_potential!, calculate_weighting_potential!, calculate_electric_field!, calculate_drift_fields!
 export ElectricFieldChargeDriftModel, ADLChargeDriftModel, IsotropicChargeDriftModel
-export NoChargeTrappingModel, BoggsChargeTrappingModel
+export NoChargeTrappingModel, BoggsChargeTrappingModel, ConstantLifetimeChargeTrappingModel
 export get_active_volume, is_depleted, estimate_depletion_voltage
 export calculate_stored_energy, calculate_mutual_capacitance, calculate_capacitance_matrix
 export simulate_waveforms


### PR DESCRIPTION
# Changes
Add a new charge trapping model: 
- Based on the constant lifetime for electron/hole
- Parameters for the bulk (sensitive region) and surface (dead layer, or the inactive layer) volumes respectively

# Test 
The pulses while the hole lifetimes are 10 ns, 100 ns,,,1 ms. (the electron lifetime = 1ms)
<img width="498" alt="image" src="https://github.com/user-attachments/assets/c97f7b4f-ddc9-4c24-bf7a-dfa5dce983d2" />



# Code for the test
```julia
using Revise
using Plots
using Pkg
Pkg.develop(path="./SolidStateDetectors.jl")
using SolidStateDetectors
using Unitful

T = Float32
sim = Simulation{T}(SSD_examples[:TrueCoaxial])
det_r=T(10/1000) # m
det_z=T(10/1000) # m
simulate!(sim)

bel = shl = sel = 1e6
plots=plot()
bhl_list = [10, 100, 1000, 10000, 100000, 1000000]
legend_name_list = ["10 ns", "100 ns", "1 µs", "10 µs", "100 µs", "1 ms"]
for (bhl,legend_name) in zip(bhl_list, legend_name_list)
    legend_name = "Hole lifetime = $(legend_name)"
    if_in_bulk = pos -> true
    parameters = Dict("parameters" => Dict("bhl" => bhl*u"ns", "bel" => bel*u"ns", "shl" => shl*u"ns", "sel" => sel*u"ns", "if_in_bulk" => if_in_bulk))
    trapping_model=BulkSurfaceConstantLifetimeChargeTrappingModel{T}(parameters)
    sim.detector = SolidStateDetector(sim.detector, trapping_model)

    energy_depos =[T(2.95/1000)] * u"keV"
    starting_positions = [CylindricalPoint{T}(det_r/2, deg2rad(0), det_z/2)]
    evt1 = Event(starting_positions, energy_depos);
    simulate!(evt1, sim, Δt = 1u"ns",max_nsteps=100)
    collected_charge=ustrip(maximum(evt1.waveforms[1].signal))
    plot!(evt1.waveforms[1], lw = 1.5, xlabel = "Time", ylabel = "Charge", 
                        unitformat = :slash, legend = true, label=legend_name, tickfontsize = 12, guidefontsize = 14,xlim=[0,100])
end
plots
```