### PR TITLE
Corrections for impurity density models

### DIFF
--- a/docs/src/man/electric_potential.md
+++ b/docs/src/man/electric_potential.md
@@ -105,6 +105,47 @@ impurity_density:
 Here, the impurity density at the origin is $10^{10}$cm$^{-3}$ and it increases radially with the gradient $10^{10}$cm$^{-4}$.
 If no units are given, `init` is parsed in units of `units.length`$^{-3}$ and `gradient` in units of `units.length`$^{-4}$.
 
+### Boule Impurity Densities
+
+Boule impurity densities are meant to be used when the impurity density is defined in the boule coordinates, where the z-axis is aligned with the boule growth direction. 
+Different models are provided. In each the field `det_z0` is the z-coordinate of the detector origin in boule coordinates. 
+The z-direction of the detector is opposite to the z-direction of the boule coordinates.
+In this matter the detector impurities are automatically determined from those of the boule, depending on `det_z0`.
+```yaml 
+impurity_density:
+  name: linear_exponential_boule
+  a: -1e10cm^-3
+  b: -1e9cm^-4
+  n: -2e9cm^-3
+  l: 5cm
+  m: 3cm
+  det_z0: 120cm
+```
+In this example, the impurity density is modeled along the boule as a linear plus an exponential term: $a + b*z + n*e^{(z - l)/m}$ with $z$ in boule coordinates. 
+The impurity density of the detector will in turn be modeled by: $a + b*(z_0 - z) + n*e^{(z_0 - z - l)/m}$ with $z$ in detector coordinates.
+If no units are given, `a` and `n` are parsed in units of `units.length`$^{-3}$, `b` in units of `units.length`$^{-4}$ and `l`, `m` and `det_z0` in units of `units.length`.
+
+### Correcting Impurity Densities
+
+When simulating real detectors, the simulated depletion voltage often differs from the measured value. This discrepancy arises primarily from the high uncertainty in impurity density measurements. A straightforward approach to improve the agreement is to apply a scaling factor and an offset to the impurity density. 
+The scaling factor accounts for potential systematic errors in impurity density measurements. 
+The offset is motivated by the thermal release of impurities from deep hole traps, which leads to a shift in the effective impurity density throughout the detector after biasing. In steady-state operation, this effect can be approximated as a uniform offset
+These terms can be added to the configuration file under `corrections`. 
+```yaml 
+impurity_density:
+  name: linear_exponential_boule
+  a: -1e10cm^-3
+  b: -1e9cm^-4
+  n: -2e9cm^-3
+  l: 5cm
+  m: 3cm
+  det_z0: 120cm
+  corrections:
+    scale: 0.9
+    offset: -1e9cm^-3
+```
+If no units are given, `offset` is parsed in units of `units.length`$^{-3}$.
+Corrections can be applied to any impurity density model. Given an originally calculated impurity density $\rho$, the corrected impurity density used in the simulation is $f*\rho+t$ where $f$ and $t$ are the scale and offset respectively.
 
 ### Custom Impurity Density
 

--- a/src/ImpurityDensities/BouleImpurityDensities/LinBouleImpurityDensity.jl
+++ b/src/ImpurityDensities/BouleImpurityDensities/LinBouleImpurityDensity.jl
@@ -37,3 +37,5 @@ function get_impurity_density(idm::LinBouleImpurityDensity, pt::AbstractCoordina
 end
 
 (*)(scale::Real, idm::LinBouleImpurityDensity{T}) where {T} = LinBouleImpurityDensity{T}(T(scale*idm.a), T(scale*idm.b), idm.det_z0)
+
+(+)(offset::Real, idm::LinBouleImpurityDensity{T}) where {T} = LinBouleImpurityDensity{T}(T(offset+idm.a), idm.b, idm.det_z0)

--- a/src/ImpurityDensities/BouleImpurityDensities/LinBouleImpurityDensity.jl
+++ b/src/ImpurityDensities/BouleImpurityDensities/LinBouleImpurityDensity.jl
@@ -38,4 +38,4 @@ end
 
 (*)(scale::Real, idm::LinBouleImpurityDensity{T}) where {T} = LinBouleImpurityDensity{T}(T(scale*idm.a), T(scale*idm.b), idm.det_z0)
 
-(+)(offset::Real, idm::LinBouleImpurityDensity{T}) where {T} = LinBouleImpurityDensity{T}(T(offset+idm.a), idm.b, idm.det_z0)
+(+)(offset::Union{<:Real, <:Quantity{<:Real, Unitful.𝐋^(-3)}}, idm::LinBouleImpurityDensity{T}) where {T} = LinBouleImpurityDensity{T}(T(to_internal_units(offset)+idm.a), idm.b, idm.det_z0)

--- a/src/ImpurityDensities/BouleImpurityDensities/LinExpBouleImpurityDensity.jl
+++ b/src/ImpurityDensities/BouleImpurityDensities/LinExpBouleImpurityDensity.jl
@@ -46,3 +46,5 @@ function get_impurity_density(idm::LinExpBouleImpurityDensity, pt::AbstractCoord
 end
 
 (*)(scale::Real, idm::LinExpBouleImpurityDensity{T}) where {T} = LinExpBouleImpurityDensity{T}(T(scale*idm.a), T(scale*idm.b), T(scale*idm.n), idm.l, idm.m, idm.det_z0)
+
+(+)(offset::Real, idm::LinExpBouleImpurityDensity{T}) where {T} = LinExpBouleImpurityDensity{T}(T(offset+idm.a), idm.b, idm.n, idm.l, idm.m, idm.det_z0)

--- a/src/ImpurityDensities/BouleImpurityDensities/LinExpBouleImpurityDensity.jl
+++ b/src/ImpurityDensities/BouleImpurityDensities/LinExpBouleImpurityDensity.jl
@@ -47,4 +47,4 @@ end
 
 (*)(scale::Real, idm::LinExpBouleImpurityDensity{T}) where {T} = LinExpBouleImpurityDensity{T}(T(scale*idm.a), T(scale*idm.b), T(scale*idm.n), idm.l, idm.m, idm.det_z0)
 
-(+)(offset::Real, idm::LinExpBouleImpurityDensity{T}) where {T} = LinExpBouleImpurityDensity{T}(T(offset+idm.a), idm.b, idm.n, idm.l, idm.m, idm.det_z0)
+(+)(offset::Union{<:Real, <:Quantity{<:Real, Unitful.𝐋^(-3)}}, idm::LinExpBouleImpurityDensity{T}) where {T} = LinExpBouleImpurityDensity{T}(T(to_internal_units(offset)+idm.a), idm.b, idm.n, idm.l, idm.m, idm.det_z0)

--- a/src/ImpurityDensities/BouleImpurityDensities/ParBouleImpurityDensity.jl
+++ b/src/ImpurityDensities/BouleImpurityDensities/ParBouleImpurityDensity.jl
@@ -41,4 +41,4 @@ end
 
 (*)(scale::Real, idm::ParBouleImpurityDensity{T}) where {T} = ParBouleImpurityDensity{T}(T(scale*idm.a), T(scale*idm.b), T(scale*idm.c), idm.det_z0)
 
-(+)(offset::Real, idm::ParBouleImpurityDensity{T}) where {T} = ParBouleImpurityDensity{T}(T(offset+idm.a), idm.b, idm.c, idm.det_z0)
+(+)(offset::Union{<:Real, <:Quantity{<:Real, Unitful.𝐋^(-3)}}, idm::ParBouleImpurityDensity{T}) where {T} = ParBouleImpurityDensity{T}(T(to_internal_units(offset)+idm.a), idm.b, idm.c, idm.det_z0)

--- a/src/ImpurityDensities/BouleImpurityDensities/ParBouleImpurityDensity.jl
+++ b/src/ImpurityDensities/BouleImpurityDensities/ParBouleImpurityDensity.jl
@@ -40,3 +40,5 @@ function get_impurity_density(idm::ParBouleImpurityDensity, pt::AbstractCoordina
 end
 
 (*)(scale::Real, idm::ParBouleImpurityDensity{T}) where {T} = ParBouleImpurityDensity{T}(T(scale*idm.a), T(scale*idm.b), T(scale*idm.c), idm.det_z0)
+
+(+)(offset::Real, idm::ParBouleImpurityDensity{T}) where {T} = ParBouleImpurityDensity{T}(T(offset+idm.a), idm.b, idm.c, idm.det_z0)

--- a/src/ImpurityDensities/BouleImpurityDensities/ParExpBouleImpurityDensity.jl
+++ b/src/ImpurityDensities/BouleImpurityDensities/ParExpBouleImpurityDensity.jl
@@ -50,4 +50,4 @@ end
 
 (*)(scale::Real, idm::ParExpBouleImpurityDensity{T}) where {T} = ParExpBouleImpurityDensity{T}(T(scale*idm.a), T(scale*idm.b), T(scale*idm.c), T(scale*idm.n), idm.l, idm.m, idm.det_z0)
 
-(+)(offset::Real, idm::ParExpBouleImpurityDensity{T}) where {T} = ParExpBouleImpurityDensity{T}(T(offset+idm.a), idm.b, idm.c, idm.n, idm.l, idm.m, idm.det_z0)
+(+)(offset::Union{<:Real, <:Quantity{<:Real, Unitful.𝐋^(-3)}}, idm::ParExpBouleImpurityDensity{T}) where {T} = ParExpBouleImpurityDensity{T}(T(to_internal_units(offset)+idm.a), idm.b, idm.c, idm.n, idm.l, idm.m, idm.det_z0)

--- a/src/ImpurityDensities/BouleImpurityDensities/ParExpBouleImpurityDensity.jl
+++ b/src/ImpurityDensities/BouleImpurityDensities/ParExpBouleImpurityDensity.jl
@@ -49,3 +49,5 @@ function get_impurity_density(idm::ParExpBouleImpurityDensity, pt::AbstractCoord
 end
 
 (*)(scale::Real, idm::ParExpBouleImpurityDensity{T}) where {T} = ParExpBouleImpurityDensity{T}(T(scale*idm.a), T(scale*idm.b), T(scale*idm.c), T(scale*idm.n), idm.l, idm.m, idm.det_z0)
+
+(+)(offset::Real, idm::ParExpBouleImpurityDensity{T}) where {T} = ParExpBouleImpurityDensity{T}(T(offset+idm.a), idm.b, idm.c, idm.n, idm.l, idm.m, idm.det_z0)

--- a/src/ImpurityDensities/ConstantImpurityDensity.jl
+++ b/src/ImpurityDensities/ConstantImpurityDensity.jl
@@ -33,4 +33,4 @@ end
 
 (*)(scale::Real, lcdm::ConstantImpurityDensity{T}) where {T} = ConstantImpurityDensity{T}(T(scale * lcdm.ρ))
 
-(+)(offset::Real, lcdm::ConstantImpurityDensity{T}) where {T} = ConstantImpurityDensity{T}(T(offset + lcdm.ρ))
+(+)(offset::Union{<:Real, <:Quantity{<:Real, Unitful.𝐋^(-3)}}, lcdm::ConstantImpurityDensity{T}) where {T} = ConstantImpurityDensity{T}(T(to_internal_units(offset) + lcdm.ρ))

--- a/src/ImpurityDensities/ConstantImpurityDensity.jl
+++ b/src/ImpurityDensities/ConstantImpurityDensity.jl
@@ -32,3 +32,5 @@ function ImpurityDensity(T::DataType, t::Val{:constant}, dict::AbstractDict, inp
 end
 
 (*)(scale::Real, lcdm::ConstantImpurityDensity{T}) where {T} = ConstantImpurityDensity{T}(T(scale * lcdm.ρ))
+
+(+)(offset::Real, lcdm::ConstantImpurityDensity{T}) where {T} = ConstantImpurityDensity{T}(T(offset + lcdm.ρ))

--- a/src/ImpurityDensities/CylindricalImpurityDensity.jl
+++ b/src/ImpurityDensities/CylindricalImpurityDensity.jl
@@ -54,3 +54,5 @@ function get_impurity_density(lcdm::CylindricalImpurityDensity{T}, pt::AbstractC
 end
 
 (*)(scale::Real, lcdm::CylindricalImpurityDensity{T}) where {T} = CylindricalImpurityDensity{T}(T.(scale .* lcdm.offsets), T.(scale .* lcdm.gradients))
+
+(+)(offset::Real, lcdm::CylindricalImpurityDensity{T}) where {T} = CylindricalImpurityDensity{T}(T.(offset .+ lcdm.offsets), lcdm.gradients)

--- a/src/ImpurityDensities/CylindricalImpurityDensity.jl
+++ b/src/ImpurityDensities/CylindricalImpurityDensity.jl
@@ -55,4 +55,4 @@ end
 
 (*)(scale::Real, lcdm::CylindricalImpurityDensity{T}) where {T} = CylindricalImpurityDensity{T}(T.(scale .* lcdm.offsets), T.(scale .* lcdm.gradients))
 
-(+)(offset::Real, lcdm::CylindricalImpurityDensity{T}) where {T} = CylindricalImpurityDensity{T}(T.(offset .+ lcdm.offsets), lcdm.gradients)
+(+)(offset::Union{<:Real, <:Quantity{<:Real, Unitful.𝐋^(-3)}}, lcdm::CylindricalImpurityDensity{T}) where {T} = CylindricalImpurityDensity{T}(T.(to_internal_units(offset) .+ lcdm.offsets), lcdm.gradients)

--- a/src/ImpurityDensities/ImpurityDensities.jl
+++ b/src/ImpurityDensities/ImpurityDensities.jl
@@ -28,7 +28,7 @@ abstract type AbstractImpurityDensity{T <: SSDFloat} end
 end
 
 (*)(idm::AbstractImpurityDensity, scale::Real) = (*)(scale, idm)
-(+)(idm::AbstractImpurityDensity, offset::Real) = (+)(offset, idm)
+(+)(idm::AbstractImpurityDensity, offset::Union{<:Real, <:Quantity{<:Real, Unitful.𝐋^(-3)}}) = (+)(offset, idm)
 
 """
     get_impurity_density(id::AbstractImpurityDensity, pt::AbstractCoordinatePoint)

--- a/src/ImpurityDensities/ImpurityDensities.jl
+++ b/src/ImpurityDensities/ImpurityDensities.jl
@@ -28,6 +28,7 @@ abstract type AbstractImpurityDensity{T <: SSDFloat} end
 end
 
 (*)(idm::AbstractImpurityDensity, scale::Real) = (*)(scale, idm)
+(+)(idm::AbstractImpurityDensity, offset::Real) = (*)(offset, idm)
 
 """
     get_impurity_density(id::AbstractImpurityDensity, pt::AbstractCoordinatePoint)

--- a/src/ImpurityDensities/ImpurityDensities.jl
+++ b/src/ImpurityDensities/ImpurityDensities.jl
@@ -28,7 +28,7 @@ abstract type AbstractImpurityDensity{T <: SSDFloat} end
 end
 
 (*)(idm::AbstractImpurityDensity, scale::Real) = (*)(scale, idm)
-(+)(idm::AbstractImpurityDensity, offset::Real) = (*)(offset, idm)
+(+)(idm::AbstractImpurityDensity, offset::Real) = (+)(offset, idm)
 
 """
     get_impurity_density(id::AbstractImpurityDensity, pt::AbstractCoordinatePoint)

--- a/src/ImpurityDensities/LinearImpurityDensity.jl
+++ b/src/ImpurityDensities/LinearImpurityDensity.jl
@@ -57,3 +57,5 @@ function get_impurity_density(lcdm::LinearImpurityDensity{T}, pt::AbstractCoordi
 end
 
 (*)(scale::Real, lcdm::LinearImpurityDensity{T}) where {T} = LinearImpurityDensity{T}(T.(scale .* lcdm.offsets), T.(scale .* lcdm.gradients))
+
+(+)(offset::Real, lcdm::LinearImpurityDensity{T}) where {T} = LinearImpurityDensity{T}(T.(offset .+ lcdm.offsets), lcdm.gradients)

--- a/src/ImpurityDensities/LinearImpurityDensity.jl
+++ b/src/ImpurityDensities/LinearImpurityDensity.jl
@@ -58,4 +58,4 @@ end
 
 (*)(scale::Real, lcdm::LinearImpurityDensity{T}) where {T} = LinearImpurityDensity{T}(T.(scale .* lcdm.offsets), T.(scale .* lcdm.gradients))
 
-(+)(offset::Real, lcdm::LinearImpurityDensity{T}) where {T} = LinearImpurityDensity{T}(T.(offset .+ lcdm.offsets), lcdm.gradients)
+(+)(offset::Union{<:Real, <:Quantity{<:Real, Unitful.𝐋^(-3)}}, lcdm::LinearImpurityDensity{T}) where {T} = LinearImpurityDensity{T}(T.(to_internal_units(offset) .+ lcdm.offsets), lcdm.gradients)

--- a/src/SolidStateDetector/Semiconductor.jl
+++ b/src/SolidStateDetector/Semiconductor.jl
@@ -51,7 +51,10 @@ end
 function Semiconductor{T}(dict::AbstractDict, input_units::NamedTuple, outer_transformations) where T <: SSDFloat
 
     impurity_density_model = if haskey(dict, "impurity_density") 
-        ImpurityDensity(T, dict["impurity_density"], input_units)
+        hascorrections = haskey(dict["impurity_density"], "corrections")
+        impurity_density_scale = hascorrections && haskey(dict["impurity_density"]["corrections"], "scale") ? _parse_value(T, dict["impurity_density"]["corrections"]["scale"], NoUnits) : T(1)
+        impurity_density_offset = hascorrections && haskey(dict["impurity_density"]["corrections"], "offset") ? _parse_value(T, dict["impurity_density"]["corrections"]["offset"], input_units.length^(-3)) : T(0)
+        impurity_density_scale * ImpurityDensity(T, dict["impurity_density"], input_units) + impurity_density_offset
     elseif haskey(dict, "charge_density_model") 
         @warn "Config file deprication: The field \"charge_density_model\" under semiconductor is deprecated. 
             It should be changed to \"impurity_density\". In later version this will result in an error.

--- a/src/SolidStateDetector/Semiconductor.jl
+++ b/src/SolidStateDetector/Semiconductor.jl
@@ -52,8 +52,8 @@ function Semiconductor{T}(dict::AbstractDict, input_units::NamedTuple, outer_tra
 
     impurity_density_model = if haskey(dict, "impurity_density") 
         hascorrections = haskey(dict["impurity_density"], "corrections")
-        impurity_density_scale = hascorrections && haskey(dict["impurity_density"]["corrections"], "scale") ? _parse_value(T, dict["impurity_density"]["corrections"]["scale"], NoUnits) : T(1)
-        impurity_density_offset = hascorrections && haskey(dict["impurity_density"]["corrections"], "offset") ? _parse_value(T, dict["impurity_density"]["corrections"]["offset"], input_units.length^(-3)) : T(0)
+        impurity_density_scale = hascorrections ? _parse_value(T, get(dict["impurity_density"]["corrections"], "scale", 1), NoUnits) : T(1)
+        impurity_density_offset = hascorrections ? _parse_value(T, get(dict["impurity_density"]["corrections"], "offset", 0), input_units.length^(-3)) : T(0)
         impurity_density_scale * ImpurityDensity(T, dict["impurity_density"], input_units) + impurity_density_offset
     elseif haskey(dict, "charge_density_model") 
         @warn "Config file deprication: The field \"charge_density_model\" under semiconductor is deprecated. 

--- a/test/BEGe_01.yaml
+++ b/test/BEGe_01.yaml
@@ -30,6 +30,9 @@ detectors:
     impurity_density:
       name: constant
       value: -5e9cm^-3
+      corrections:
+        scale: 0.8
+        offset: -5e8cm^-3
     geometry:
       translate:
         tube:

--- a/test/test_boule_impurity_densities.jl
+++ b/test/test_boule_impurity_densities.jl
@@ -6,7 +6,7 @@ T = Float32
 @timed_testset "Test boule impurity densities and corrections" begin
     sim = Simulation{T}("BEGe_01.yaml")
 
-    @test SolidStateDetectors.get_impurity_density(sim.detector.semiconductor.impurity_density_model, CylindricalPoint{T}(0,0,0)) == T(0.8*SolidStateDetectors.to_internal_units(-5e9u"cm^-3") + SolidStateDetectors.to_internal_units(-5e8u"cm^-3"))
+    @test SolidStateDetectors.get_impurity_density(sim.detector.semiconductor.impurity_density_model, CylindricalPoint{T}(0,0,0)) == T(0.8*T(SolidStateDetectors.to_internal_units(-5e9u"cm^-3")) + T(SolidStateDetectors.to_internal_units(-5e8u"cm^-3")))
 
     det_z0 = T(0.12)
     boule_ρ0 = T(-1e16)

--- a/test/test_boule_impurity_densities.jl
+++ b/test/test_boule_impurity_densities.jl
@@ -3,8 +3,11 @@ using Test
 
 T = Float32
 
-@timed_testset "Test boule impurity densities" begin
+@timed_testset "Test boule impurity densities and corrections" begin
     sim = Simulation{T}("BEGe_01.yaml")
+
+    @test SolidStateDetectors.get_impurity_density(sim.detector.semiconductor.impurity_density_model, CylindricalPoint{T}(0,0,0)) == T(0.8*SolidStateDetectors.to_internal_units(-5e9u"cm^-3") + SolidStateDetectors.to_internal_units(-5e8u"cm^-3"))
+
     det_z0 = T(0.12)
     boule_ρ0 = T(-1e16)
     boule_gradient = T(-1e17)


### PR DESCRIPTION
When simulating real detectors, the simulated depletion voltage often differs from the measured value. This discrepancy arises primarily from the high uncertainty in impurity density measurements. A straightforward approach to improve the agreement is to apply a scaling factor and an offset to the impurity density. 

- The scaling factor accounts for potential systematic errors in impurity density measurements. 
- The offset is motivated by the thermal release of impurities from deep hole traps, which leads to a shift in the effective impurity density throughout the detector after biasing. In steady-state operation, this effect can be approximated as a uniform offset

With this PR, these terms can be added to the configuration file under `corrections` like so:
```yaml 
impurity_density:
  name: linear_exponential_boule
  a: -1e10cm^-3
  b: -1e9cm^-4
  n: -2e9cm^-3
  l: 5cm
  m: 3cm
  det_z0: 120cm
  corrections:
    scale: 0.9
    offset: -1e9cm^-3
```

One test was added and documentation was added to the manual.