### PR TITLE
Explicitly add `Base.` to method for `NamedTuple` and `Symbol`

### DIFF
--- a/src/Axes/DiscreteAxis.jl
+++ b/src/Axes/DiscreteAxis.jl
@@ -257,7 +257,7 @@ end
 
 Base.convert(T::Type{DiscreteAxis}, x::NamedTuple; unit = Unitful.NoUnits) = T(x, unit = unit)
 
-function NamedTuple(ax::DiscreteAxis{T, BL, BR}; unit = Unitful.NoUnits) where {T, BL, BR}
+function Base.NamedTuple(ax::DiscreteAxis{T, BL, BR}; unit = Unitful.NoUnits) where {T, BL, BR}
     int::Interval = ax.interval
     int_types::Tuple{Symbol, Symbol} = get_boundary_types(int)
     return (

--- a/src/ElectricField/ElectricField.jl
+++ b/src/ElectricField/ElectricField.jl
@@ -25,7 +25,7 @@ end
 @inline getindex(ef::ElectricField{T, N, S}, s::Symbol) where {T, N, S} = getindex(ef.grid, s)
 
 
-function NamedTuple(ef::ElectricField{T, 3}) where {T}
+function Base.NamedTuple(ef::ElectricField{T, 3}) where {T}
     return (
         grid = NamedTuple(ef.grid),
         values = ef.data #* internal_efield_unit,

--- a/src/Grids/Grids.jl
+++ b/src/Grids/Grids.jl
@@ -132,7 +132,7 @@ end
 
 Base.convert(T::Type{Grid}, x::NamedTuple) = T(x)
 
-function NamedTuple(grid::CylindricalGrid{T}) where {T}
+function Base.NamedTuple(grid::CylindricalGrid{T}) where {T}
     axr::DiscreteAxis{T} = grid.axes[1]
     axφ::DiscreteAxis{T} = grid.axes[2]
     axz::DiscreteAxis{T} = grid.axes[3]
@@ -146,7 +146,7 @@ function NamedTuple(grid::CylindricalGrid{T}) where {T}
         )
     )
 end
-function NamedTuple(grid::CartesianGrid3D{T}) where {T}
+function Base.NamedTuple(grid::CartesianGrid3D{T}) where {T}
     axx::DiscreteAxis{T} = grid.axes[1]
     axy::DiscreteAxis{T} = grid.axes[2]
     axz::DiscreteAxis{T} = grid.axes[3]

--- a/src/MaterialProperties/MaterialProperties.jl
+++ b/src/MaterialProperties/MaterialProperties.jl
@@ -21,7 +21,7 @@ material_properties[:Vacuum] = (
 )
 
 abstract type HPGe <: AbstractDriftMaterial end 
-Symbol(::Type{HPGe}) = :HPGe
+Base.Symbol(::Type{HPGe}) = :HPGe
 material_properties[:HPGe] = (
     E_ionisation = 2.95u"eV",
     f_fano = 0.129, # https://doi.org/10.1103/PhysRev.163.238
@@ -36,7 +36,7 @@ material_properties[:HPGe] = (
 
 # These values might just be approximations
 abstract type Si <: AbstractDriftMaterial end
-Symbol(::Type{Si}) = :Si
+Base.Symbol(::Type{Si}) = :Si
 material_properties[:Si] = (
     E_ionisation = 3.62u"eV",
     f_fano = 0.11,
@@ -50,7 +50,7 @@ material_properties[:Si] = (
 )
 
 abstract type CsPbBr3 <: AbstractDriftMaterial end
-Symbol(::Type{CsPbBr3}) = :CsPbBr3
+Base.Symbol(::Type{CsPbBr3}) = :CsPbBr3
 material_properties[:CsPbBr3] = (
     name = "CsPbBr3",
     f_fano = 0.1, # https://doi.org/10.1038/s41566-020-00727-1

--- a/src/ScalarPotentials/DielectricDistribution.jl
+++ b/src/ScalarPotentials/DielectricDistribution.jl
@@ -33,7 +33,7 @@ end
 
 
 
-function NamedTuple(ϵ::DielectricDistribution{T}) where {T <: SSDFloat}
+function Base.NamedTuple(ϵ::DielectricDistribution{T}) where {T <: SSDFloat}
     return (
         grid = NamedTuple(ϵ.grid),
         values = ϵ.data,

--- a/src/ScalarPotentials/EffectiveChargeDensity.jl
+++ b/src/ScalarPotentials/EffectiveChargeDensity.jl
@@ -28,7 +28,7 @@ end
 
 
 
-function NamedTuple(ρ::EffectiveChargeDensity{T}) where {T <: SSDFloat}
+function Base.NamedTuple(ρ::EffectiveChargeDensity{T}) where {T <: SSDFloat}
     return (
         grid = NamedTuple(ρ.grid),
         values = ρ.data * internal_voltage_unit,

--- a/src/ScalarPotentials/ElectricPotential.jl
+++ b/src/ScalarPotentials/ElectricPotential.jl
@@ -25,7 +25,7 @@ end
 @inline getindex(epot::ElectricPotential{T, N, S}, s::Symbol) where {T, N, S} = getindex(epot.grid, s)
 
 
-function NamedTuple(epot::ElectricPotential{T, 3}) where {T}
+function Base.NamedTuple(epot::ElectricPotential{T, 3}) where {T}
     return (
         grid = NamedTuple(epot.grid),
         values = epot.data * u"V",

--- a/src/ScalarPotentials/ImpurityScale.jl
+++ b/src/ScalarPotentials/ImpurityScale.jl
@@ -31,7 +31,7 @@ end
 @inline getindex(impscale::ImpurityScale{T, N, S}, s::Symbol) where {T, N, S} = getindex(impscale.grid, s)
 
 
-function NamedTuple(impscale::ImpurityScale{T, 3}) where {T}
+function Base.NamedTuple(impscale::ImpurityScale{T, 3}) where {T}
     return (
         grid = NamedTuple(impscale.grid),
         values = impscale.data,

--- a/src/ScalarPotentials/PointTypes.jl
+++ b/src/ScalarPotentials/PointTypes.jl
@@ -219,7 +219,7 @@ end
 
 Base.convert(T::Type{PointTypes}, x::NamedTuple) = T(x)
 
-function NamedTuple(point_types::PointTypes{T, 3}) where {T}
+function Base.NamedTuple(point_types::PointTypes{T, 3}) where {T}
     return (
         grid = NamedTuple(point_types.grid),
         values = point_types.data,

--- a/src/ScalarPotentials/WeightingPotential.jl
+++ b/src/ScalarPotentials/WeightingPotential.jl
@@ -34,7 +34,7 @@ function WeightingPotential(nt::NamedTuple)
 end
 Base.convert(T::Type{WeightingPotential}, x::NamedTuple) = T(x)
 
-function NamedTuple(wpot::WeightingPotential{T, 3}) where {T}
+function Base.NamedTuple(wpot::WeightingPotential{T, 3}) where {T}
     return (
         grid = NamedTuple(wpot.grid),
         values = wpot.data,

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -61,7 +61,7 @@ end
 get_precision_type(::Simulation{T}) where {T} = T
 get_coordinate_system(::Simulation{T, CS}) where {T, CS} = CS
 
-function NamedTuple(sim::Simulation{T}) where {T <: SSDFloat}
+function Base.NamedTuple(sim::Simulation{T}) where {T <: SSDFloat}
     wpots_strings = ["WeightingPotential_$(contact.id)" for contact in sim.detector.contacts]
     nt = (
         detector_json_string = _namedtuple(sim.config_dict),


### PR DESCRIPTION
In `julia-1.12`, I am getting some warnings as SSD defines methods for `NamedTuple` and `Symbol` from `Base`.

Instead of just adding `import Base: NamedTuple, Symbol`, I have explicitly added the prefix `Base.` to all of these methods, which is consistent with the way SSD defines methods for other `Base` methods (e.g. `convert`, ...)
