### PR TITLE
Add support for simulation for dead layer-Step4: impurity model based on the lithium thermal diffusion process

### DIFF
--- a/docs/src/man/electric_potential.md
+++ b/docs/src/man/electric_potential.md
@@ -105,6 +105,25 @@ impurity_density:
 Here, the impurity density at the origin is $10^{10}$cm$^{-3}$ and it increases radially with the gradient $10^{10}$cm$^{-4}$.
 If no units are given, `init` is parsed in units of `units.length`$^{-3}$ and `gradient` in units of `units.length`$^{-4}$.
 
+### P-type PN junction Impurity Density
+A PN junctin impurity model based on lithium thermal diffusion and constant bulk impurity density. The surface lithium density is saturated.
+ref: [Dai _et al._ (2023)](https://doi.org/10.1016/j.apradiso.2022.110638)
+
+This density model could be defined in the code: 
+```julia
+T = Float64
+sim = Simulation{T}(SSD_examples[:TrueCoaxial])
+
+calculate_depth2surface = pt -> 0.01-hypot(pt[1], pt[2])
+Li_annealing_temperature::T=623
+Li_annealing_time::T=18*60
+Bulk_Impurity = p_type_density = -1e10 * 1e6
+
+pn_junction_impurity_density = PtypePNJunctionImpurityDensity{T}(Li_annealing_temperature, Li_annealing_time, calculate_depth2surface, p_type_density)
+sim.detector = SolidStateDetector(sim.detector, pn_junction_impurity_density)
+```
+
+This model couldn't be defined in the configuration because a depth2surface function is needed, except when using the public_TrueCoaxial.yaml.
 
 ### Custom Impurity Density
 

--- a/examples/example_config_files/public_TrueCoaxial.yaml
+++ b/examples/example_config_files/public_TrueCoaxial.yaml
@@ -26,10 +26,12 @@ medium: vacuum
 detectors:
 - semiconductor:
     material: HPGe
-    temperature: 77
+    temperature: 90
     impurity_density:
-      name: constant
-      value: 1e8cm^-3
+      name: PtypePNjunction
+      Li_annealing_temperature: 623
+      Li_annealing_time: 1080
+      bulk_imp: -1e10cm^-3
     charge_drift_model:
       include: ADLChargeDriftModel/drift_velocity_config.yaml
     charge_trapping_model:
@@ -37,12 +39,12 @@ detectors:
       parameters:
         τh: 1ms
         τe: 1ms
-        τh_inactive: 80ns
-        τe_inactive: 80ns
+        τh_inactive: 1μs
+        τe_inactive: 1μs
       inactive_layer_geometry:
         tube:
           r:
-            from: 9.0
+            from: 8.957282
             to: 10.0
           h: 10.0
           origin:
@@ -56,19 +58,19 @@ detectors:
         origin:
           z: 5.0
   contacts:
-    - name: "P+"
+    - name: "P⁺"
       id: 1
       material: HPGe
       potential: -500
       geometry:
         tube:
           r:
-            from: 0.5
+            from: 1.0
             to: 1.0
           h: 10.0
           origin:
             z: 5.0
-    - name: "N+"
+    - name: "N⁺"
       id: 2
       material: HPGe
       potential: 0

--- a/src/ImpurityDensities/ImpurityDensities.jl
+++ b/src/ImpurityDensities/ImpurityDensities.jl
@@ -47,3 +47,6 @@ include("LinearImpurityDensity.jl")
 include("CylindricalImpurityDensity.jl")
 
 include("BouleImpurityDensities/BouleImpurityDensities.jl")
+
+include("ThermalDiffusionLithiumDensity.jl")
+include("PtypePNJunctionImpurityDensity.jl")

--- a/src/ImpurityDensities/PtypePNJunctionImpurityDensity.jl
+++ b/src/ImpurityDensities/PtypePNJunctionImpurityDensity.jl
@@ -1,0 +1,59 @@
+"""
+    struct ThermalDiffusionLithiumDensity{T <: SSDFloat} <: AbstractImpurityDensity{T}
+
+A PN junctin impurity model based on lithium thermal diffusion and constant bulk impurity density.
+The surface lithium density is saturated.
+
+ref: [Dai _et al._ (2023)](https://doi.org/10.1016/j.apradiso.2022.110638)
+ 
+## Fields
+* `Li_annealing_temperature::T`: lithium annealing temperature when the lithium is diffused into the crystal. The default value is 623 K.
+* `Li_annealing_time::T`: lithium annealing time. The default value is 18 minutes.
+* `calculate_depth2surface::Function`: the function for describing the depth to surface.
+* `bulk_imp::T`: the bulk impurity density constant.
+* `bulk/surface_imp_model::T`: there two variables will be constructed with above parameters.
+"""
+
+struct PtypePNJunctionImpurityDensity{T <: SSDFloat} <: AbstractImpurityDensity{T}
+	Li_annealing_temperature::T
+	Li_annealing_time::T
+    calculate_depth2surface::Function
+    bulk_imp::T
+    surface_imp_model::ThermalDiffusionLithiumDensity{T}
+    bulk_imp_model::ConstantImpurityDensity{T}
+end
+function PtypePNJunctionImpurityDensity{T}(Li_annealing_temperature::T,
+    Li_annealing_time::T,
+    calculate_depth2surface::Function,
+    bulk_imp::T
+    ) where {T <: SSDFloat}
+    bulk_imp_model = ConstantImpurityDensity{T}(bulk_imp)
+    surface_imp_model = ThermalDiffusionLithiumDensity{T}(Li_annealing_temperature, Li_annealing_time, calculate_depth2surface)
+    PtypePNJunctionImpurityDensity(Li_annealing_temperature,Li_annealing_time,calculate_depth2surface, bulk_imp, surface_imp_model, bulk_imp_model)
+end
+
+function ImpurityDensity(T::DataType, t::Val{:PtypePNjunction}, dict::AbstractDict, input_units::NamedTuple)
+    Li_annealing_temperature = T(623)
+    Li_annealing_time= T(18*60)
+    calculate_depth2surface = pt->0.01-hypot(pt[1],pt[2]) # default for the public_TrueCoaxial.yaml
+    bulk_imp = T(-1e16)
+
+    if haskey(dict, "Li_annealing_temperature")
+        Li_annealing_temperature = _parse_value(T, dict["Li_annealing_temperature"], u"K")
+    end
+    if haskey(dict, "Li_annealing_time")
+        Li_annealing_time = _parse_value(T, dict["Li_annealing_time"], u"s")
+    end
+    if haskey(dict, "calculate_depth2surface")
+        calculate_depth2surface = dict["calculate_depth2surface"]
+    end
+    if haskey(dict, "bulk_imp")
+        bulk_imp = _parse_value(T, dict["bulk_imp"], input_units.length^(-3))
+    end
+
+    PtypePNJunctionImpurityDensity{T}(Li_annealing_temperature, Li_annealing_time, calculate_depth2surface, bulk_imp)
+end
+
+function get_impurity_density(PtypePNjunction::PtypePNJunctionImpurityDensity{T}, pt::AbstractCoordinatePoint{T})::T where {T <: SSDFloat}
+    get_impurity_density(PtypePNjunction.bulk_imp_model, pt)+get_impurity_density(PtypePNjunction.surface_imp_model, pt)
+end

--- a/src/ImpurityDensities/ThermalDiffusionLithiumDensity.jl
+++ b/src/ImpurityDensities/ThermalDiffusionLithiumDensity.jl
@@ -1,0 +1,68 @@
+"""
+    struct ThermalDiffusionLithiumDensity{T <: SSDFloat} <: AbstractImpurityDensity{T}
+
+Lithium impurity density model
+
+ref: [Dai _et al._ (2023)](https://doi.org/10.1016/j.apradiso.2022.110638)
+ 
+## Fields
+* `Li_annealing_temperature::T`: lithium annealing temperature when the lithium is diffused into the crystal. The default value is 623 K.
+* `Li_annealing_time::T`: lithium annealing time. The default value is 18 minutes.
+* `calculate_depth2surface::Function`: the function for describing the depth to surface
+* `Li_surface::T`: the lithium concentration in the surface
+* `D_Li::T`: the diffusivity of lithium in germanium
+"""
+
+struct ThermalDiffusionLithiumDensity{T <: SSDFloat} <: AbstractImpurityDensity{T}
+	Li_annealing_temperature::T # in K
+	Li_annealing_time::T # in s
+    calculate_depth2surface::Function # pt -> depth (depth in m)
+	Li_surface::T # in m^-3
+    D_Li::T # in m^2*s^-1
+end
+function calculate_D_Li(Li_annealing_temperature::T)::T where {T <: SSDFloat}
+    if Li_annealing_temperature<=873
+        D0 = 2.5e-3*1e-4 # m^2*s^-1
+        H = 11800 # cal
+    else
+        D0 = 1.3e-3*1e-4
+        H = 10700
+    end
+    D_Li = D0 * exp(-H/(R_gas*Li_annealing_temperature))
+    D_Li
+end
+function calculate_Li_surface_saturated_density(Li_annealing_temperature::T)::T where {T <: SSDFloat}
+    10^(21.27 - 2610.0/(Li_annealing_temperature)) * 1e6 # m^-3
+end
+function ThermalDiffusionLithiumDensity{T}(Li_annealing_temperature::T,
+    Li_annealing_time::T,
+    calculate_depth2surface::Function,
+    Li_surface::T=calculate_Li_surface_saturated_density(Li_annealing_temperature),
+    D_Li::T=calculate_D_Li(Li_annealing_temperature)
+    ) where {T <: SSDFloat}
+    ThermalDiffusionLithiumDensity(Li_annealing_temperature,Li_annealing_time,calculate_depth2surface, Li_surface, D_Li)
+end
+
+function ImpurityDensity(T::DataType, t::Val{:tdld}, dict::AbstractDict, input_units::NamedTuple)
+    Li_annealing_temperature = T(623)
+    Li_annealing_time= T(18*60)
+    calculate_depth2surface = pt->0.001
+
+    if haskey(dict, "Li_annealing_temperature")
+        Li_annealing_temperature = _parse_value(T, dict["Li_annealing_temperature"], u"K")
+    end
+    if haskey(dict, "Li_annealing_time")
+        Li_annealing_time = _parse_value(T, dict["Li_annealing_time"], u"s")
+    end
+    if haskey(dict, "calculate_depth2surface")
+        calculate_depth2surface = dict["calculate_depth2surface"]
+    end
+
+    ThermalDiffusionLithiumDensity{T}(Li_annealing_temperature, Li_annealing_time, calculate_depth2surface)
+end
+
+function get_impurity_density(tdld::ThermalDiffusionLithiumDensity{T}, pt::AbstractCoordinatePoint{T})::T where {T <: SSDFloat}
+    pt::CartesianPoint{T} = CartesianPoint(pt)
+    depth = tdld.calculate_depth2surface(pt)
+	tdld.Li_surface * Distributions.erfc(depth/2/sqrt(tdld.D_Li*tdld.Li_annealing_time))
+end

--- a/src/MaterialProperties/MaterialProperties.jl
+++ b/src/MaterialProperties/MaterialProperties.jl
@@ -5,6 +5,7 @@ const elementary_charge = Float64(ustrip(u"C", Unitful.q))
 const ϵ0 = Float64(ustrip(u"F/m", Unitful.ϵ0))
 const kB = Float64(ustrip(u"J/K", Unitful.k))
 const me = Float64(ustrip(u"kg", Unitful.me))
+const R_gas = Float64(ustrip(u"cal/K/mol", Unitful.R))
 
 const material_properties = Dict{Symbol, NamedTuple}()
 

--- a/src/SolidStateDetectors.jl
+++ b/src/SolidStateDetectors.jl
@@ -77,7 +77,7 @@ export Simulation, simulate!
 export Event, drift_charges!
 export add_baseline_and_extend_tail
 export NBodyChargeCloud
-export LinearImpurityDensity, LinBouleImpurityDensity, LinExpBouleImpurityDensity
+export LinearImpurityDensity, LinBouleImpurityDensity, LinExpBouleImpurityDensity, ThermalDiffusionLithiumDensity, PtypePNJunctionImpurityDensity
 
 using Unitful: RealOrRealQuantity as RealQuantity
 const SSDFloat = Union{Float16, Float32, Float64}


### PR DESCRIPTION
A PN junction impurity model based on lithium thermal diffusion and constant bulk impurity density.

Test:
Use the example yaml-TrueCoaxial and apply this impurity model:
<img width="511" alt="image" src="https://github.com/user-attachments/assets/88327f2a-803d-47d4-9993-8af33440078b" />


Code for test:
```julia
using Revise
using Pkg
using Plots
using Unitful
Pkg.develop(path = "./SolidStateDetectors.jl")
using SolidStateDetectors

T = Float64
mm = T(1 / 1000)
det_z = det_r = 10 * mm
pn_r = 8.957282 * mm
sim = Simulation{T}(SSD_examples[:TrueCoaxial])

calculate_electric_potential!(sim, max_n_iterations = 10, grid = Grid(sim), verbose = false, depletion_handling = true)
g = sim.electric_potential.grid
ax1, ax2, ax3 = g.axes
bulk_tick_dis = 0.05 * mm
dl_tick_dis = 0.01 * mm
user_additional_ticks_ax1 = sort(vcat(ax1.interval.left:bulk_tick_dis:pn_r, pn_r:dl_tick_dis:ax1.interval.right))
user_ax1 = typeof(ax1)(ax1.interval, user_additional_ticks_ax1)
user_g = typeof(g)((user_ax1, ax2, ax3))
calculate_electric_potential!(sim, refinement_limits = 0.1, use_nthreads = 8, grid = user_g, depletion_handling = true)

z_draw = det_z / 2
plot(sim.imp_scale, y = z_draw, xunit = u"mm", yunit = u"mm", title = "")
vline!([pn_r / mm], lw = 2, ls = :dash, color = :darkred, label = "PN junction boundary")
```