### PR TITLE
Add contractor method and scale function to BouleImpurityDensity

### DIFF
--- a/src/ImpurityDensities/BouleImpurityDensities/LinBouleImpurityDensity.jl
+++ b/src/ImpurityDensities/BouleImpurityDensities/LinBouleImpurityDensity.jl
@@ -16,6 +16,13 @@ struct LinBouleImpurityDensity{T <: SSDFloat} <: AbstractImpurityDensity{T}
     det_z0::T
 end
 
+function LinBouleImpurityDensity{T}(pars::Vector{<:Number}, det_z0::Number) where {T}
+    LinBouleImpurityDensity{T}(
+        T.(to_internal_units(pars))..., 
+        T(to_internal_units(det_z0))
+        )
+end
+
 function ImpurityDensity(T::DataType, t::Val{:linear_boule}, dict::AbstractDict, input_units::NamedTuple)
     a::T = haskey(dict, "a") ? _parse_value(T, dict["a"], input_units.length^(-3)) : T(0)
     b::T = haskey(dict, "b") ? _parse_value(T, dict["b"], input_units.length^(-4)) : T(0)
@@ -28,3 +35,5 @@ function get_impurity_density(idm::LinBouleImpurityDensity, pt::AbstractCoordina
     z = cpt[3]
     idm.a + idm.b * (idm.det_z0 - z)
 end
+
+(*)(scale::Real, idm::LinBouleImpurityDensity{T}) where {T} = LinBouleImpurityDensity{T}(T(scale*idm.a), T(scale*idm.b), idm.det_z0)

--- a/src/ImpurityDensities/BouleImpurityDensities/LinExpBouleImpurityDensity.jl
+++ b/src/ImpurityDensities/BouleImpurityDensities/LinExpBouleImpurityDensity.jl
@@ -22,6 +22,13 @@ struct LinExpBouleImpurityDensity{T <: SSDFloat} <: AbstractImpurityDensity{T}
     det_z0::T
 end
 
+function LinExpBouleImpurityDensity{T}(pars::Vector{<:Number}, det_z0::Number) where {T}
+    LinExpBouleImpurityDensity{T}(
+        T.(to_internal_units(pars))..., 
+        T(to_internal_units(det_z0))
+        )
+end
+
 function ImpurityDensity(T::DataType, t::Val{:linear_exponential_boule}, dict::AbstractDict, input_units::NamedTuple)
     a::T = haskey(dict, "a") ? _parse_value(T, dict["a"], input_units.length^(-3)) : T(0)
     b::T = haskey(dict, "b") ? _parse_value(T, dict["b"], input_units.length^(-4)) : T(0)
@@ -37,3 +44,5 @@ function get_impurity_density(idm::LinExpBouleImpurityDensity, pt::AbstractCoord
     z = cpt[3]
     idm.a + idm.b * (idm.det_z0 - z) + idm.n * exp((idm.det_z0 - z - idm.l)/idm.m)
 end
+
+(*)(scale::Real, idm::LinExpBouleImpurityDensity{T}) where {T} = LinExpBouleImpurityDensity{T}(T(scale*idm.a), T(scale*idm.b), T(scale*idm.n), idm.l, idm.m, idm.det_z0)

--- a/src/ImpurityDensities/BouleImpurityDensities/ParBouleImpurityDensity.jl
+++ b/src/ImpurityDensities/BouleImpurityDensities/ParBouleImpurityDensity.jl
@@ -18,6 +18,13 @@ struct ParBouleImpurityDensity{T <: SSDFloat} <: AbstractImpurityDensity{T}
     det_z0::T
 end
 
+function ParBouleImpurityDensity{T}(pars::Vector{<:Number}, det_z0::Number) where {T}
+    ParBouleImpurityDensity{T}(
+        T.(to_internal_units(pars))..., 
+        T(to_internal_units(det_z0))
+        )
+end
+
 function ImpurityDensity(T::DataType, t::Val{:parabolic_boule}, dict::AbstractDict, input_units::NamedTuple)
     a::T = haskey(dict, "a") ? _parse_value(T, dict["a"], input_units.length^(-3)) : T(0)
     b::T = haskey(dict, "b") ? _parse_value(T, dict["b"], input_units.length^(-4)) : T(0)
@@ -31,3 +38,5 @@ function get_impurity_density(idm::ParBouleImpurityDensity, pt::AbstractCoordina
     z = cpt[3]
     idm.a + idm.b * (idm.det_z0 - z) + idm.c * (idm.det_z0 - z)^2
 end
+
+(*)(scale::Real, idm::ParBouleImpurityDensity{T}) where {T} = ParBouleImpurityDensity{T}(T(scale*idm.a), T(scale*idm.b), T(scale*idm.c), idm.det_z0)

--- a/src/ImpurityDensities/BouleImpurityDensities/ParExpBouleImpurityDensity.jl
+++ b/src/ImpurityDensities/BouleImpurityDensities/ParExpBouleImpurityDensity.jl
@@ -24,6 +24,13 @@ struct ParExpBouleImpurityDensity{T <: SSDFloat} <: AbstractImpurityDensity{T}
     det_z0::T
 end
 
+function ParExpBouleImpurityDensity{T}(pars::Vector{Number}, det_z0::Number) where {T}
+    ParExpBouleImpurityDensity{T}(
+        T.(to_internal_units(pars))..., 
+        T(to_internal_units(det_z0))
+        )
+end
+
 function ImpurityDensity(T::DataType, t::Val{:parabolic_exponential_boule}, dict::AbstractDict, input_units::NamedTuple)
     a::T = haskey(dict, "a") ? _parse_value(T, dict["a"], input_units.length^(-3)) : T(0)
     b::T = haskey(dict, "b") ? _parse_value(T, dict["b"], input_units.length^(-4)) : T(0)
@@ -40,3 +47,5 @@ function get_impurity_density(idm::ParExpBouleImpurityDensity, pt::AbstractCoord
     z = cpt[3]
     idm.a + idm.b * (idm.det_z0 - z) + idm.c * (idm.det_z0 - z)^2 + idm.n * exp((idm.det_z0 - z - idm.l)/idm.m)
 end
+
+(*)(scale::Real, idm::ParExpBouleImpurityDensity{T}) where {T} = ParExpBouleImpurityDensity{T}(T(scale*idm.a), T(scale*idm.b), T(scale*idm.c), T(scale*idm.n), idm.l, idm.m, idm.det_z0)

--- a/src/ImpurityDensities/ConstantImpurityDensity.jl
+++ b/src/ImpurityDensities/ConstantImpurityDensity.jl
@@ -30,3 +30,5 @@ function ImpurityDensity(T::DataType, t::Val{:constant}, dict::AbstractDict, inp
     ρ::T = haskey(dict, "value") ? _parse_value(T, dict["value"], input_units.length^(-3)) : T(0)
     ConstantImpurityDensity{T}( ρ )
 end
+
+(*)(scale::Real, lcdm::ConstantImpurityDensity{T}) where {T} = ConstantImpurityDensity{T}(T(scale * lcdm.ρ))

--- a/src/ImpurityDensities/CylindricalImpurityDensity.jl
+++ b/src/ImpurityDensities/CylindricalImpurityDensity.jl
@@ -52,3 +52,5 @@ function get_impurity_density(lcdm::CylindricalImpurityDensity{T}, pt::AbstractC
     end
     return ρ
 end
+
+(*)(scale::Real, lcdm::CylindricalImpurityDensity{T}) where {T} = CylindricalImpurityDensity{T}(T.(scale .* lcdm.offsets), T.(scale .* lcdm.gradients))

--- a/src/ImpurityDensities/ImpurityDensities.jl
+++ b/src/ImpurityDensities/ImpurityDensities.jl
@@ -27,7 +27,7 @@ abstract type AbstractImpurityDensity{T <: SSDFloat} end
     return ImpurityDensity(T, Val{Symbol(dict["name"])}(), dict, input_units)
 end
 
-(*)(idm::AbstractImpurityDensity{T}, scale::Real) where {T} = (*)(scale, idm)
+(*)(idm::AbstractImpurityDensity, scale::Real) = (*)(scale, idm)
 
 """
     get_impurity_density(id::AbstractImpurityDensity, pt::AbstractCoordinatePoint)

--- a/src/ImpurityDensities/ImpurityDensities.jl
+++ b/src/ImpurityDensities/ImpurityDensities.jl
@@ -27,6 +27,8 @@ abstract type AbstractImpurityDensity{T <: SSDFloat} end
     return ImpurityDensity(T, Val{Symbol(dict["name"])}(), dict, input_units)
 end
 
+(*)(idm::AbstractImpurityDensity{T}, scale::Real) where {T} = (*)(scale, idm)
+
 """
     get_impurity_density(id::AbstractImpurityDensity, pt::AbstractCoordinatePoint)
     

--- a/src/ImpurityDensities/LinearImpurityDensity.jl
+++ b/src/ImpurityDensities/LinearImpurityDensity.jl
@@ -55,3 +55,5 @@ function get_impurity_density(lcdm::LinearImpurityDensity{T}, pt::AbstractCoordi
     end
     return ρ
 end
+
+(*)(scale::Real, lcdm::LinearImpurityDensity{T}) where {T} = LinearImpurityDensity{T}(T.(scale .* lcdm.offsets), T.(scale .* lcdm.gradients))

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -992,17 +992,18 @@ function _calculate_potential!( sim::Simulation{T, CS}, potential_type::UnionAll
         end
     end
     if verbose && depletion_handling && isEP
+        depletion_tol = 0.1
         maximum_applied_potential = maximum(broadcast(c -> c.potential, sim.detector.contacts))
         minimum_applied_potential = minimum(broadcast(c -> c.potential, sim.detector.contacts))
         @inbounds for i in eachindex(sim.electric_potential.data)
-            if sim.electric_potential.data[i] < minimum_applied_potential # p-type
+            if sim.electric_potential.data[i] < minimum_applied_potential - depletion_tol# p-type
                 @warn """Detector seems not to be fully depleted at a bias voltage of $(bias_voltage) V.
                     At least one grid point has a smaller potential value ($(sim.electric_potential.data[i]) V)
                     than the minimum applied potential ($(minimum_applied_potential) V). This should not be.
                     However, small overshoots could be due to numerical precision."""
                 break
             end
-            if sim.electric_potential.data[i] > maximum_applied_potential # n-type
+            if sim.electric_potential.data[i] > maximum_applied_potential + depletion_tol # n-type
                 @warn """Detector seems not to be not fully depleted at a bias voltage of $(bias_voltage) V.
                     At least one grid point has a higher potential value ($(sim.electric_potential.data[i]) V)
                     than the maximum applied potential ($(maximum_applied_potential) V). This should not be.

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -995,14 +995,14 @@ function _calculate_potential!( sim::Simulation{T, CS}, potential_type::UnionAll
         maximum_applied_potential = maximum(broadcast(c -> c.potential, sim.detector.contacts))
         minimum_applied_potential = minimum(broadcast(c -> c.potential, sim.detector.contacts))
         @inbounds for i in eachindex(sim.electric_potential.data)
-            if sim.electric_potential.data[i] < minimum_applied_potential# p-type
+            if sim.electric_potential.data[i] < minimum_applied_potential # p-type
                 @warn """Detector seems not to be fully depleted at a bias voltage of $(bias_voltage) V.
                     At least one grid point has a smaller potential value ($(sim.electric_potential.data[i]) V)
                     than the minimum applied potential ($(minimum_applied_potential) V). This should not be.
                     However, small overshoots could be due to numerical precision."""
                 break
             end
-            if sim.electric_potential.data[i] > maximum_applied_potential# n-type
+            if sim.electric_potential.data[i] > maximum_applied_potential # n-type
                 @warn """Detector seems not to be not fully depleted at a bias voltage of $(bias_voltage) V.
                     At least one grid point has a higher potential value ($(sim.electric_potential.data[i]) V)
                     than the maximum applied potential ($(maximum_applied_potential) V). This should not be.

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -819,7 +819,7 @@ function _calculate_potential!( sim::Simulation{T, CS}, potential_type::UnionAll
         min_tick_distance::Union{Missing, LengthQuantity, Tuple{LengthQuantity, <:Union{LengthQuantity, AngleQuantity}, LengthQuantity}} = missing,
         max_tick_distance::Union{Missing, LengthQuantity, Tuple{LengthQuantity, <:Union{LengthQuantity, AngleQuantity}, LengthQuantity}} = missing,
         max_distance_ratio::Real = 5,
-        depletion_handling::Bool = false,
+        depletion_handling::Bool = false
         use_nthreads::Union{Int, Vector{Int}} = Base.Threads.nthreads(),
         sor_consts::Union{Missing, <:Real, Tuple{<:Real,<:Real}} = missing,
         max_n_iterations::Int = 50000,
@@ -992,18 +992,17 @@ function _calculate_potential!( sim::Simulation{T, CS}, potential_type::UnionAll
         end
     end
     if verbose && depletion_handling && isEP
-        depletion_tol = 0.1
         maximum_applied_potential = maximum(broadcast(c -> c.potential, sim.detector.contacts))
         minimum_applied_potential = minimum(broadcast(c -> c.potential, sim.detector.contacts))
         @inbounds for i in eachindex(sim.electric_potential.data)
-            if sim.electric_potential.data[i] < minimum_applied_potential - depletion_tol# p-type
+            if sim.electric_potential.data[i] < minimum_applied_potential# p-type
                 @warn """Detector seems not to be fully depleted at a bias voltage of $(bias_voltage) V.
                     At least one grid point has a smaller potential value ($(sim.electric_potential.data[i]) V)
                     than the minimum applied potential ($(minimum_applied_potential) V). This should not be.
                     However, small overshoots could be due to numerical precision."""
                 break
             end
-            if sim.electric_potential.data[i] > maximum_applied_potential + depletion_tol # n-type
+            if sim.electric_potential.data[i] > maximum_applied_potential# n-type
                 @warn """Detector seems not to be not fully depleted at a bias voltage of $(bias_voltage) V.
                     At least one grid point has a higher potential value ($(sim.electric_potential.data[i]) V)
                     than the maximum applied potential ($(maximum_applied_potential) V). This should not be.

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -819,7 +819,7 @@ function _calculate_potential!( sim::Simulation{T, CS}, potential_type::UnionAll
         min_tick_distance::Union{Missing, LengthQuantity, Tuple{LengthQuantity, <:Union{LengthQuantity, AngleQuantity}, LengthQuantity}} = missing,
         max_tick_distance::Union{Missing, LengthQuantity, Tuple{LengthQuantity, <:Union{LengthQuantity, AngleQuantity}, LengthQuantity}} = missing,
         max_distance_ratio::Real = 5,
-        depletion_handling::Bool = false
+        depletion_handling::Bool = false,
         use_nthreads::Union{Int, Vector{Int}} = Base.Threads.nthreads(),
         sor_consts::Union{Missing, <:Real, Tuple{<:Real,<:Real}} = missing,
         max_n_iterations::Int = 50000,

--- a/src/SolidStateDetectors.jl
+++ b/src/SolidStateDetectors.jl
@@ -58,7 +58,7 @@ import TypedTables
 
 import Base: size, sizeof, length, getindex, setindex!, axes, getproperty, broadcast,
              range, ndims, eachindex, enumerate, iterate, IndexStyle, eltype, in, convert,
-             show, print, println, display, +, -, &
+             show, print, println, display, +, -, &, *
 
 export SolidStateDetector
 export SSD_examples


### PR DESCRIPTION
User can now construct BouleImpurityDensities from a unitfull vector and value like so:
```julia
idm = LinBouleImpurityDensity{T}(pars::Vector{<:Number}, det_z0::Number)
````
Then units are automatically converted to SSD internal units. 
Scaling of BouleImpurityDensities is also now possible with:

```julia
scale*idm
```
Which will scale the correct parameters in the `BouleImpurityDensity` such the numerical value calculated by get_impurity_density would be scaled accordingly.

I also added a tolerance for the warning when using depletion handling:
`""Detector seems not to be not fully depleted at a bias voltage of""`...
This warning appears almost every time and should be dropped unless it falls out of the given tolerance