### PR TITLE
Add geometric validation for electrode termination in charge drift

### DIFF
--- a/src/ChargeDrift/ChargeDrift.jl
+++ b/src/ChargeDrift/ChargeDrift.jl
@@ -36,7 +36,8 @@ end
 function _drift_charges(det::SolidStateDetector{T}, grid::Grid{T, 3}, point_types::PointTypes{T, 3},
                         starting_points::VectorOfArrays{CartesianPoint{T}}, energies::VectorOfArrays{T},
                         electric_field::Interpolations.Extrapolation{<:SVector{3}, 3},
-                        Δt::RQ; max_nsteps::Int = 2000, diffusion::Bool = false, self_repulsion::Bool = false, verbose::Bool = true)::Vector{EHDriftPath{T}} where {T <: SSDFloat, RQ <: RealQuantity}
+                        Δt::RQ; max_nsteps::Int = 2000, diffusion::Bool = false, self_repulsion::Bool = false, 
+                        geometry_check::Bool = false, verbose::Bool = true)::Vector{EHDriftPath{T}} where {T <: SSDFloat, RQ <: RealQuantity}
 
     drift_paths::Vector{EHDriftPath{T}} = Vector{EHDriftPath{T}}(undef, length(flatview(starting_points)))
     dt::T = T(to_internal_units(Δt))
@@ -53,8 +54,8 @@ function _drift_charges(det::SolidStateDetector{T}, grid::Grid{T, 3}, point_type
         timestamps_e::Vector{T} = Vector{T}(undef, max_nsteps)
         timestamps_h::Vector{T} = Vector{T}(undef, max_nsteps)
         
-        n_e::Int = _drift_charge!( drift_path_e, timestamps_e, det, point_types, grid, start_points, -charges, dt, electric_field, Electron, diffusion = diffusion, self_repulsion = self_repulsion, verbose = verbose )
-        n_h::Int = _drift_charge!( drift_path_h, timestamps_h, det, point_types, grid, start_points,  charges, dt, electric_field, Hole, diffusion = diffusion, self_repulsion = self_repulsion, verbose = verbose )
+        n_e::Int = _drift_charge!( drift_path_e, timestamps_e, det, point_types, grid, start_points, -charges, dt, electric_field, Electron; diffusion, self_repulsion, geometry_check, verbose )
+        n_h::Int = _drift_charge!( drift_path_h, timestamps_h, det, point_types, grid, start_points,  charges, dt, electric_field, Hole; diffusion, self_repulsion, geometry_check, verbose )
     
         for i in eachindex(start_points)
             drift_paths[drift_path_counter + i] = EHDriftPath{T}( drift_path_e[i,1:n_e], drift_path_h[i,1:n_h], timestamps_e[1:n_e], timestamps_h[1:n_h] )
@@ -178,6 +179,7 @@ function _check_and_update_position!(
             point_types::PointTypes{T, 3, S},
             startpos::AbstractVector{CartesianPoint{T}},
             Δt::T,
+            geometry_check::Bool,
             verbose::Bool
         )::Nothing where {T <: SSDFloat, S}
         
@@ -196,7 +198,7 @@ function _check_and_update_position!(
             crossing_pos::CartesianPoint{T}, cd_point_type::UInt8, surface_normal::CartesianVector{T} = 
                 get_crossing_pos(det, point_types, copy(current_pos[n]), current_pos[n] + step_vectors[n])
             if cd_point_type == CD_ELECTRODE
-                if crossing_pos in det.contacts
+                if !geometry_check || crossing_pos in det.contacts
                     done[n] = true
                     drift_path[n,istep] = crossing_pos
                     current_pos[n] = crossing_pos
@@ -254,6 +256,7 @@ function _drift_charge!(
                             ::Type{CC};
                             diffusion::Bool = false,
                             self_repulsion::Bool = false,
+                            geometry_check::Bool = false,
                             verbose::Bool = true
                         )::Int where {T <: SSDFloat, S, CC <: ChargeCarrier}
                         
@@ -307,7 +310,7 @@ function _drift_charge!(
         _get_driftvectors!(step_vectors, done, Δt, det.semiconductor.charge_drift_model, CC)
         diffusion && _add_fieldvector_diffusion!(step_vectors, done, diffusion_length)
         _modulate_driftvectors!(step_vectors, current_pos, det.virtual_drift_volumes)
-        _check_and_update_position!(step_vectors, current_pos, done, normal, drift_path, timestamps, istep, det, grid, point_types, startpos, Δt, verbose)
+        _check_and_update_position!(step_vectors, current_pos, done, normal, drift_path, timestamps, istep, det, grid, point_types, startpos, Δt, geometry_check, verbose)
         if all(done) break end
     end
 

--- a/src/Event/Event.jl
+++ b/src/Event/Event.jl
@@ -185,6 +185,7 @@ Calculates the electron and hole drift paths for the given [`Event`](@ref) and [
 * `Δt::RealQuantity = 5u"ns"`: Time step used for the drift.
 * `diffusion::Bool = false`: Activate or deactive diffusion of charge carriers via random walk.
 * `self_repulsion::Bool = false`: Activate or deactive self-repulsion of charge carriers of the same type.
+* `geometry_check::Bool = false`: Perform extra geometry checks when determining if charge carriers have reached a contact.
 * `verbose = true`: Activate or deactivate additional info output.
 
 ## Example 
@@ -195,9 +196,9 @@ drift_charges!(evt, sim, Δt = 1u"ns", verbose = false)
 !!! note
     Using values with units for `Δt` requires the package [Unitful.jl](https://github.com/PainterQubits/Unitful.jl).
 """
-function drift_charges!(evt::Event{T}, sim::Simulation{T}; max_nsteps::Int = 1000, Δt::RealQuantity = 5u"ns", diffusion::Bool = false, self_repulsion::Bool = false, verbose::Bool = true)::Nothing where {T <: SSDFloat}
-    !in(evt, sim.detector) && move_charges_inside_semiconductor!(evt, sim.detector, verbose = verbose)
-    evt.drift_paths = drift_charges(sim, evt.locations, evt.energies, Δt = Δt, max_nsteps = max_nsteps, diffusion = diffusion, self_repulsion = self_repulsion, verbose = verbose)
+function drift_charges!(evt::Event{T}, sim::Simulation{T}; max_nsteps::Int = 1000, Δt::RealQuantity = 5u"ns", diffusion::Bool = false, self_repulsion::Bool = false, geometry_check::Bool = false, verbose::Bool = true)::Nothing where {T <: SSDFloat}
+    !in(evt, sim.detector) && move_charges_inside_semiconductor!(evt, sim.detector; verbose)
+    evt.drift_paths = drift_charges(sim, evt.locations, evt.energies; Δt, max_nsteps, diffusion, self_repulsion, geometry_check, verbose)
     nothing
 end
 function get_signal!(evt::Event{T}, sim::Simulation{T}, contact_id::Int; Δt::RealQuantity = 5u"ns")::Nothing where {T <: SSDFloat}
@@ -267,6 +268,7 @@ The output is stored in `evt.drift_paths` and `evt.waveforms`.
 * `Δt::RealQuantity = 5u"ns"`: Time step used for the drift.
 * `diffusion::Bool = false`: Activate or deactive diffusion of charge carriers via random walk.
 * `self_repulsion::Bool = false`: Activate or deactive self-repulsion of charge carriers of the same type.
+* `geometry_check::Bool = false`: Perform extra geometry checks when determining if charge carriers have reached a contact.
 * `verbose = true`: Activate or deactivate additional info output.
 
 ## Example 
@@ -276,9 +278,9 @@ simulate!(evt, sim, Δt = 1u"ns", verbose = false)
 
 See also [`drift_charges!`](@ref) and [`get_signals!`](@ref).
 """
-function simulate!(evt::Event{T}, sim::Simulation{T}; max_nsteps::Int = 1000, Δt::RealQuantity = 5u"ns", diffusion::Bool = false, self_repulsion::Bool = false, verbose::Bool = true)::Nothing where {T <: SSDFloat}
-    drift_charges!(evt, sim, max_nsteps = max_nsteps, Δt = Δt, diffusion = diffusion, self_repulsion = self_repulsion, verbose = verbose)
-    get_signals!(evt, sim, Δt = Δt)
+function simulate!(evt::Event{T}, sim::Simulation{T}; max_nsteps::Int = 1000, Δt::RealQuantity = 5u"ns", diffusion::Bool = false, self_repulsion::Bool = false, geometry_check::Bool = false, verbose::Bool = true)::Nothing where {T <: SSDFloat}
+    drift_charges!(evt, sim; max_nsteps, Δt, diffusion, self_repulsion, geometry_check, verbose)
+    get_signals!(evt, sim; Δt)
     nothing
 end
 

--- a/src/PlotRecipes/ElectricField.jl
+++ b/src/PlotRecipes/ElectricField.jl
@@ -166,7 +166,7 @@ end
 
     for el_field in (el_field_itp, el_field_itp_inv)
         paths::Array{CartesianPoint{T}, 2} = fill(zero(CartesianVector{T}), length(spawn_positions), max_nsteps)
-        last_step::Int = _drift_charge!(paths, Vector{T}(undef, max_nsteps), sim.detector, sim.point_types, sim.electric_potential.grid, CartesianPoint.(spawn_positions), ones(T, length(spawn_positions)), T(to_internal_units(Δt)), el_field, Electron, verbose = false )
+        last_step::Int = _drift_charge!(paths, Vector{T}(undef, max_nsteps), sim.detector, sim.point_types, sim.electric_potential.grid, CartesianPoint.(spawn_positions), ones(T, length(spawn_positions)), T(to_internal_units(Δt)), el_field, Electron, geometry_check = false, verbose = false)
         for i in 1:size(paths, 1)
             path = @view paths[i, 1:last_step]
             @series begin

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -1201,10 +1201,11 @@ end
 @deprecate apply_charge_drift_model!(args...; kwargs...) calculate_drift_fields!(args...; kwargs...)
 
 function drift_charges( sim::Simulation{T}, starting_positions::VectorOfArrays{CartesianPoint{T}}, energies::VectorOfArrays{T};
-                        Δt::RealQuantity = 5u"ns", max_nsteps::Int = 1000, diffusion::Bool = false, self_repulsion::Bool = false, verbose::Bool = true )::Vector{EHDriftPath{T}} where {T <: SSDFloat}
+                        Δt::RealQuantity = 5u"ns", max_nsteps::Int = 1000, diffusion::Bool = false, self_repulsion::Bool = false, 
+                        geometry_check::Bool = false, verbose::Bool = true )::Vector{EHDriftPath{T}} where {T <: SSDFloat}
     return _drift_charges(   sim.detector, sim.point_types.grid, sim.point_types, starting_positions, energies, 
-                             interpolated_vectorfield(sim.electric_field), Δt, 
-                             max_nsteps = max_nsteps, diffusion = diffusion, self_repulsion = self_repulsion, verbose = verbose)
+                             interpolated_vectorfield(sim.electric_field), Δt;
+                             max_nsteps, diffusion, self_repulsion, geometry_check, verbose)
 end
 
 function get_signal(sim::Simulation{T, CS}, drift_paths::Vector{EHDriftPath{T}}, energy_depositions::Vector{T}, contact_id::Int; Δt::TT = T(5) * u"ns") where {T <: SSDFloat, CS, TT}


### PR DESCRIPTION
**Problem**
Charge carriers incorrectly terminated when point_types flagged positions as `CD_ELECTRODE `due to grid discretization, even though they hadn't reached actual electrode geometry.(see 
https://github.com/JuliaPhysics/SolidStateDetectors.jl/discussions/474)

**Solution**
Added `crossing_pos in det.contacts` validation in `_check_and_update_position!()`:
Only terminate when charge actually reaches electrode geometry
Reclassify failed cases as `CD_FLOATING_BOUNDARY` to continue surface drift
