### PR TITLE
Avoid deadlock concurrency in LegendHDF5IO extension

### DIFF
--- a/docs/src/man/IO.md
+++ b/docs/src/man/IO.md
@@ -48,6 +48,3 @@ using SolidStateDetectors
 using LegendHDF5IO
 ssd_read("<name-of-simulation-file>.h5", Simulation)
 ```
-
-!!! note
-    `LegendHDF5IO` must be loaded **after** loading `SolidStateDetectors`!

--- a/ext/SolidStateDetectorsLegendHDF5IOExt.jl
+++ b/ext/SolidStateDetectorsLegendHDF5IOExt.jl
@@ -4,8 +4,8 @@ module SolidStateDetectorsLegendHDF5IOExt
 
 import ..LegendHDF5IO
 
-using SolidStateDetectors
-using SolidStateDetectors: RealQuantity, SSDFloat, to_internal_units, chunked_ranges, LengthQuantity
+using ..SolidStateDetectors
+using ..SolidStateDetectors: RealQuantity, SSDFloat, to_internal_units, chunked_ranges, LengthQuantity
 using TypedTables, Unitful
 using Format
 

--- a/src/IO/IO.jl
+++ b/src/IO/IO.jl
@@ -30,10 +30,6 @@ ssd_write("example_sim.h5", sim)
 !!! warn
     If a file with `filename` already exists, it will be overwritten by this method.
 
-!!! note 
-    In order to use this method, the package [LegendHDF5IO.jl](https://github.com/legend-exp/LegendHDF5IO.jl) 
-    has to be loaded after loading SolidStateDetectors.jl.
-
 See also [`ssd_read`](@ref).
 """
 function ssd_write end
@@ -55,10 +51,6 @@ using SolidStateDetectors
 using LegendHDF5IO
 sim = ssd_read("example_sim.h5", Simulation)
 ```
-
-!!! note 
-    In order to use this method, the package [LegendHDF5IO.jl](https://github.com/legend-exp/LegendHDF5IO.jl) 
-    has to be loaded after loading SolidStateDetectors.jl.
 
 See also [`ssd_write`](@ref).
 """


### PR DESCRIPTION
Because `LegendHDF5IO` is not registered in the `General` registry, we load the `LegendHDF5IO` extension using `Requires`.

This triggered a deadlock concurrency error when loading `LegendHDF5IO` before `SolidStateDetectors`.
This PR avoids triggering this error.


MWE:
```julia
using LegendHDF5IO
using SolidStateDetectors
```

Previously
```
┌ Warning: Error requiring `LegendHDF5IO` from `SolidStateDetectors`
│   exception =
│    LoadError: ConcurrencyViolationError("deadlock detected in loading SolidStateDetectors -> SolidStateDetectors")
[...]
```

Now:
```
* works (no exception being thrown)
```