### PR TITLE
Add multithreading support in the electric field calculation

### DIFF
--- a/src/ElectricField/ElectricField.jl
+++ b/src/ElectricField/ElectricField.jl
@@ -54,7 +54,7 @@ function ElectricField(epot::ElectricPotential{T, 3, S}, point_types::PointTypes
 end
 
 
-function get_electric_field_from_potential(epot::ElectricPotential{T, 3, Cylindrical}, point_types::PointTypes{T}, fieldvector_coordinates=:xyz; use_nthreads::Int = Base.Threads.threadid())::ElectricField{T, 3, Cylindrical} where {T <: SSDFloat}
+function get_electric_field_from_potential(epot::ElectricPotential{T, 3, Cylindrical}, point_types::PointTypes{T}; use_nthreads::Int = Base.Threads.threadid())::ElectricField{T, 3, Cylindrical} where {T <: SSDFloat}
     p = epot.data
     axr::Vector{T} = collect(epot.grid.axes[1])
     axφ::Vector{T} = collect(epot.grid.axes[2])
@@ -157,9 +157,7 @@ function get_electric_field_from_potential(epot::ElectricPotential{T, 3, Cylindr
             end
         end
     end
-    if fieldvector_coordinates == :xyz
-        ef = convert_field_vectors_to_xyz(ef, axφ)
-    end
+    ef = convert_field_vectors_to_xyz(ef, axφ)
     return ElectricField(ef, point_types.grid)
 end
 
@@ -175,6 +173,7 @@ function convert_field_vectors_to_xyz(field::Array{SArray{Tuple{3},T,1,3},3}, φ
     end
     return field_xyz
 end
+
 
 
 function interpolated_scalarfield(spot::ScalarPotential{T, 3, Cylindrical}) where {T}
@@ -216,9 +215,9 @@ function get_electric_field_from_potential(epot::ElectricPotential{T, 3, Cartesi
     axx::Vector{T} = collect(epot.grid.axes[1])
     axy::Vector{T} = collect(epot.grid.axes[2])
     axz::Vector{T} = collect(epot.grid.axes[3])
-    axx_ext::Vector{T} = get_extended_ticks(epot.grid.axes[1])
-    axy_ext::Vector{T} = get_extended_ticks(epot.grid.axes[2])
-    axz_ext::Vector{T} = get_extended_ticks(epot.grid.axes[3])
+    # axx_ext::Vector{T} = get_extended_ticks(epot.grid.axes[1])
+    # axy_ext::Vector{T} = get_extended_ticks(epot.grid.axes[2])
+    # axz_ext::Vector{T} = get_extended_ticks(epot.grid.axes[3])
 
     ef::Array{SVector{3, T}} = Array{SVector{3, T}}(undef, size(epot.data))
 

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -1167,7 +1167,7 @@ Calculates the [`ElectricField`](@ref) from the [`ElectricPotential`](@ref) stor
 !!! note 
     This method only works if `sim.electric_potential` has already been calculated and is not `missing`.
 """
-function calculate_electric_field!(sim::Simulation{T, CS}; n_points_in_φ::Union{Missing, Int} = missing)::Nothing where {T <: SSDFloat, CS}
+function calculate_electric_field!(sim::Simulation{T, CS}; n_points_in_φ::Union{Missing, Int} = missing, use_nthreads::Int = Base.Threads.nthreads())::Nothing where {T <: SSDFloat, CS}
     @assert !ismissing(sim.electric_potential) "Electric potential has not been calculated yet. Please run `calculate_electric_potential!(sim)` first."
     periodicity::T = width(sim.world.intervals[2])
     e_pot, point_types = if CS == Cylindrical && periodicity == T(0) # 2D, only one point in φ
@@ -1181,7 +1181,7 @@ function calculate_electric_field!(sim::Simulation{T, CS}; n_points_in_φ::Union
             end
         end
         get_2π_potential(sim.electric_potential, n_points_in_φ = n_points_in_φ),
-        get_2π_potential(sim.point_types,  n_points_in_φ = n_points_in_φ);
+        get_2π_potential(sim.point_types,  n_points_in_φ = n_points_in_φ)
     elseif CS == Cylindrical
         get_2π_potential(sim.electric_potential),
         get_2π_potential(sim.point_types)
@@ -1189,7 +1189,7 @@ function calculate_electric_field!(sim::Simulation{T, CS}; n_points_in_φ::Union
         sim.electric_potential,
         sim.point_types
     end
-    sim.electric_field = get_electric_field_from_potential(e_pot, point_types);
+    sim.electric_field = get_electric_field_from_potential(e_pot, point_types; use_nthreads)
     nothing
 end
 


### PR DESCRIPTION
Not sure why we never did this before, but the electric field calculation did not support multithreading. Adding it can result in a significant speedup.

Example:
```julia
using SolidStateDetectors, Unitful
sim = Simulation(SSD_examples[:CGD])
calculate_electric_potential!(sim, max_tick_distance = 0.05u"mm",
    max_n_iterations = 1, refinement_limits = Float64[])
```
```
Simulation: ExampleCuboid
Electric Potential Calculation
Bias voltage: 2000.0 V
Precision: Float32
Device: CPU
Max. CPU Threads: 64
Coordinate system: Cartesian
N Refinements: -> 0
Convergence limit: 1.0e-7  => 0.0002 V
Initial grid size: (374, 366, 370)

```
Before this PR:
```julia
@time calculate_electric_field!(sim)
```
```
  6.976945 seconds (16 allocations: 579.623 MiB, 3.73% gc time)
```

After this PR (using 64 threads)
```julia
@time calculate_electric_field!(sim)
```
```
  0.304666 seconds (277 allocations: 579.653 MiB, 22.28% gc time)
```

@oschulz Not sure if the increase in allocations is something to worry about or not, but it is definitely faster now.


