### PR TITLE
Raise the threshold of decay time from 1 yr to 1e+60 year

### DIFF
--- a/ext/SolidStateDetectorsGeant4Ext.jl
+++ b/ext/SolidStateDetectorsGeant4Ext.jl
@@ -174,6 +174,10 @@ function Geant4.G4JLApplication(
 
     configure(app)
     initialize(app)
+
+    # See also https://geant4-forum.web.cern.ch/t/radioactive-decay-completely-not-working/11798/4
+    ui`/process/had/rdm/thresholdForVeryLongDecayTime 1.0e+60 year`
+
     app
 
     # ToDo:


### PR DESCRIPTION
One of the undergrads in our lab, @JunwenDiao, found that 207Bi didn't have beta decay as expected with the latest version of SolidStateDetectors.jl.

![image (1)](https://github.com/user-attachments/assets/c2dd9a30-0678-4c54-aabf-9e716d0287ca)

It was later found that the issue is the same I had when I simulated events for the HADES dataset with Geant4.jl, which is that [since v11.2, the time for decay threshold has been changed to 1 year.](https://geant4-forum.web.cern.ch/t/radioactive-decay-completely-not-working/11798)

![image](https://github.com/user-attachments/assets/0f4888c1-9044-4aa3-b413-eaa73e8e30e3)

This PR could prevent others from stumbling on this in the future :)

---

The script and the config file used to generate the two plots are attached [here](https://github.com/user-attachments/files/20935778/Archive.zip).