### PR TITLE
Use `G4SingleParticleSource` instead of `G4ParticleGun` for isotope source generation.

### DIFF
--- a/ext/Geant4/g4jl_application.jl
+++ b/ext/Geant4/g4jl_application.jl
@@ -37,7 +37,7 @@ function _processHits(step::G4Step, ::G4TouchableHistory, data::SDData{T})::Bool
             # detno
             detno = Int32(1), #step |> GetPostStepPoint |> GetPhysicalVolume, # get ID?
             # thit
-            thit = T(0)*u"s", #step |> GetPostStepPoint |> GetGlobalTime,
+            thit = (step |> GetPostStepPoint |> GetGlobalTime) / Geant4.SystemOfUnits.nanosecond * u"ns",
             # edep
             edep = T(edep * 1000u"keV"),
             # pos


### PR DESCRIPTION
The resulted energy spectrum is not a Dirac delta function anymore, but
it is not similar to a typical 207-Bi spectrum either. Maybe it's caused
by the following line?

`SetParticleMomentumDirection(GetAngDist(gun), data.direction)`

It does not make sense to me that one specifies the direction of the
momentum of an isotope source. I modified it only to make the code
compile.
