### PR TITLE
Add support for simulation for dead layer: optimization, more geometry support, tutorials, etc

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -47,7 +47,8 @@ makedocs(
         "Tutorials" => [
             "tutorials/complete_simulation_chain_IVC.md",
             "tutorials/custom_impurity_density_pn_junction.md",
-            "tutorials/geant4_ssd.md"
+            "tutorials/geant4_ssd.md",
+            "tutorials/dead_layer_simulation.md"
         ],
         "API" => "api.md",
         "LICENSE" => "LICENSE.md",

--- a/docs/src/man/charge_drift.md
+++ b/docs/src/man/charge_drift.md
@@ -165,6 +165,12 @@ detectors:
         value: 5.6769e15cm^-3
 ```
 
+The `charge_drift_model` needs:
+- `model`: the name of the charge drift model, which in this case is `InactiveLayerChargeDriftModel`
+- `temperature`: the crystal temperature
+- `bulk_impurity_density`: the density of the p-type impurity in the crystal
+- `surface_impurity_density`: the density profile of lithium (n-type) in the surface layer
+- `neutral_impurity_density`: the density profile of the non-ionized impurity in the crystal
 
 ### Custom Charge Drift Model
 

--- a/docs/src/man/charge_drift.md
+++ b/docs/src/man/charge_drift.md
@@ -166,11 +166,11 @@ detectors:
 ```
 
 The `charge_drift_model` needs:
-- `model`: the name of the charge drift model, which in this case is `InactiveLayerChargeDriftModel`
-- `temperature`: the crystal temperature
+- `model`: the name of the charge drift model, which in this case is `InactiveLayerChargeDriftModel`.
+- `temperature`: the crystal temperature.
 - `bulk_impurity_density` (optional): the density of the p-type impurity in the crystal.
-- `surface_impurity_density` (optional): the density profile of lithium (n-type) in the surface layer
-- `neutral_impurity_density`: the density profile of the non-ionized impurity in the crystal
+- `surface_impurity_density` (optional): the density profile of lithium (n-type) in the surface layer.
+- `neutral_impurity_density`: the density profile of the non-ionized impurity in the crystal.
 
 > Note that the fields `bulk_impurity_density` and `surface_impurity_density` do not need to be explicitly defined if `PtypePNJunctionImpurityDensity` is chosen as the overall impurity density profile.
 

--- a/docs/src/man/charge_drift.md
+++ b/docs/src/man/charge_drift.md
@@ -135,6 +135,37 @@ If no temperature is given as a parameter, the calculations will be performed at
 It should be noted that the correct model has not yet been identified, and the parameters inside these configuration files -besides the default ADL ones- are just educated guesses.
 
 
+### Inactive Layer Charge Drift Model
+
+The [`InactiveLayerChargeDriftModel`](@ref) describes a system in which electrons and holes move along the electric field lines. The mobilities for electrons and holes are scalar ($+$ for holes, and $-$ for electrons), and thus, the velocity field has the same (or opposite) direction as the electric field.
+
+The mobilities are calculated considering three major scattering process: scattering off ionized impurities, neutral impurities and acoustic phonons. Thus, the mobilities depend on the impurity concentrations and temperature.
+
+The precision of the the calculation `T` (`Float32` or `Float64`) has to be given as a keyword `T`. Note that `T` has to be of the same type as the chosen in the simulation:
+
+The `InactiveLayerChargeDriftModel` can be specified in the configuration file as field `charge_drift_model` of the `semiconductor` of a detector, e.g.
+
+```yaml 
+detectors:
+  semiconductor:
+    # ...
+    charge_drift_model:
+      model: InactiveLayerChargeDriftModel
+      temperature: 90K
+      bulk_impurity_density:
+        name: constant
+        value: -1e10cm^-3
+      surface_impurity_density:
+        name: li_diffusion
+        lithium_annealing_temperature: 623K
+        lithium_annealing_time: 18minute
+        doped_contact_id: 2
+      neutral_impurity_density:
+        name: constant
+        value: 5.6769e15cm^-3
+```
+
+
 ### Custom Charge Drift Model
 
 The user can implement and use his own drift model.

--- a/docs/src/man/charge_drift.md
+++ b/docs/src/man/charge_drift.md
@@ -168,9 +168,11 @@ detectors:
 The `charge_drift_model` needs:
 - `model`: the name of the charge drift model, which in this case is `InactiveLayerChargeDriftModel`
 - `temperature`: the crystal temperature
-- `bulk_impurity_density`: the density of the p-type impurity in the crystal
-- `surface_impurity_density`: the density profile of lithium (n-type) in the surface layer
+- `bulk_impurity_density` (optional): the density of the p-type impurity in the crystal.
+- `surface_impurity_density` (optional): the density profile of lithium (n-type) in the surface layer
 - `neutral_impurity_density`: the density profile of the non-ionized impurity in the crystal
+
+> We could save the `bulk_impurity_density` and `surface_impurity_density` fields, if the `PtypePNJunctionImpurityDensity` is defined as the overall impurity density profile.
 
 ### Custom Charge Drift Model
 

--- a/docs/src/man/charge_drift.md
+++ b/docs/src/man/charge_drift.md
@@ -172,7 +172,7 @@ The `charge_drift_model` needs:
 - `surface_impurity_density` (optional): the density profile of lithium (n-type) in the surface layer
 - `neutral_impurity_density`: the density profile of the non-ionized impurity in the crystal
 
-> We could save the `bulk_impurity_density` and `surface_impurity_density` fields, if the `PtypePNJunctionImpurityDensity` is defined as the overall impurity density profile.
+> Note that the fields `bulk_impurity_density` and `surface_impurity_density` do not need to be explicitly defined if `PtypePNJunctionImpurityDensity` is chosen as the overall impurity density profile.
 
 ### Custom Charge Drift Model
 

--- a/docs/src/man/charge_drift.md
+++ b/docs/src/man/charge_drift.md
@@ -176,7 +176,7 @@ The `charge_drift_model` needs:
 
 ### Custom Charge Drift Model
 
-The user can implement and use his own drift model.
+The user can implement and use their own drift model.
 
 The first step is to define a `struct` for the model which is a subtype of `SolidStateDetectors.AbstractChargeDriftModel`:
 

--- a/docs/src/man/electric_potential.md
+++ b/docs/src/man/electric_potential.md
@@ -114,8 +114,8 @@ This density model can be defined in the config file, e.g.
 ```yaml
 impurity_density:
   name: PtypePNjunction
-  Li_annealing_temperature: 623K
-  Li_annealing_time: 18minute
+  lithium_annealing_temperature: 623K
+  lithium_annealing_time: 18minute
   doped_contact_id: 2
   bulk_impurity_density:
     name: constant
@@ -134,12 +134,12 @@ T = Float64
 sim = Simulation{T}(SSD_examples[:TrueCoaxial])
 
 distance_to_contact = pt -> 0.01 - hypot(pt[1], pt[2])
-Li_annealing_temperature::T = 623 # Kelvin
-Li_annealing_time::T = 18*60 # seconds
+lithium_annealing_temperature::T = 623 # Kelvin
+lithium_annealing_time::T = 18*60 # seconds
 p_type_density::T = -1e16 # m^-3
 bulk_imp_model = ConstantImpurityDensity{T}(p_type_density)
 
-pn_junction_impurity_density = PtypePNJunctionImpurityDensity{T}(Li_annealing_temperature, Li_annealing_time, nothing, bulk_imp_model, distance_to_contact)
+pn_junction_impurity_density = PtypePNJunctionImpurityDensity{T}(lithium_annealing_temperature, lithium_annealing_time, nothing, bulk_imp_model, distance_to_contact)
 sim.detector = SolidStateDetector(sim.detector, pn_junction_impurity_density)
 ```
 

--- a/docs/src/man/electric_potential.md
+++ b/docs/src/man/electric_potential.md
@@ -107,7 +107,7 @@ If no units are given, `init` is parsed in units of `units.length`$^{-3}$ and `g
 
 ### P-type PN junction Impurity Density
 
-A PN junction impurity model based on lithium thermal diffusion and custom bulk impurity density. The surface lithium density is saturated.
+A PN junction impurity model based on lithium thermal diffusion and custom bulk impurity density. The surface lithium density is at the saturation level.
 ref: [Dai _et al._ (2023)](https://doi.org/10.1016/j.apradiso.2022.110638)
 
 This density model can be defined in the config file, e.g.
@@ -121,8 +121,15 @@ impurity_density:
     name: constant
     value: -1e10cm^-3
 ```
-which defines a detector with a constant p-type impurity density of
-$10^{10}$cm$^{-3}$ and a highly-doped Lithium contact close to the contact with ID 2, created using a lithium annealing temperature of 623K and an annealing time of 18 minutes.
+The `impurity_density` needs:
+- `name`: the name of the impurity density model, which in this case is `PtypePNjunction`.
+- `lithium_annealing_temperature` (optional): lithium annealing temperature, when the lithium is diffused into the crystal. The default value is 623 K.
+- `lithium_annealing_time` (optional): lithium annealing time. The default value is 18 minutes.
+- `doped_contact_id`:  the doped contact id.
+- `bulk_impurity_density`: the density profile of the p-type impurities.
+
+The example above defines a detector with a constant p-type impurity density of
+$10^{10}$cm$^{-3}$ and a highly-doped Lithium contact close to the contact with ID 2, created using a lithium annealing temperature of 623 K and an annealing time of 18 minutes.
 
 It is based on the internal implementation of `distance_to_surface`, which might not work for all combinations of primitives.
 

--- a/docs/src/tutorials/dead_layer_simulation_lit.jl
+++ b/docs/src/tutorials/dead_layer_simulation_lit.jl
@@ -1,9 +1,9 @@
-# # Inactive layer simulation Chain: True coaxial detector
+# # Inactive layer simulation: True coaxial detector
 
 # ## Set the physical models for the inactive layer (dead layer) simulation with YAML
-# - drift model for the inactive layer
-# - constant lifetime trapping model
-# - mobility-tied diffusion model
+# - using drift model for the inactive layer
+# - using constant lifetime trapping model
+# - using mobility-tied diffusion model (by calling the `calculate_mobility` function in the drift model struct)
 
 using Plots
 using Unitful
@@ -15,7 +15,7 @@ mm=T(1/1000)
 det_rin=1*mm
 det_z=det_r=10*mm
 z_draw=det_z/2
-pn_r=8.957282*mm # this one was calculated by searching the zero impurity point (displayed in the following section). 
+pn_r=8.957282*mm # this one was calculated by searching the zero impurity point (displayed in the following section)
 
 sim = Simulation{T}(SSD_examples[:TrueCoaxial])
 cfn=SSD_examples[:TrueCoaxial]
@@ -65,7 +65,7 @@ plot!(ylabel = "Mobility [cm\$^2\$/V/s]", xlabel = "Depth to surface [mm]",
 #md savefig("tutorial_mob_dl.svg"); nothing # hide
 #md # [![tutorial_mob_dl](tutorial_mob_dl.svg)](tutorial_mob_dl.pdf)
 
-# ## Calculate electric field
+# ## Calculate the electric field
 # To simulate the inactive layer, we need to calculate the electric field with very fine grid.
 calculate_electric_potential!(sim, max_n_iterations = 10, grid = Grid(sim), verbose = false, depletion_handling = true)
 g = sim.electric_potential.grid

--- a/docs/src/tutorials/dead_layer_simulation_lit.jl
+++ b/docs/src/tutorials/dead_layer_simulation_lit.jl
@@ -1,0 +1,141 @@
+# # Inactive layer simulation Chain: True coaxial detector
+
+# ## Set the physical models for the inactive layer (dead layer) simulation with YAML
+# - drift model for the inactive layer
+# - constant lifetime trapping model
+# - mobility-tied diffusion model
+
+using Revise
+using Pkg
+using Plots
+using Unitful
+using Printf
+using SolidStateDetectors
+T = Float64
+
+# the geometry parameters of the model for following display
+mm=T(1/1000)
+det_rin=1*mm
+det_z=det_r=10*mm
+z_draw=det_z/2
+pn_r=8.957282*mm # this one was calculated by searching the zero impurity point (displayed in the following section). 
+
+sim = Simulation{T}(SSD_examples[:TrueCoaxial])
+cfn=SSD_examples[:TrueCoaxial]
+print(open(f -> read(f, String), cfn))
+plot(sim.detector, xunit = u"mm", yunit = u"mm", zunit = u"mm")
+#jl savefig("tutorial_det_dl.pdf") # hide
+#md savefig("tutorial_det_dl.pdf") # hide
+#md savefig("tutorial_det_dl.svg"); nothing # hide
+#md # [![tutorial_det_dl](tutorial_det_dl.svg)](tutorial_det_dl.pdf)
+
+# ## Display the impurity profile defined
+# > Above position of the PN junction boundary `pn_r` is calculate by searching the point on the curve where the density is zero.
+z_draw=det_z/2
+r_list=0*mm:0.01*mm:det_r
+imp_list= T[]
+for r in r_list
+    pt=CylindricalPoint{T}(r, 0, z_draw)
+    push!(imp_list, SolidStateDetectors.get_impurity_density(sim.detector.semiconductor.impurity_density_model, pt))
+end
+imp_list = imp_list ./ 1e6 # in cm^-3
+plot(r_list/mm, imp_list, xlabel="r [mm]", ylabel="Impurity density [cm\$^{-3}\$]", label="",
+    color=:darkblue,lw=2, grid=:on, xlims=(0,10),ylims=(-2e10, 1e11))
+vline!([pn_r/mm], lw = 2, ls=:dash, color = :darkred, label = "PN junction boundary")
+#jl savefig("tutorial_imp_dl.pdf") # hide
+#md savefig("tutorial_imp_dl.pdf") # hide
+#md savefig("tutorial_imp_dl.svg"); nothing # hide
+#md # [![tutorial_imp_dl](tutorial_imp_dl.svg)](tutorial_imp_dl.pdf)
+
+# ## Dispaly the mobility curve
+using SolidStateDetectors:Electron,Hole
+cdm = sim.detector.semiconductor.charge_drift_model
+depth_list = 0 : 0.01*mm : (det_r-pn_r)
+hole_mobility_list=[]
+electron_mobility_list=[]
+for depth in depth_list
+    r=det_r-depth
+    pt = CylindricalPoint{T}([r,0,z_draw])
+    pt = CartesianPoint{T}(pt)
+    push!(hole_mobility_list, cdm.calculate_mobility(pt, Hole))
+    push!(electron_mobility_list, cdm.calculate_mobility(pt, Electron))
+end
+plot(depth_list/mm, hole_mobility_list, label="Hole", lw=4)
+plot!(depth_list/mm, electron_mobility_list, label="Electron", lw=4)
+plot!(ylabel = "Mobility [cm\$^2\$/V/s]", xlabel = "Depth to surface [mm]",
+	legend = :topleft, frame = :box, grid = :on, minorgrid = :on, xticks = 0:0.2:1.2, yticks = 0:0.5:4.5, ylims = [0, 4.5])
+#jl savefig("tutorial_mob_dl.pdf") # hide
+#md savefig("tutorial_mob_dl.pdf") # hide
+#md savefig("tutorial_mob_dl.svg"); nothing # hide
+#md # [![tutorial_mob_dl](tutorial_mob_dl.svg)](tutorial_mob_dl.pdf)
+
+# ## Calculate electric field
+# To simulate the inactive layer, we need to calculate the electric field with very fine grid.
+calculate_electric_potential!(sim, max_n_iterations = 10, grid=  Grid(sim), verbose = false, depletion_handling = true)
+g = sim.electric_potential.grid
+ax1, ax2, ax3 = g.axes
+bulk_tick_dis=0.05*mm
+dl_tick_dis=0.01*mm
+user_additional_ticks_ax1=sort(vcat(ax1.interval.left:bulk_tick_dis:pn_r,pn_r:dl_tick_dis:ax1.interval.right))
+user_ax1 = typeof(ax1)(ax1.interval, user_additional_ticks_ax1)
+user_g = typeof(g)((user_ax1, ax2, ax3))
+calculate_electric_potential!(sim, refinement_limits = 0.1, use_nthreads=8, grid =  user_g, depletion_handling = true)
+calculate_electric_field!(sim)
+calculate_weighting_potential!(sim, 1,use_nthreads=8,depletion_handling = true)
+calculate_weighting_potential!(sim, 2,use_nthreads=8,depletion_handling = true);
+plot(
+    begin
+        imp=plot(sim.imp_scale, φ = 0,xunit=u"mm",yunit=u"mm", title="impurity scale")
+        vline!([pn_r/mm], lw = 2, ls=:dash, color = :darkred, label = "PN junction boundary", legendfontsize=6)
+    end,
+    begin
+        plot(sim.point_types, φ = 0,xunit=u"mm",yunit=u"mm", title="point types")
+        vline!([pn_r/mm], lw = 2, ls=:dash, color = :darkred, label = "PN junction boundary", legendfontsize=6)
+    end,
+    begin
+        plot(sim.electric_potential, title="electric potential")
+        vline!([pn_r/mm], lw = 2, ls=:dash, color = :darkred, label = "PN junction boundary", legendfontsize=6)
+    end,
+    begin
+        plot(sim.electric_field, title="electric field", clims=(0,100*2000))
+        vline!([pn_r/mm], lw = 2, ls=:dash, color = :darkred, label = "PN junction boundary", legendfontsize=6)
+    end,
+    size=(800,600), layout = (2,2)
+)
+#jl savefig("tutorial_ef_dl.pdf") # hide
+#md savefig("tutorial_ef_dl.pdf") # hide
+#md savefig("tutorial_ef_dl.svg"); nothing # hide
+#md # [![tutorial_ef_dl](tutorial_ef_dl.svg)](tutorial_ef_dl.pdf)
+
+# ## Pulse shape and CCE simulation
+depth_list = 0.1*mm : 0.1*mm : (det_r-pn_r)
+pulse_list = []
+totTime = 5 # us
+totEnergy = 1 # 1 keV --> simulating ~339 carrier pairs
+max_nsteps = Int(totTime * 1000)
+N=Int(totEnergy*1000÷2.95)
+z = det_z/2
+for depth in depth_list
+    r=det_r-depth
+    energy_depos =fill(T(2.95/1000),N) * u"keV"
+    starting_positions = repeat([CylindricalPoint{T}(r, deg2rad(0), z)],N)
+    evt = Event(starting_positions, energy_depos);
+    simulate!(evt, sim, Δt = 1u"ns",max_nsteps=max_nsteps, diffusion = true, end_drift_when_no_field = false, self_repulsion = false)
+    charge=ustrip(evt.waveforms[1].signal)
+    push!(pulse_list, charge)
+end
+pulse_plot=plot()
+eff_list = []
+for (i,depth) in enumerate(1:length(depth_list))
+    depth_str = @sprintf("%.1f", depth_list[depth]/mm)
+    plot!(pulse_list[depth], label="Depth: $(depth_str) mm", lw=2, xlabel="Time [ns]", ylabel="Amplitude [e]",
+        legend=:topright, grid = :on, minorgrid = :on, frame=:box)
+    push!(eff_list, maximum(pulse_list[i])/N)
+end
+cce_plot=plot(depth_list/mm, eff_list, xlabel="Depth to surface [mm]", lw=2, ylabel="Charge collection efficiency",
+    frame=:box, grid=:on, minorgrid=:on, xticks=0:0.2:1.2, yticks=0:0.1:1, dpi=500, color=:black, label="")
+plot(pulse_plot, cce_plot, layout = (1,2), size = (1000, 400), margin=5Plots.mm)
+#jl savefig("tutorial_pulse_cce_dl.pdf") # hide
+#md savefig("tutorial_pulse_cce_dl.pdf") # hide
+#md savefig("tutorial_pulse_cce_dl.svg"); nothing # hide
+#md # [![tutorial_pulse_cce_dl](tutorial_pulse_cce_dl.svg)](tutorial_pulse_cce_dl.pdf)

--- a/docs/src/tutorials/dead_layer_simulation_lit.jl
+++ b/docs/src/tutorials/dead_layer_simulation_lit.jl
@@ -3,7 +3,7 @@
 # ## Set the physical models for the inactive layer (dead layer) simulation with YAML
 # - using drift model for the inactive layer
 # - using constant lifetime trapping model
-# - using mobility-tied diffusion model (by calling the `calculate_mobility` function in the drift model struct)
+# - using mobility-tied diffusion model (by calling the `calculate_mobility` function with the drift model)
 
 using Plots
 using Unitful
@@ -53,8 +53,8 @@ for depth in depth_list
     r=det_r-depth
     pt = CylindricalPoint{T}([r, 0, z_draw])
     pt = CartesianPoint{T}(pt)
-    push!(hole_mobility_list, cdm.calculate_mobility(pt, Hole))
-    push!(electron_mobility_list, cdm.calculate_mobility(pt, Electron))
+    push!(hole_mobility_list, SolidStateDetectors.calculate_mobility(cdm, pt, Hole))
+    push!(electron_mobility_list, SolidStateDetectors.calculate_mobility(cdm, pt, Electron))
 end
 plot(depth_list/mm, hole_mobility_list, label = "Hole", lw = 4)
 plot!(depth_list/mm, electron_mobility_list, label = "Electron", lw = 4)

--- a/examples/example_config_files/public_TrueCoaxial.yaml
+++ b/examples/example_config_files/public_TrueCoaxial.yaml
@@ -60,7 +60,7 @@ detectors:
       inactive_layer_geometry:
         tube:
           r:
-            from: 8.957282 # set to the depth of the pn junction boundary when lithium diffusion temperature is 623K, time is 18 minutes
+            from: 8.957282 # set to the depth of the pn junction boundary when lithium diffusion temperature is 623 K, time is 18 minutes
             to: 10.0
           h: 10.0
           origin:

--- a/examples/example_config_files/public_TrueCoaxial.yaml
+++ b/examples/example_config_files/public_TrueCoaxial.yaml
@@ -29,8 +29,8 @@ detectors:
     temperature: 90
     impurity_density:
       name: PtypePNjunction
-      Li_annealing_temperature: 623K
-      Li_annealing_time: 18minute
+      lithium_annealing_temperature: 623K
+      lithium_annealing_time: 18minute
       doped_contact_id: 2
       bulk_impurity_density:
         name: constant

--- a/examples/example_config_files/public_TrueCoaxial.yaml
+++ b/examples/example_config_files/public_TrueCoaxial.yaml
@@ -41,6 +41,15 @@ detectors:
       neutral_impurity_density:
         name: constant
         value: 5.6769e15cm^-3
+      # # Uncomment the following lines if you want to use different bulk and surface impurity densities in the charge_drift_model section
+      # bulk_impurity_density:
+      #   name: constant
+      #   value: -1e10cm^-3
+      # surface_impurity_density:
+      #   name: li_diffusion
+      #   lithium_annealing_temperature: 623K
+      #   lithium_annealing_time: 18minute
+      #   doped_contact_id: 2
     charge_trapping_model:
       model: ConstantLifetime
       parameters:

--- a/src/ChargeDriftModels/InactiveLayerChargeDriftModel/InactiveLayerChargeDriftModel.jl
+++ b/src/ChargeDriftModels/InactiveLayerChargeDriftModel/InactiveLayerChargeDriftModel.jl
@@ -15,7 +15,6 @@ Ref: [Dai _et al._ (2023)](https://doi.org/10.1016/j.apradiso.2022.110638)
 ## Extra field for constructing the model
 - `temperature::T`: the crystal temperature (Kelvin), the default is 90 (Kelvin).
 """
-
 struct InactiveLayerChargeDriftModel{T <: SSDFloat} <: AbstractChargeDriftModel{T}
     calculate_mobility::Function
     temperature::T

--- a/src/ChargeDriftModels/InactiveLayerChargeDriftModel/InactiveLayerChargeDriftModel.jl
+++ b/src/ChargeDriftModels/InactiveLayerChargeDriftModel/InactiveLayerChargeDriftModel.jl
@@ -2,18 +2,18 @@
     struct InactiveLayerChargeDriftModel{T <: SSDFloat} <: AbstractChargeDriftModel{T}
         
 Charge drift model in which the electrons and holes drift along the electric field.
-There factors are considered in the mobility calculation: ionized impurities, neutral impurities, and acoustic phonon.
+Three factors are considered in the mobility calculation: ionized impurities, neutral impurities, and acoustic phonons.
 
 Ref: [Dai _et al._ (2023)](https://doi.org/10.1016/j.apradiso.2022.110638)
 
 ## Fields
-- `calculate_mobility::Function`: Mobility calculation function.
+- `calculate_mobility::Function`: Mobility function, which is called in the `getVe`, `getVh` and the diffusion coefficient calculation.
 - `neutral_imp_model::AbstractImpurityDensity{T}`: the neutral impurity density model. The default is a constant impurity density of 1e21 m⁻³.
 - `bulk_imp_model::AbstractImpurityDensity{T}`: the bulk impurity density model. The default is the defined (bulk) impurity density if the model is constructed in the config, otherwise the default is a constant impurity density of -1e16 m⁻³.
 - `surface_imp_model::AbstractImpurityDensity{T}`: the surface impurity density model. The default is the defined surface impurity density if the model is constructed in the config, otherwise the default is a constant impurity density of 0 m⁻³.
 
 ## Extra field for constructing the model
-- `temperature::T`: temperature of the crystal (Kelvin).
+- `temperature::T`: the crystal temperature (Kelvin), the default is 90 (Kelvin).
 """
 
 struct InactiveLayerChargeDriftModel{T <: SSDFloat} <: AbstractChargeDriftModel{T}
@@ -25,7 +25,7 @@ struct InactiveLayerChargeDriftModel{T <: SSDFloat} <: AbstractChargeDriftModel{
 end
 
 function InactiveLayerChargeDriftModel{T}(
-    temperature::T = T(90), # Kelvin
+    temperature::T = T(90),
     neutral_imp_model::AbstractImpurityDensity{T} = ConstantImpurityDensity{T}(T(1e21)),
     bulk_imp_model::AbstractImpurityDensity{T} = ConstantImpurityDensity{T}(T(-1e16)),
     surface_imp_model::AbstractImpurityDensity{T} = ConstantImpurityDensity{T}(T(0)),

--- a/src/ChargeDriftModels/InactiveLayerChargeDriftModel/InactiveLayerChargeDriftModel.jl
+++ b/src/ChargeDriftModels/InactiveLayerChargeDriftModel/InactiveLayerChargeDriftModel.jl
@@ -7,27 +7,23 @@ Three factors are considered in the mobility calculation: ionized impurities, ne
 Ref: [Dai _et al._ (2023)](https://doi.org/10.1016/j.apradiso.2022.110638)
 
 ## Fields
-- `calculate_mobility::Function`: Mobility function, which is called in the `getVe`, `getVh` and the diffusion coefficient calculation.
+- `calculate_mobility::Function`: the mobility function, which is called in the `getVe`, `getVh` and the diffusion coefficient calculation.
+
+## Parameters for constructing the model
+- `temperature::T`: the crystal temperature (Kelvin), the default is 90 (Kelvin).
 - `neutral_imp_model::AbstractImpurityDensity{T}`: the neutral impurity density model. The default is a constant impurity density of 1e21 m⁻³.
 - `bulk_imp_model::AbstractImpurityDensity{T}`: the bulk impurity density model. The default is the defined (bulk) impurity density if the model is constructed in the config, otherwise the default is a constant impurity density of -1e16 m⁻³.
 - `surface_imp_model::AbstractImpurityDensity{T}`: the surface impurity density model. The default is the defined surface impurity density if the model is constructed in the config, otherwise the default is a constant impurity density of 0 m⁻³.
-
-## Extra field for constructing the model
-- `temperature::T`: the crystal temperature (Kelvin), the default is 90 (Kelvin).
 """
 struct InactiveLayerChargeDriftModel{T <: SSDFloat} <: AbstractChargeDriftModel{T}
     calculate_mobility::Function
-    temperature::T
-    neutral_imp_model::AbstractImpurityDensity{T}
-    bulk_imp_model::AbstractImpurityDensity{T}
-    surface_imp_model::AbstractImpurityDensity{T}
 end
 
 function InactiveLayerChargeDriftModel{T}(
     temperature::T = T(90),
     neutral_imp_model::AbstractImpurityDensity{T} = ConstantImpurityDensity{T}(T(1e21)),
     bulk_imp_model::AbstractImpurityDensity{T} = ConstantImpurityDensity{T}(T(-1e16)),
-    surface_imp_model::AbstractImpurityDensity{T} = ConstantImpurityDensity{T}(T(0)),
+    surface_imp_model::AbstractImpurityDensity{T} = ConstantImpurityDensity{T}(T(0))
 ) where {T <: SSDFloat}
 
     function calculate_mobility(pt::AbstractCoordinatePoint{T}, CC::Type{CC_type}) where {T <: SSDFloat, CC_type <: ChargeCarrier}
@@ -38,7 +34,7 @@ function InactiveLayerChargeDriftModel{T}(
             temperature, CC)
     end
 
-    InactiveLayerChargeDriftModel{T}(calculate_mobility, temperature, neutral_imp_model, bulk_imp_model, surface_imp_model)
+    InactiveLayerChargeDriftModel{T}(calculate_mobility)
 end
 
 function _calculate_mobility_with_impurities(

--- a/src/ChargeDriftModels/InactiveLayerChargeDriftModel/InactiveLayerChargeDriftModel.jl
+++ b/src/ChargeDriftModels/InactiveLayerChargeDriftModel/InactiveLayerChargeDriftModel.jl
@@ -7,34 +7,33 @@ Three factors are considered in the mobility calculation: ionized impurities, ne
 Ref: [Dai _et al._ (2023)](https://doi.org/10.1016/j.apradiso.2022.110638)
 
 ## Fields
-- `calculate_mobility::Function`: the mobility function, which is called in the `getVe`, `getVh` and the diffusion coefficient calculation.
-
-## Parameters for constructing the model
 - `temperature::T`: the crystal temperature (Kelvin), the default is 90 (Kelvin).
 - `neutral_imp_model::AbstractImpurityDensity{T}`: the neutral impurity density model. The default is a constant impurity density of 1e21 m⁻³.
 - `bulk_imp_model::AbstractImpurityDensity{T}`: the bulk impurity density model. The default is the defined (bulk) impurity density if the model is constructed in the config, otherwise the default is a constant impurity density of -1e16 m⁻³.
 - `surface_imp_model::AbstractImpurityDensity{T}`: the surface impurity density model. The default is the defined surface impurity density if the model is constructed in the config, otherwise the default is a constant impurity density of 0 m⁻³.
 """
 struct InactiveLayerChargeDriftModel{T <: SSDFloat} <: AbstractChargeDriftModel{T}
-    calculate_mobility::Function
+    temperature::T
+    neutral_imp_model::AbstractImpurityDensity{T}
+    bulk_imp_model::AbstractImpurityDensity{T}
+    surface_imp_model::AbstractImpurityDensity{T}
+    
+    # constructor with default values
+    InactiveLayerChargeDriftModel{T}(
+        temperature::T = T(90),
+        neutral_imp_model::AbstractImpurityDensity{T} = ConstantImpurityDensity{T}(T(1e21)),
+        bulk_imp_model::AbstractImpurityDensity{T} = ConstantImpurityDensity{T}(T(-1e16)),
+        surface_imp_model::AbstractImpurityDensity{T} = ConstantImpurityDensity{T}(T(0))
+    ) where {T <: SSDFloat} = new{T}(temperature, neutral_imp_model, bulk_imp_model, surface_imp_model)
 end
 
-function InactiveLayerChargeDriftModel{T}(
-    temperature::T = T(90),
-    neutral_imp_model::AbstractImpurityDensity{T} = ConstantImpurityDensity{T}(T(1e21)),
-    bulk_imp_model::AbstractImpurityDensity{T} = ConstantImpurityDensity{T}(T(-1e16)),
-    surface_imp_model::AbstractImpurityDensity{T} = ConstantImpurityDensity{T}(T(0))
-) where {T <: SSDFloat}
 
-    function calculate_mobility(pt::AbstractCoordinatePoint{T}, CC::Type{CC_type}) where {T <: SSDFloat, CC_type <: ChargeCarrier}
-        _calculate_mobility_with_impurities(
-            get_impurity_density(neutral_imp_model, pt),
-            get_impurity_density(bulk_imp_model, pt),
-            get_impurity_density(surface_imp_model, pt),
-            temperature, CC)
-    end
-
-    InactiveLayerChargeDriftModel{T}(calculate_mobility)
+function calculate_mobility(cdm::InactiveLayerChargeDriftModel{T}, pt::AbstractCoordinatePoint{T}, CC::Type{CC_type}) where {T <: SSDFloat, CC_type <: ChargeCarrier}
+    _calculate_mobility_with_impurities(
+        get_impurity_density(cdm.neutral_imp_model, pt),
+        get_impurity_density(cdm.bulk_imp_model, pt),
+        get_impurity_density(cdm.surface_imp_model, pt),
+        cdm.temperature, CC)
 end
 
 function _calculate_mobility_with_impurities(
@@ -49,6 +48,7 @@ function _calculate_mobility_with_impurities(
 
     1/(1/μI + 1/μA + 1/μN)
 end
+
 function _calculate_mobility_with_impurities(
     Nn::T, bulk_imp::T, surface_imp::T,
     temperature::T,
@@ -63,8 +63,9 @@ function _calculate_mobility_with_impurities(
 end
 
 function InactiveLayerChargeDriftModel{T}(config::AbstractDict,
-    imp_model::AbstractImpurityDensity, input_units::NamedTuple,
-) where {T <: SSDFloat}
+        imp_model::AbstractImpurityDensity, input_units::NamedTuple,
+    ) where {T <: SSDFloat}
+
     temperature = _parse_value(T, get(config, "temperature", 90u"K"), input_units.temperature)
 
     neutral_imp_model = if haskey(config, "neutral_impurity_density")
@@ -92,13 +93,9 @@ function InactiveLayerChargeDriftModel{T}(config::AbstractDict,
 end
 
 @fastmath function getVe(fv::SVector{3, T}, cdm::InactiveLayerChargeDriftModel{T}, current_pos::CartesianPoint{T} = zero(CartesianPoint{T})) where {T <: SSDFloat}
-    @inbounds begin
-        -cdm.calculate_mobility(current_pos, Electron)*fv
-    end
+    -calculate_mobility(cdm, current_pos, Electron) * fv
 end
 
 @fastmath function getVh(fv::SVector{3, T}, cdm::InactiveLayerChargeDriftModel{T}, current_pos::CartesianPoint{T} = zero(CartesianPoint{T})) where {T <: SSDFloat}
-    @inbounds begin
-        cdm.calculate_mobility(current_pos, Hole)*fv
-    end
+    calculate_mobility(cdm, current_pos, Hole) * fv
 end

--- a/src/ChargeDriftModels/IsotropicChargeDriftModel/IsotropicChargeDriftModel.jl
+++ b/src/ChargeDriftModels/IsotropicChargeDriftModel/IsotropicChargeDriftModel.jl
@@ -39,14 +39,13 @@ function IsotropicChargeDriftModel{T}(config::AbstractDict) where {T <: SSDFloat
     IsotropicChargeDriftModel{T}(config["mobilities"]["e"], config["mobilities"]["h"])
 end
 
+calculate_mobility(cdm::IsotropicChargeDriftModel{T}, ::AbstractCoordinatePoint{T}, ::Type{Electron}) where {T <: SSDFloat} = cdm.μ_e
+calculate_mobility(cdm::IsotropicChargeDriftModel{T}, ::AbstractCoordinatePoint{T}, ::Type{Hole})     where {T <: SSDFloat} = cdm.μ_h
+
 @fastmath function getVe(fv::SVector{3, T}, cdm::IsotropicChargeDriftModel{T}, current_pos::CartesianPoint{T} = zero(CartesianPoint{T})) where {T <: SSDFloat}
-    @inbounds begin 
-        -cdm.μ_e*fv
-    end
+    -cdm.μ_e*fv
 end
 
 @fastmath function getVh(fv::SVector{3, T}, cdm::IsotropicChargeDriftModel{T}, current_pos::CartesianPoint{T} = zero(CartesianPoint{T})) where {T <: SSDFloat}
-    @inbounds begin 
-        cdm.μ_h*fv
-    end
+    cdm.μ_h*fv
 end

--- a/src/ConstructiveSolidGeometry/Intervals.jl
+++ b/src/ConstructiveSolidGeometry/Intervals.jl
@@ -18,8 +18,13 @@ end
     csgtol < mod(α - α_int[1], T(2π)) < (α_int[2] - α_int[1]) - csgtol 
 end
 
-# @inline _in_angular_interval_closed(α::Real, α_int::Nothing, tol::Real = 0) = true
+@inline _in_angular_interval_closed(α::Real, α_int::Nothing, tol::Real = 0) = true
 # @inline _in_angular_interval_closed(α::Real, α_int::AbstractInterval{T}, tol::Real = 0) where {T} = mod(α - (α_int.left-tol), T(2π)) ≤ (α_int.right+tol) - (α_int.left-tol)
 # 
 # @inline _in_angular_interval_open(α::T, α_int::Nothing) where {T<:Real} = 0 < mod(α, T(2π)) < T(2π)
 # @inline _in_angular_interval_open(α::Real, α_int::AbstractInterval{T}) where {T} = 0 < mod(α - α_int.left, T(2π)) < width(α_int)
+
+@inline _in_φ(p::CylindricalPoint, φ::Nothing) = true
+@inline _in_φ(p::CylindricalPoint, φ::Real) = p.φ <= φ
+@inline _in_φ(p::CylindricalPoint, φ::Tuple{T,T}) where {T} =  r[1]<=p.φ<=φ[2]
+@inline _in_φ(p::CartesianPoint, φ::Union{Nothing, Real, Tuple{T,T}}) where {T} =  _in_φ(CylindricalPoint(p), φ)

--- a/src/ConstructiveSolidGeometry/LinePrimitives/Edge.jl
+++ b/src/ConstructiveSolidGeometry/LinePrimitives/Edge.jl
@@ -25,6 +25,8 @@ function Edge{T}(;
     Edge{T}(a, b)
 end
 
+Edge{T}(a::CylindricalPoint{T}, b::CylindricalPoint{T}) where {T} = Edge{T}(CartesianPoint(a), CartesianPoint(b))
+
 direction(e::Edge) = e.b - e.a
 
 Line(e::Edge{T}) where {T} = Line{T}(e.a, direction(e))

--- a/src/ConstructiveSolidGeometry/SurfacePrimitives/ConeMantle.jl
+++ b/src/ConstructiveSolidGeometry/SurfacePrimitives/ConeMantle.jl
@@ -323,18 +323,17 @@ end
 # end
 
 
-function distance_to_line_segment(point::AbstractCoordinatePoint{T}, seg::Tuple{AbstractCoordinatePoint{T},AbstractCoordinatePoint{T}})::T where {T}
+function distance_to_line(point::AbstractCoordinatePoint{T}, edge::Edge{T})::T where {T}
     point = CartesianPoint(point)
-    seg = (CartesianPoint(seg[1]), CartesianPoint(seg[2]))
-    v12 = normalize(CartesianVector{T}(seg[2] - seg[1]))
-    v_point_1 = CartesianVector{T}(point - seg[1])
+    v12 = normalize(CartesianVector{T}(edge.b - edge.a))
+    v_point_1 = CartesianVector{T}(point - edge.a)
     proj_on_v12 = dot(v12,v_point_1)
     if geom_round(proj_on_v12) ≤ T(0)
-        return norm(seg[1] - point)
+        return norm(edge.a - point)
     else
-        v_point_2 = CartesianVector{T}(point - seg[2])
+        v_point_2 = CartesianVector{T}(point - edge.b)
         if geom_round(dot(v12,v_point_2)) ≥ T(0)
-            return norm(seg[2] - point)
+            return norm(edge.b - point)
         else
             return sqrt(abs(dot(v_point_1,v_point_1) - proj_on_v12^2))
         end
@@ -348,18 +347,18 @@ function distance_to_surface(point::AbstractCoordinatePoint{T}, c::ConeMantle{T,
     pcy = CylindricalPoint(point)
     rbot::T, rtop::T = get_r_limits(c)
     zMin::T, zMax::T = get_z_limits(c)
-    distance_to_line_segment(CartesianPoint{T}(pcy.r,0,pcy.z), (CartesianPoint{T}(rbot,0,zMin),CartesianPoint{T}(rtop,0,zMax)))
+    distance_to_line(CartesianPoint{T}(pcy.r,0,pcy.z), Edge{T}(CartesianPoint{T}(rbot,0,zMin),CartesianPoint{T}(rtop,0,zMax)))
 end
 
-function distance_to_surface(point::AbstractCoordinatePoint{T}, c::ConeMantle{T, <:Any, <:Tuple{T,T}, <:Any})::T where {T}
+function distance_to_surface(point::AbstractCoordinatePoint{T}, c::ConeMantle{T, <:Any, <:AbstractInterval, <:Any})::T where {T}
     pcy = CylindricalPoint(point)
     φMin::T, φMax::T = get_φ_limits(c)
     rbot::T, rtop::T = get_r_limits(c)
     zMin::T, zMax::T = get_z_limits(c)
     if _in_φ(pcy, c.φ)
-        return distance_to_line_segment(CartesianPoint{T}(pcy.r,0,pcy.z), (CartesianPoint{T}(rbot,0,zMin),CartesianPoint{T}(rtop,0,zMax)))
+        return distance_to_line(CartesianPoint{T}(pcy.r,0,pcy.z), Edge{T}(CartesianPoint{T}(rbot,0,zMin),CartesianPoint{T}(rtop,0,zMax)))
     else
         φNear = Δ_φ(T(pcy.φ),φMin) ≤ Δ_φ(T(pcy.φ),φMax) ? φMin : φMax
-        return distance_to_line_segment(point, (CylindricalPoint{T}(rbot,φNear,zMin),CylindricalPoint{T}(rtop,φNear,zMax)))
+        return distance_to_line(point, Edge{T}(CylindricalPoint{T}(rbot,φNear,zMin), CylindricalPoint{T}(rtop,φNear,zMax)))
     end
 end

--- a/src/ImpurityDensities/PtypePNJunctionImpurityDensity.jl
+++ b/src/ImpurityDensities/PtypePNJunctionImpurityDensity.jl
@@ -6,7 +6,7 @@ The surface lithium density is saturated. Ref: [Dai _et al._ (2023)](https://doi
  
 ## Fields
 * `surface_imp_model::ThermalDiffusionLithiumDensity{T}`: the density profile of lithium (n-type).
-* `bulk_imp_model::AbstractImpurityDensity{T}`: the density of the p-type impurity.
+* `bulk_imp_model::AbstractImpurityDensity{T}`: the density profile of the p-type impurity.
 """
 
 struct PtypePNJunctionImpurityDensity{T <: SSDFloat} <: AbstractImpurityDensity{T}

--- a/src/ImpurityDensities/PtypePNJunctionImpurityDensity.jl
+++ b/src/ImpurityDensities/PtypePNJunctionImpurityDensity.jl
@@ -2,13 +2,12 @@
 struct PtypePNJunctionImpurityDensity{T <: SSDFloat} <: AbstractImpurityDensity{T}
 
 A PN junction impurity model based on lithium thermal diffusion and constant bulk impurity density.
-The surface lithium density is saturated. Ref: [Dai _et al._ (2023)](https://doi.org/10.1016/j.apradiso.2022.110638)
+The surface lithium density is at the saturation level. Ref: [Dai _et al._ (2023)](https://doi.org/10.1016/j.apradiso.2022.110638)
  
 ## Fields
-* `surface_imp_model::ThermalDiffusionLithiumDensity{T}`: the density profile of lithium (n-type).
-* `bulk_imp_model::AbstractImpurityDensity{T}`: the density profile of the p-type impurity.
+* `surface_imp_model::ThermalDiffusionLithiumDensity{T}`: the density profile of lithium (n-type). Detailed in [`ThermalDiffusionLithiumDensity`](@ref).
+* `bulk_imp_model::AbstractImpurityDensity{T}`: the density profile of the p-type impurities.
 """
-
 struct PtypePNJunctionImpurityDensity{T <: SSDFloat} <: AbstractImpurityDensity{T}
     surface_imp_model::ThermalDiffusionLithiumDensity{T}
     bulk_imp_model::AbstractImpurityDensity{T}

--- a/src/ImpurityDensities/ThermalDiffusionLithiumDensity.jl
+++ b/src/ImpurityDensities/ThermalDiffusionLithiumDensity.jl
@@ -11,8 +11,17 @@ Lithium impurity density model. Ref: [Dai _et al._ (2023)](https://doi.org/10.10
     2) custom. Custom function might be much faster while the detector has good symmetry.
 * `lithium_density_on_contact::T`: the lithium concentration in the surface (in m^-3)
 * `lithium_diffusivity_in_germanium::T`: the diffusivity of lithium in germanium (in m^2*s^-1)
-"""
 
+## Parameters for constructing the model
+* `lithium_annealing_temperature::T`
+* `lithium_annealing_time::T`
+* `contact_with_lithium_doped::G`: the geometry of the contact with lithium doped, which is used to calculate the distance to the surface.
+    - If you don't pass this parameter, the `distance_to_contact` function should be passed.
+    - If you pass this parameter but don't pass the `distance_to_contact` function, the `distance_to_contact` function will use the default one.
+* `distance_to_contact::Function`: optional, default is `ConstructiveSolidGeometry.distance_to_surface(pt, contact_with_lithium_doped)`
+* `lithium_density_on_contact::T`: optional, default is the saturated lithium density at the given temperature
+* `lithium_diffusivity_in_germanium::T`: optional, default is calculated with the annealing temperature
+"""
 struct ThermalDiffusionLithiumDensity{T <: SSDFloat} <: AbstractImpurityDensity{T}
     lithium_annealing_temperature::T
     lithium_annealing_time::T

--- a/src/SolidStateDetectors.jl
+++ b/src/SolidStateDetectors.jl
@@ -69,6 +69,7 @@ export ElectricPotential, PointTypes, EffectiveChargeDensity, DielectricDistribu
 export apply_initial_state!
 export calculate_electric_potential!, calculate_weighting_potential!, calculate_electric_field!, calculate_drift_fields!
 export ElectricFieldChargeDriftModel, ADLChargeDriftModel, IsotropicChargeDriftModel, InactiveLayerChargeDriftModel
+export LinearImpurityDensity, LinBouleImpurityDensity, LinExpBouleImpurityDensity, ThermalDiffusionLithiumDensity, PtypePNJunctionImpurityDensity
 export NoChargeTrappingModel, BoggsChargeTrappingModel, ConstantLifetimeChargeTrappingModel
 export get_active_volume, is_depleted, estimate_depletion_voltage
 export calculate_stored_energy, calculate_mutual_capacitance, calculate_capacitance_matrix
@@ -78,7 +79,6 @@ export Simulation, simulate!
 export Event, drift_charges!
 export add_baseline_and_extend_tail
 export NBodyChargeCloud
-export LinearImpurityDensity, LinBouleImpurityDensity, LinExpBouleImpurityDensity, ThermalDiffusionLithiumDensity, PtypePNJunctionImpurityDensity
 
 using Unitful: RealOrRealQuantity as RealQuantity
 const SSDFloat = Union{Float16, Float32, Float64}

--- a/test/test_charge_drift_models.jl
+++ b/test/test_charge_drift_models.jl
@@ -229,7 +229,17 @@ end
         @test SolidStateDetectors.calculate_mobility(simA.detector.semiconductor.charge_drift_model, CartesianPoint{T}(0,0,0), SolidStateDetectors.Hole) isa T
     end
 
-    # TODO: Add a test that the detector is not fully depleted?
+    @testset "Test if the detector is not depleted" begin
+        mm = 1 / 1000
+        pn_r = 8.957282 * mm
+        ax1, ax2, ax3 = Grid(simA).axes
+        bulk_tick_dis, dl_tick_dis  = 0.05 * mm, 0.01 * mm
+        user_additional_ticks_ax1 = sort(vcat(ax1.interval.left:bulk_tick_dis:pn_r, pn_r:dl_tick_dis:ax1.interval.right))
+        user_ax1 = typeof(ax1)(ax1.interval, user_additional_ticks_ax1)
+        user_g = typeof(g)((user_ax1, ax2, ax3))
+        calculate_electric_potential!(simA, grid=user_g, depletion_handling=true)
+        @test !is_depleted(simA.point_types)
+    end
 end
 
 @timed_testset "Test IsotropicChargeDriftModel" begin

--- a/test/test_charge_drift_models.jl
+++ b/test/test_charge_drift_models.jl
@@ -232,7 +232,8 @@ end
     @testset "Test if the detector is not depleted" begin
         mm = 1 / 1000
         pn_r = 8.957282 * mm
-        ax1, ax2, ax3 = Grid(simA).axes
+        g = Grid(simA)
+        ax1, ax2, ax3 = g.axes
         bulk_tick_dis, dl_tick_dis  = 0.05 * mm, 0.01 * mm
         user_additional_ticks_ax1 = sort(vcat(ax1.interval.left:bulk_tick_dis:pn_r, pn_r:dl_tick_dis:ax1.interval.right))
         user_ax1 = typeof(ax1)(ax1.interval, user_additional_ticks_ax1)

--- a/test/test_charge_drift_models.jl
+++ b/test/test_charge_drift_models.jl
@@ -203,19 +203,20 @@ end
 @timed_testset "Test InactiveLayerChargeDriftModel" begin
     @testset "Test constructors of InactiveLayerChargeDriftModel" begin
         cdm0 = InactiveLayerChargeDriftModel{T}()
-        @test cdm0.temperature == T(90)
-        @test cdm0.neutral_imp_model == ConstantImpurityDensity{T}(1e21)
-        @test cdm0.bulk_imp_model == ConstantImpurityDensity{T}(-1e16)
-        @test cdm0.surface_imp_model == ConstantImpurityDensity{T}(0)
+        @test cdm0 isa AbstractChargeDriftModel{T}
+        @test hasproperty(cdm0, :calculate_mobility)
+        # the charge drift model should define methods for coordinate points and charge carriers:
+        @test cdm0.calculate_mobility(CartesianPoint{T}(0,0,0), SolidStateDetectors.Electron) isa T
+        @test cdm0.calculate_mobility(CartesianPoint{T}(0,0,0), SolidStateDetectors.Hole) isa T
     end
 
     simA = @test_nowarn Simulation{T}(SSD_examples[:TrueCoaxial])
     @testset "Parse the TrueCoaxial config file" begin
         @test simA.detector.semiconductor.charge_drift_model isa AbstractChargeDriftModel{T}
-        @test simA.detector.semiconductor.charge_drift_model.temperature == T(90)
-        @test simA.detector.semiconductor.charge_drift_model.neutral_imp_model == ConstantImpurityDensity{T}(5.6769e21)
-        @test simA.detector.semiconductor.charge_drift_model.bulk_imp_model == simA.detector.semiconductor.impurity_density_model.bulk_imp_model
-        @test simA.detector.semiconductor.charge_drift_model.surface_imp_model == simA.detector.semiconductor.impurity_density_model.surface_imp_model
+        @test hasproperty(simA.detector.semiconductor.charge_drift_model, :calculate_mobility)
+        # the charge drift model should define methods for coordinate points and charge carriers:
+        @test simA.detector.semiconductor.charge_drift_model.calculate_mobility(CartesianPoint{T}(0,0,0), SolidStateDetectors.Electron) isa T
+        @test simA.detector.semiconductor.charge_drift_model.calculate_mobility(CartesianPoint{T}(0,0,0), SolidStateDetectors.Hole) isa T
     end
 
 end

--- a/test/test_diffusion.jl
+++ b/test/test_diffusion.jl
@@ -1,5 +1,5 @@
 using SolidStateDetectors
-using SolidStateDetectors: Electron, Hole
+using SolidStateDetectors: Electron, Hole, AbstractChargeDriftModel
 using LinearAlgebra
 using Test
 
@@ -16,24 +16,24 @@ T = Float32
     
     step_vectors = zeros(CartesianVector{T}, N)
 
-    # if calculate_mobility gives a zero mobility, nothing should happen
-    calculate_mobility(pt::CartesianPoint{T}, ::Type{Hole}) where {T} = zero(T)
-    SolidStateDetectors._add_fieldvector_diffusion!(step_vectors, done, Δt, calculate_mobility, current_pos, crystal_temperature, Hole)
-    @test all(iszero.(step_vectors))  
-    calculate_mobility(pt::CartesianPoint{T}, ::Type{Electron}) where {T} = zero(T)
-    SolidStateDetectors._add_fieldvector_diffusion!(step_vectors, done, Δt, calculate_mobility, current_pos, crystal_temperature, Electron)
+    # Charge Drift model with zero mobility
+    cdm0 = IsotropicChargeDriftModel{T}(0,0)
+    SolidStateDetectors._add_fieldvector_diffusion!(step_vectors, done, Δt, cdm0, current_pos, crystal_temperature, Hole)
+    @test all(iszero.(step_vectors))
+    SolidStateDetectors._add_fieldvector_diffusion!(step_vectors, done, Δt, cdm0, current_pos, crystal_temperature, Electron)
     @test all(iszero.(step_vectors))
     
     # if the mobility is set to some position-independent value, then we know what the length of the expected step_vectors should be
     μ0 = T(5.0 + rand() * 5.0)
-    calculate_mobility_constant(pt::CartesianPoint{T}, ::Type{Hole}) where {T} = μ0
-    SolidStateDetectors._add_fieldvector_diffusion!(step_vectors, done, Δt, calculate_mobility_constant, current_pos, crystal_temperature, Hole)
+    cdmµ = IsotropicChargeDriftModel{T}(µ0, µ0)
+    SolidStateDetectors._add_fieldvector_diffusion!(step_vectors, done, Δt, cdmµ, current_pos, crystal_temperature, Hole)
     D0 = μ0 * crystal_temperature * SolidStateDetectors.kB / SolidStateDetectors.elementary_charge
     @test all(isapprox.(norm.(step_vectors), sqrt(6 * D0 * Δt), rtol = 0.01))
     step_vectors = zeros(CartesianVector{T}, N) # reset step vectors
     
-    # use a position-dependent mobility
-    calculate_mobility_pos(pt::CartesianPoint{T}, ::Type{Hole}) where {T} = pt.z
-    SolidStateDetectors._add_fieldvector_diffusion!(step_vectors, done, Δt, calculate_mobility_pos, current_pos, crystal_temperature, Hole)
+    # define a new charge drift model with position-dependent mobility
+    struct PositionDependentChargeDriftModel{T} <: AbstractChargeDriftModel{T} end
+    SolidStateDetectors.calculate_mobility(::PositionDependentChargeDriftModel{T}, pt::CartesianPoint{T}, ::Type{Hole}) where {T} = pt.z
+    SolidStateDetectors._add_fieldvector_diffusion!(step_vectors, done, Δt, PositionDependentChargeDriftModel{T}(), current_pos, crystal_temperature, Hole)
     @test all(isapprox.(norm.(step_vectors).^2 ./ (6 * Δt) * SolidStateDetectors.elementary_charge / (crystal_temperature * SolidStateDetectors.kB), zs, rtol = 0.01))
 end


### PR DESCRIPTION
The almost final PR for the dead layer simulation:
- [x] Support the geometry of BEGe/PPCGe/ICPCGe
- [ ] Support more detector geometry, and consider the translation and rotation -- this will leave to another PR by someone else. 
- [x] Optimize the code, docs and docstrings
- [x] Write a tutorial subsection for the dead layer simulation


Add one more at 0620:
- [ ] Use the PointType or the effective charge to decide if a point is inside the inactive layer geometry for the trapping model instead of using the user-defined new inactive_layer_geometry -- this will leave to another PR.