### PR TITLE
Disallow Geant4_julia_jll v0.2.3, it's broken

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SolidStateDetectors"
 uuid = "71e43887-2bd9-5f77-aebd-47f656f0a3f0"
-version = "0.10.17"
+version = "0.10.18"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/Project.toml
+++ b/Project.toml
@@ -41,9 +41,10 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [weakdeps]
 Geant4 = "559df036-b7a0-42fd-85df-7d5dd9d70f44"
+Geant4_julia_jll = "e202cb52-5471-567a-9cb0-0ca301e27810"
 
 [extensions]
-SolidStateDetectorsGeant4Ext = "Geant4"
+SolidStateDetectorsGeant4Ext = ["Geant4", "Geant4_julia_jll"]
 
 [compat]
 Adapt = "3, 4"
@@ -55,6 +56,7 @@ FillArrays = "0.9, 0.10, 0.11, 0.12, 0.13, 1"
 Format = "1.2"
 GPUArrays = "8, 9, 10, 11"
 Geant4 = "0.1.13, 0.2"
+Geant4_julia_jll = "0.1.15, 0.2.0 - 0.2.2"
 Interpolations = "0.14, 0.15, 0.16"
 IntervalSets = "0.6, 0.7"
 JSON = "0.21.2"


### PR DESCRIPTION
We can't limit Geant4_jll directly to avoid the `length` issue in  v11.3.2+0, since

```
Geant4_jll = "11.2.0 - 11.3.2+0"
```

is not allowed, but limiting Geant4_julia_jll seems to work as well.