### PR TITLE
Add `ADL2016ChargeDriftModel` with updated values and electron-drift model

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -20,6 +20,7 @@ jobs:
     strategy:
       matrix:
         version: ['1.10', '1', 'pre']
+    continue-on-error: ${{ matrix.version == 'pre' }}
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/examples/example_config_files/ADLChargeDriftModel/drift_velocity_config_2016.yaml
+++ b/examples/example_config_files/ADLChargeDriftModel/drift_velocity_config_2016.yaml
@@ -1,0 +1,20 @@
+model: ADLChargeDriftModel2016
+phi110: -45°
+material: HPGe
+drift:
+  velocity:
+    model: Bruyneel2016
+    parameters:
+      e100:
+        mu0: 37165cm^2/(V*s)
+        beta: 0.804
+        E0: 507.7V/cm
+        mun: -145cm^2/(V*s)
+      h100:
+        mu0: 62934cm^2/(V*s)
+        beta: 0.735
+        E0: 181.9V/cm
+      h111:
+        mu0: 62383cm^2/(V*s)
+        beta: 0.749
+        E0: 143.9V/cm

--- a/examples/example_config_files/ADLChargeDriftModel/drift_velocity_config_2016.yaml
+++ b/examples/example_config_files/ADLChargeDriftModel/drift_velocity_config_2016.yaml
@@ -1,4 +1,4 @@
-model: ADLChargeDriftModel2016
+model: ADL2016ChargeDriftModel
 phi110: -45°
 material: HPGe
 drift:
@@ -10,6 +10,10 @@ drift:
         beta: 0.804
         E0: 507.7V/cm
         mun: -145cm^2/(V*s)
+      escattering:
+        eta0: 0.496
+        b: 0.0296
+        Eref: 1200V/cm
       h100:
         mu0: 62934cm^2/(V*s)
         beta: 0.735

--- a/src/ChargeDriftModels/ADLChargeDriftModel/ADL2006ChargeDriftModel.jl
+++ b/src/ChargeDriftModels/ADLChargeDriftModel/ADL2006ChargeDriftModel.jl
@@ -1,0 +1,189 @@
+# This file is a part of SolidStateDetectors.jl, licensed under the MIT License (MIT).
+
+
+@doc raw"""
+    ADLChargeDriftModel{T <: SSDFloat, M <: AbstractDriftMaterial, N, TM <: AbstractTemperatureModel{T}} <: AbstractChargeDriftModel{T}
+
+Charge drift model for electrons and holes based on the AGATA Detector Library
+published in [Bruyneel _et al._, NIMA 569, 764 (2006)](https://doi.org/10.1016/j.nima.2006.08.130).
+Find a detailed description of the calculations in [ADL Charge Drift Model](@ref).
+
+## Fields
+- `electrons::CarrierParameters{T}`: Parameters to describe the electron drift along the <100> and <111> axes.
+- `holes::CarrierParameters{T}`: Parameters to describe the hole drift along the <100> and <111> axes.
+- `crystal_orientation::SMatrix{3,3,T,9}`: Rotation matrix that transforms the global coordinate system to the crystal coordinate system given by the <100>, <010> and <001> axes of the crystal.
+- `γ::SVector{N,SMatrix{3,3,T,9}}`: Reciprocal mass tensors to the `N` valleys of the conduction band.
+- `parameters::ADLParameters{T}`: Parameters needed for the calculation of the electron drift velocity.
+- `temperaturemodel::TM`: Models to scale the resulting drift velocities with respect to temperature
+
+See also [`CarrierParameters`](@ref).
+"""
+struct ADLChargeDriftModel{T <: SSDFloat, M <: AbstractDriftMaterial, N, TM <: AbstractTemperatureModel{T}} <: AbstractChargeDriftModel{T}
+    electrons::CarrierParameters{T}
+    holes::CarrierParameters{T}
+    crystal_orientation::SMatrix{3,3,T,9}
+    γ::SVector{N,SMatrix{3,3,T,9}}
+    parameters::ADLParameters{T}
+    temperaturemodel::TM
+end
+
+function ADLChargeDriftModel{T,M,N,TM}(chargedriftmodel::ADLChargeDriftModel{<:Any,M,N,TM})::ADLChargeDriftModel{T,M,N,TM} where {T <: SSDFloat, M, N, TM}
+    cdmf64 = chargedriftmodel
+    e100 = VelocityParameters{T}(cdmf64.electrons.axis100.mu0, cdmf64.electrons.axis100.beta, cdmf64.electrons.axis100.E0, cdmf64.electrons.axis100.mun)
+    e111 = VelocityParameters{T}(cdmf64.electrons.axis111.mu0, cdmf64.electrons.axis111.beta, cdmf64.electrons.axis111.E0, cdmf64.electrons.axis111.mun)
+    h100 = VelocityParameters{T}(cdmf64.holes.axis100.mu0, cdmf64.holes.axis100.beta, cdmf64.holes.axis100.E0, cdmf64.holes.axis100.mun)
+    h111 = VelocityParameters{T}(cdmf64.holes.axis111.mu0, cdmf64.holes.axis111.beta, cdmf64.holes.axis111.E0, cdmf64.holes.axis111.mun)
+    electrons = CarrierParameters{T}(e100, e111)
+    holes     = CarrierParameters{T}(h100, h111)
+    crystal_orientation = SMatrix{3,3,T,9}(cdmf64.crystal_orientation)
+    γ = Vector{SMatrix{3,3,T,9}}( cdmf64.γ )
+    parameters = ADLParameters{T}(cdmf64.parameters.ml_inv, cdmf64.parameters.mt_inv, cdmf64.parameters.Γ0_inv, cdmf64.parameters.Γ1, cdmf64.parameters.Γ2)
+    temperaturemodel::AbstractTemperatureModel{T} = cdmf64.temperaturemodel
+    ADLChargeDriftModel{T,M,N,TM}(electrons, holes, crystal_orientation, γ, parameters, temperaturemodel)
+end
+
+
+
+ADLChargeDriftModel{T}(args...; kwargs...) where {T <: SSDFloat} = ADLChargeDriftModel(args...; T=T, kwargs...)
+
+const default_ADL_config_file = joinpath(get_path_to_example_config_files(), "ADLChargeDriftModel/drift_velocity_config.yaml")
+function ADLChargeDriftModel(config_filename::AbstractString = default_ADL_config_file; kwargs...)
+    ADLChargeDriftModel(parse_config_file(config_filename); kwargs...)
+end
+
+# Check the syntax of the ADLChargeDriftModel config file before parsing
+function ADLChargeDriftModel(config::AbstractDict; kwargs...)
+    if !haskey(config, "drift") 
+        throw(ConfigFileError("ADLChargeDriftModel config file needs entry 'drift'.")) 
+    elseif !haskey(config["drift"], "velocity") 
+        throw(ConfigFileError("ADLChargeDriftModel config file needs entry 'drift/velocity'.")) 
+    elseif !haskey(config["drift"]["velocity"], "parameters")
+        throw(ConfigFileError("ADLChargeDriftModel config file needs entry 'drift/velocity/parameters'."))
+    end
+
+    for axis in ("e100", "e111", "h100", "h111")
+        if !haskey(config["drift"]["velocity"]["parameters"], axis)
+            throw(ConfigFileError("ADLChargeDriftModel config file needs entry 'drift/velocity/parameters/$(axis)'."))
+        end
+        for param in ("mu0", "beta", "E0", "mun")
+            if !haskey(config["drift"]["velocity"]["parameters"][axis], param) && !(axis[1] == 'h' && param == "mun") # holes have no μn
+                throw(ConfigFileError("ADLChargeDriftModel config file needs entry 'drift/velocity/parameters/$(axis)/$(param)'."))
+            end
+        end
+    end
+    _ADLChargeDriftModel(config; kwargs...)
+end
+
+
+function _ADLChargeDriftModel(
+        config::AbstractDict; 
+        T::Type=Float32,
+        e100μ0::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["e100"]["mu0"], 
+        e100β::Union{RealQuantity,String}  = config["drift"]["velocity"]["parameters"]["e100"]["beta"], 
+        e100E0::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["e100"]["E0"],
+        e100μn::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["e100"]["mun"],
+        e111μ0::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["e111"]["mu0"], 
+        e111β::Union{RealQuantity,String}  = config["drift"]["velocity"]["parameters"]["e111"]["beta"], 
+        e111E0::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["e111"]["E0"],
+        e111μn::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["e111"]["mun"],
+        h100μ0::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["h100"]["mu0"], 
+        h100β::Union{RealQuantity,String}  = config["drift"]["velocity"]["parameters"]["h100"]["beta"], 
+        h100E0::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["h100"]["E0"],
+        h111μ0::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["h111"]["mu0"], 
+        h111β::Union{RealQuantity,String}  = config["drift"]["velocity"]["parameters"]["h111"]["beta"], 
+        h111E0::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["h111"]["E0"],
+        material::Type{<:AbstractDriftMaterial} = HPGe,
+        temperature::Union{Missing, Real}= missing, 
+        phi110::Union{Missing, Real, AngleQuantity} = missing
+    )::ADLChargeDriftModel{T}
+    
+    e100 = VelocityParameters{T}(
+        _parse_value(T, e100μ0, internal_mobility_unit), 
+        _parse_value(T, e100β,  NoUnits), 
+        _parse_value(T, e100E0, internal_efield_unit),
+        _parse_value(T, e100μn, internal_mobility_unit)
+    )
+    
+    e111 = VelocityParameters{T}(
+        _parse_value(T, e111μ0, internal_mobility_unit), 
+        _parse_value(T, e111β,  NoUnits), 
+        _parse_value(T, e111E0, internal_efield_unit),
+        _parse_value(T, e111μn, internal_mobility_unit)
+    )
+    
+    h100 = VelocityParameters{T}(
+        _parse_value(T, h100μ0, internal_mobility_unit), 
+        _parse_value(T, h100β,  NoUnits), 
+        _parse_value(T, h100E0, internal_efield_unit),
+        0
+    )
+    
+    h111 = VelocityParameters{T}(
+        _parse_value(T, h111μ0, internal_mobility_unit), 
+        _parse_value(T, h111β,  NoUnits), 
+        _parse_value(T, h111E0, internal_efield_unit),
+        0
+    )
+
+    electrons = CarrierParameters{T}(e100, e111)
+    holes     = CarrierParameters{T}(h100, h111)
+    
+    
+    if "material" in keys(config)
+        config_material::String = config["material"]
+        if config_material == "HPGe"
+            material = HPGe
+        elseif config_material == "Si"
+            material = Si
+        else
+            @warn "Material \"$(config_material)\" not supported for ADLChargeDriftModel.\nSupported materials are \"Si\" and \"HPGe\".\nUsing \"$(Symbol(material))\" as default."
+        end
+    end
+
+    parameters = if "masses" in keys(config["drift"])
+        ml = T(config["drift"]["masses"]["ml"])
+        mt = T(config["drift"]["masses"]["mt"])
+        ADLParameters{T}(ml, mt, material)
+    else
+        ml = T(material_properties[Symbol(material)].ml)
+        mt = T(material_properties[Symbol(material)].mt)
+        ADLParameters{T}(ml, mt, material)
+    end
+
+    crystal_orientation::SMatrix{3,3,T,9} = if ismissing(phi110) 
+        if "phi110" in keys(config)
+            RotZ{T}(- π/4 - _parse_value(T, config["phi110"], u"rad"))
+        else
+            transpose(parse_rotation_matrix(T, config, u"rad")) # replace u"rad" with the units in the config file
+        end
+    else
+        RotZ{T}(- π/4 - _parse_value(T, phi110, u"rad"))
+    end
+
+    γ = setup_γj(crystal_orientation, parameters, material)
+
+    if !ismissing(temperature) temperature = T(temperature) end  #if you give the temperature it will be used, otherwise read from config file                         
+
+    if "temperature_dependence" in keys(config)
+        if "model" in keys(config["temperature_dependence"])
+            model::String = config["temperature_dependence"]["model"]
+            if model == "Linear"
+                temperaturemodel = LinearModel{T}(config, temperature = temperature)
+            elseif model == "PowerLaw"
+                temperaturemodel = PowerLawModel{T}(config, temperature = temperature)
+            elseif model == "Boltzmann"
+                temperaturemodel = BoltzmannModel{T}(config, temperature = temperature)
+            else
+                temperaturemodel = VacuumModel{T}(config)
+                println("Config File does not suit any of the predefined temperature models. The drift velocity will not be rescaled.")
+            end
+        else
+            temperaturemodel = VacuumModel{T}(config)
+            println("No temperature model specified. The drift velocity will not be rescaled.")
+        end
+    else
+        temperaturemodel = VacuumModel{T}(config)
+        # println("No temperature dependence found in Config File. The drift velocity will not be rescaled.")
+    end
+    return ADLChargeDriftModel{T,material,length(γ),typeof(temperaturemodel)}(electrons, holes, crystal_orientation, γ, parameters, temperaturemodel)
+end

--- a/src/ChargeDriftModels/ADLChargeDriftModel/ADL2016ChargeDriftModel.jl
+++ b/src/ChargeDriftModels/ADLChargeDriftModel/ADL2016ChargeDriftModel.jl
@@ -1,0 +1,163 @@
+# This file is a part of SolidStateDetectors.jl, licensed under the MIT License (MIT).
+
+@doc raw"""
+    ADL2016ChargeDriftModel{T <: SSDFloat, M <: AbstractDriftMaterial, N, TM <: AbstractTemperatureModel{T}} <: AbstractChargeDriftModel{T}
+
+Charge drift model for electrons and holes based on the AGATA Detector Library,
+published in [Bruyneel _et al._, EPJA 52, 70 (2016)](https://doi.org/10.1140/epja/i2016-16070-9).
+
+## Fields
+- `electrons::VelocityParameters{T}`: Parameters to describe the electron drift along the <100> axis.
+- `holes::CarrierParameters{T}`: Parameters to describe the hole drift along the <100> and <111> axes.
+- `crystal_orientation::SMatrix{3,3,T,9}`: Rotation matrix that transforms the global coordinate system to the crystal coordinate system given by the <100>, <010> and <001> axes of the crystal.
+- `γ::SVector{N,SMatrix{3,3,T,9}}`: Reciprocal mass tensors to the `N` valleys of the conduction band.
+- `parameters::ADLParameters{T}`: Parameters needed for the calculation of the electron drift velocity.
+- `temperaturemodel::TM`: Models to scale the resulting drift velocities with respect to temperature
+
+See also [`VelocityParameters`](@ref) and [`CarrierParameters`](@ref).
+"""
+struct ADL2016ChargeDriftModel{T <: SSDFloat, M <: AbstractDriftMaterial, N, TM <: AbstractTemperatureModel{T}} <: AbstractChargeDriftModel{T}
+    electrons::VelocityParameters{T}
+    holes::CarrierParameters{T}
+    crystal_orientation::SMatrix{3,3,T,9}
+    γ::SVector{N,SMatrix{3,3,T,9}}
+    parameters::ADLParameters{T}
+    temperaturemodel::TM
+end
+
+function _ADL2016ChargeDriftModel(
+        config::AbstractDict; 
+        T::Type=Float32,
+        e100μ0::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["e100"]["mu0"], 
+        e100β::Union{RealQuantity,String}  = config["drift"]["velocity"]["parameters"]["e100"]["beta"], 
+        e100E0::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["e100"]["E0"],
+        e100μn::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["e100"]["mun"],
+        h100μ0::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["h100"]["mu0"], 
+        h100β::Union{RealQuantity,String}  = config["drift"]["velocity"]["parameters"]["h100"]["beta"], 
+        h100E0::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["h100"]["E0"],
+        h111μ0::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["h111"]["mu0"], 
+        h111β::Union{RealQuantity,String}  = config["drift"]["velocity"]["parameters"]["h111"]["beta"], 
+        h111E0::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["h111"]["E0"],
+        material::Type{<:AbstractDriftMaterial} = HPGe,
+        temperature::Union{Missing, Real} = missing, 
+        phi110::Union{Missing, Real, AngleQuantity} = missing
+    )::ADL2016ChargeDriftModel{T}
+    
+    electrons = VelocityParameters{T}(
+        _parse_value(T, e100μ0, internal_mobility_unit), 
+        _parse_value(T, e100β,  NoUnits), 
+        _parse_value(T, e100E0, internal_efield_unit),
+        _parse_value(T, e100μn, internal_mobility_unit)
+    )
+    
+    h100 = VelocityParameters{T}(
+        _parse_value(T, h100μ0, internal_mobility_unit), 
+        _parse_value(T, h100β,  NoUnits), 
+        _parse_value(T, h100E0, internal_efield_unit),
+        0
+    )
+    
+    h111 = VelocityParameters{T}(
+        _parse_value(T, h111μ0, internal_mobility_unit), 
+        _parse_value(T, h111β,  NoUnits), 
+        _parse_value(T, h111E0, internal_efield_unit),
+        0
+    )
+
+    holes     = CarrierParameters{T}(h100, h111)
+    
+    
+    if "material" in keys(config)
+        config_material::String = config["material"]
+        if config_material == "HPGe"
+            material = HPGe
+        elseif config_material == "Si"
+            material = Si
+        else
+            @warn "Material \"$(config_material)\" not supported for ADLChargeDriftModel.\nSupported materials are \"Si\" and \"HPGe\".\nUsing \"$(Symbol(material))\" as default."
+        end
+    end
+
+    ml_inv, mt_inv = parameters = if "masses" in keys(config["drift"])
+        ml = T(config["drift"]["masses"]["ml"])
+        mt = T(config["drift"]["masses"]["mt"])
+        inv(ml), inv(mt)
+    else
+        ml = T(material_properties[Symbol(material)].ml)
+        mt = T(material_properties[Symbol(material)].mt)
+        inv(ml), inv(mt)
+    end
+    
+    η0 = 0.496
+    b = 0.0296
+    Eref = 120000.0 # V/m = 1200V/cm
+    parameters = ADLParameters{T}(ml_inv, mt_inv, η0, b, Eref)
+    
+
+    crystal_orientation::SMatrix{3,3,T,9} = if ismissing(phi110) 
+        if "phi110" in keys(config)
+            RotZ{T}(- π/4 - _parse_value(T, config["phi110"], u"rad"))
+        else
+            transpose(parse_rotation_matrix(T, config, u"rad")) # replace u"rad" with the units in the config file
+        end
+    else
+        RotZ{T}(- π/4 - _parse_value(T, phi110, u"rad"))
+    end
+
+    γ = setup_γj(crystal_orientation, parameters, material)
+
+    if !ismissing(temperature) temperature = T(temperature) end  #if you give the temperature it will be used, otherwise read from config file                         
+
+    if "temperature_dependence" in keys(config)
+        if "model" in keys(config["temperature_dependence"])
+            model::String = config["temperature_dependence"]["model"]
+            if model == "Linear"
+                temperaturemodel = LinearModel{T}(config, temperature = temperature)
+            elseif model == "PowerLaw"
+                temperaturemodel = PowerLawModel{T}(config, temperature = temperature)
+            elseif model == "Boltzmann"
+                temperaturemodel = BoltzmannModel{T}(config, temperature = temperature)
+            else
+                temperaturemodel = VacuumModel{T}(config)
+                println("Config File does not suit any of the predefined temperature models. The drift velocity will not be rescaled.")
+            end
+        else
+            temperaturemodel = VacuumModel{T}(config)
+            println("No temperature model specified. The drift velocity will not be rescaled.")
+        end
+    else
+        temperaturemodel = VacuumModel{T}(config)
+        # println("No temperature dependence found in Config File. The drift velocity will not be rescaled.")
+    end
+    return ADL2016ChargeDriftModel{T,material,length(γ),typeof(temperaturemodel)}(electrons, holes, crystal_orientation, γ, parameters, temperaturemodel)
+end
+
+# Check the syntax of the ADL2016ChargeDriftModel config file before parsing
+function ADL2016ChargeDriftModel(config::AbstractDict; kwargs...)
+    if !haskey(config, "drift") 
+        throw(ConfigFileError("ADL2016ChargeDriftModel config file needs entry 'drift'.")) 
+    elseif !haskey(config["drift"], "velocity") 
+        throw(ConfigFileError("ADL2016ChargeDriftModel config file needs entry 'drift/velocity'.")) 
+    elseif !haskey(config["drift"]["velocity"], "parameters")
+        throw(ConfigFileError("ADL2016ChargeDriftModel config file needs entry 'drift/velocity/parameters'."))
+    end
+
+    for axis in ("e100", "h100", "h111")
+        if !haskey(config["drift"]["velocity"]["parameters"], axis)
+            throw(ConfigFileError("ADLCharge2016DriftModel config file needs entry 'drift/velocity/parameters/$(axis)'."))
+        end
+        for param in ("mu0", "beta", "E0", "mun")
+            if !haskey(config["drift"]["velocity"]["parameters"][axis], param) && !(axis[1] == 'h' && param == "mun") # holes have no μn
+                throw(ConfigFileError("ADLCharge2016DriftModel config file needs entry 'drift/velocity/parameters/$(axis)/$(param)'."))
+            end
+        end
+    end
+    _ADL2016ChargeDriftModel(config; kwargs...)
+end
+
+const default_ADL2016_config_file = joinpath(get_path_to_example_config_files(), "ADLChargeDriftModel/drift_velocity_config_2016.yaml")
+function ADL2016ChargeDriftModel(config_filename::AbstractString = default_ADL2016_config_file; kwargs...)
+    ADL2016ChargeDriftModel(parse_config_file(config_filename); kwargs...)
+end
+
+ADL2016ChargeDriftModel{T}(args...; kwargs...) where {T <: SSDFloat} = ADL2016ChargeDriftModel(args...; T=T, kwargs...)

--- a/src/ChargeDriftModels/ADLChargeDriftModel/ADL2016ChargeDriftModel.jl
+++ b/src/ChargeDriftModels/ADLChargeDriftModel/ADL2016ChargeDriftModel.jl
@@ -32,6 +32,9 @@ function _ADL2016ChargeDriftModel(
         e100β::Union{RealQuantity,String}  = config["drift"]["velocity"]["parameters"]["e100"]["beta"], 
         e100E0::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["e100"]["E0"],
         e100μn::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["e100"]["mun"],
+        η0::Union{Real,String}             = 0.496,
+        b::Union{Real,String}              = 0.0296,
+        Eref::Union{RealQuantity,String}   = 120000.0,
         h100μ0::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["h100"]["mu0"], 
         h100β::Union{RealQuantity,String}  = config["drift"]["velocity"]["parameters"]["h100"]["beta"], 
         h100E0::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["h100"]["E0"],
@@ -88,11 +91,12 @@ function _ADL2016ChargeDriftModel(
         inv(ml), inv(mt)
     end
     
-    η0 = 0.496
-    b = 0.0296
-    Eref = 120000.0 # V/m = 1200V/cm
-    parameters = ADLParameters{T}(ml_inv, mt_inv, η0, b, Eref)
-    
+    parameters = ADLParameters{T}(
+        ml_inv, mt_inv, 
+        _parse_value(T, η0, NoUnits), 
+        _parse_value(T, b, NoUnits), 
+        _parse_value(T, Eref, internal_efield_unit)
+    )
 
     crystal_orientation::SMatrix{3,3,T,9} = if ismissing(phi110) 
         if "phi110" in keys(config)

--- a/src/ChargeDriftModels/ADLChargeDriftModel/ADL2016ChargeDriftModel.jl
+++ b/src/ChargeDriftModels/ADLChargeDriftModel/ADL2016ChargeDriftModel.jl
@@ -32,9 +32,9 @@ function _ADL2016ChargeDriftModel(
         e100β::Union{RealQuantity,String}  = config["drift"]["velocity"]["parameters"]["e100"]["beta"], 
         e100E0::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["e100"]["E0"],
         e100μn::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["e100"]["mun"],
-        η0::Union{Real,String}             = 0.496,
-        b::Union{Real,String}              = 0.0296,
-        Eref::Union{RealQuantity,String}   = 120000.0,
+        η0::Union{Real,String}             = config["drift"]["velocity"]["parameters"]["escattering"]["eta0"],
+        b::Union{Real,String}              = config["drift"]["velocity"]["parameters"]["escattering"]["b"],
+        Eref::Union{RealQuantity,String}   = config["drift"]["velocity"]["parameters"]["escattering"]["Eref"],
         h100μ0::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["h100"]["mu0"], 
         h100β::Union{RealQuantity,String}  = config["drift"]["velocity"]["parameters"]["h100"]["beta"], 
         h100E0::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["h100"]["E0"],
@@ -146,11 +146,11 @@ function ADL2016ChargeDriftModel(config::AbstractDict; kwargs...)
         throw(ConfigFileError("ADL2016ChargeDriftModel config file needs entry 'drift/velocity/parameters'."))
     end
 
-    for axis in ("e100", "h100", "h111")
+    for axis in ("e100", "escattering", "h100", "h111")
         if !haskey(config["drift"]["velocity"]["parameters"], axis)
             throw(ConfigFileError("ADLCharge2016DriftModel config file needs entry 'drift/velocity/parameters/$(axis)'."))
         end
-        for param in ("mu0", "beta", "E0", "mun")
+        for param in (axis == "escattering" ? ("eta0", "b", "Eref") : ("mu0", "beta", "E0", "mun"))
             if !haskey(config["drift"]["velocity"]["parameters"][axis], param) && !(axis[1] == 'h' && param == "mun") # holes have no μn
                 throw(ConfigFileError("ADLCharge2016DriftModel config file needs entry 'drift/velocity/parameters/$(axis)/$(param)'."))
             end

--- a/src/ChargeDriftModels/ADLChargeDriftModel/ADLChargeDriftModel.jl
+++ b/src/ChargeDriftModels/ADLChargeDriftModel/ADLChargeDriftModel.jl
@@ -1,3 +1,5 @@
+# This file is a part of SolidStateDetectors.jl, licensed under the MIT License (MIT).
+
 @doc raw"""
 
     struct VelocityParameters{T <: SSDFloat}
@@ -33,6 +35,11 @@ struct VelocityParameters{T <: SSDFloat}
     mun::T
 end
 
+# Longitudinal drift velocity formula
+@fastmath function Vl(Emag::T, params::VelocityParameters{T})::T where {T <: SSDFloat}
+    params.mu0 * Emag / (1 + (Emag / params.E0)^params.beta)^(1 / params.beta) - params.mun * Emag
+end
+
 @doc raw"""
 
     struct CarrierParameters{T <: SSDFloat}
@@ -60,8 +67,12 @@ end
 
 # Temperature models
 include("TemperatureModels/TemperatureModels.jl")
+include("ADL2006ChargeDriftModel.jl")
+include("ADL2016ChargeDriftModel.jl")
 
-# Electron model parametrization from [3]
+
+# Electron model parametrization from Mihailescu (2000)
+# https://doi.org/10.1016/S0168-9002(99)01286-3
 @fastmath function γj(j::Integer, crystal_orientation::SMatrix{3,3,T,9}, γ0::SMatrix{3,3,T,9}, ::Type{HPGe})::SMatrix{3,3,T,9} where {T <: SSDFloat}
     tmp::T = 2 / 3
     a::T = acos(sqrt(tmp))
@@ -111,200 +122,6 @@ end
     ADLParameters{T}(ml_inv, mt_inv, Γ0, Γ1, Γ2)
 end
 
-
-# Longitudinal drift velocity formula
-@fastmath function Vl(Emag::T, params::VelocityParameters{T})::T where {T <: SSDFloat}
-    params.mu0 * Emag / (1 + (Emag / params.E0)^params.beta)^(1 / params.beta) - params.mun * Emag
-end
-
-
-@doc raw"""
-    ADLChargeDriftModel{T <: SSDFloat, M <: AbstractDriftMaterial, N, TM <: AbstractTemperatureModel{T}} <: AbstractChargeDriftModel{T}
-
-Charge drift model for electrons and holes based on the AGATA Detector Library.
-Find a detailed description of the calculations in [ADL Charge Drift Model](@ref).
-
-## Fields
-- `electrons::CarrierParameters{T}`: Parameters to describe the electron drift along the <100> and <111> axes.
-- `holes::CarrierParameters{T}`: Parameters to describe the hole drift along the <100> and <111> axes.
-- `crystal_orientation::SMatrix{3,3,T,9}`: Rotation matrix that transforms the global coordinate system to the crystal coordinate system given by the <100>, <010> and <001> axes of the crystal.
-- `γ::SVector{N,SMatrix{3,3,T,9}}`: Reciprocal mass tensors to the `N` valleys of the conduction band.
-- `parameters::ADLParameters{T}`: Parameters needed for the calculation of the electron drift velocity.
-- `temperaturemodel::TM`: Models to scale the resulting drift velocities with respect to temperature
-
-See also [`CarrierParameters`](@ref).
-"""
-struct ADLChargeDriftModel{T <: SSDFloat, M <: AbstractDriftMaterial, N, TM <: AbstractTemperatureModel{T}} <: AbstractChargeDriftModel{T}
-    electrons::CarrierParameters{T}
-    holes::CarrierParameters{T}
-    crystal_orientation::SMatrix{3,3,T,9}
-    γ::SVector{N,SMatrix{3,3,T,9}}
-    parameters::ADLParameters{T}
-    temperaturemodel::TM
-end
-
-function ADLChargeDriftModel{T,M,N,TM}(chargedriftmodel::ADLChargeDriftModel{<:Any,M,N,TM})::ADLChargeDriftModel{T,M,N,TM} where {T <: SSDFloat, M, N, TM}
-    cdmf64 = chargedriftmodel
-    e100 = VelocityParameters{T}(cdmf64.electrons.axis100.mu0, cdmf64.electrons.axis100.beta, cdmf64.electrons.axis100.E0, cdmf64.electrons.axis100.mun)
-    e111 = VelocityParameters{T}(cdmf64.electrons.axis111.mu0, cdmf64.electrons.axis111.beta, cdmf64.electrons.axis111.E0, cdmf64.electrons.axis111.mun)
-    h100 = VelocityParameters{T}(cdmf64.holes.axis100.mu0, cdmf64.holes.axis100.beta, cdmf64.holes.axis100.E0, cdmf64.holes.axis100.mun)
-    h111 = VelocityParameters{T}(cdmf64.holes.axis111.mu0, cdmf64.holes.axis111.beta, cdmf64.holes.axis111.E0, cdmf64.holes.axis111.mun)
-    electrons = CarrierParameters{T}(e100, e111)
-    holes     = CarrierParameters{T}(h100, h111)
-    crystal_orientation = SMatrix{3,3,T,9}(cdmf64.crystal_orientation)
-    γ = Vector{SMatrix{3,3,T,9}}( cdmf64.γ )
-    parameters = ADLParameters{T}(cdmf64.parameters.ml_inv, cdmf64.parameters.mt_inv, cdmf64.parameters.Γ0_inv, cdmf64.parameters.Γ1, cdmf64.parameters.Γ2)
-    temperaturemodel::AbstractTemperatureModel{T} = cdmf64.temperaturemodel
-    ADLChargeDriftModel{T,M,N,TM}(electrons, holes, crystal_orientation, γ, parameters, temperaturemodel)
-end
-
-
-
-ADLChargeDriftModel{T}(args...; kwargs...) where {T <: SSDFloat} = ADLChargeDriftModel(args...; T=T, kwargs...)
-
-const default_ADL_config_file = joinpath(get_path_to_example_config_files(), "ADLChargeDriftModel/drift_velocity_config.yaml")
-function ADLChargeDriftModel(config_filename::AbstractString = default_ADL_config_file; kwargs...)
-    ADLChargeDriftModel(parse_config_file(config_filename); kwargs...)
-end
-
-# Check the syntax of the ADLChargeDriftModel config file before parsing
-function ADLChargeDriftModel(config::AbstractDict; kwargs...)
-    if !haskey(config, "drift") 
-        throw(ConfigFileError("ADLChargeDriftModel config file needs entry 'drift'.")) 
-    elseif !haskey(config["drift"], "velocity") 
-        throw(ConfigFileError("ADLChargeDriftModel config file needs entry 'drift/velocity'.")) 
-    elseif !haskey(config["drift"]["velocity"], "parameters")
-        throw(ConfigFileError("ADLChargeDriftModel config file needs entry 'drift/velocity/parameters'."))
-    end
-
-    for axis in ("e100", "e111", "h100", "h111")
-        if !haskey(config["drift"]["velocity"]["parameters"], axis)
-            throw(ConfigFileError("ADLChargeDriftModel config file needs entry 'drift/velocity/parameters/$(axis)'."))
-        end
-        for param in ("mu0", "beta", "E0", "mun")
-            if !haskey(config["drift"]["velocity"]["parameters"][axis], param) && !(axis[1] == 'h' && param == "mun") # holes have no μn
-                throw(ConfigFileError("ADLChargeDriftModel config file needs entry 'drift/velocity/parameters/$(axis)/$(param)'."))
-            end
-        end
-    end
-    _ADLChargeDriftModel(config; kwargs...)
-end
-
-
-function _ADLChargeDriftModel(
-        config::AbstractDict; 
-        T::Type=Float32,
-        e100μ0::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["e100"]["mu0"], 
-        e100β::Union{RealQuantity,String}  = config["drift"]["velocity"]["parameters"]["e100"]["beta"], 
-        e100E0::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["e100"]["E0"],
-        e100μn::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["e100"]["mun"],
-        e111μ0::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["e111"]["mu0"], 
-        e111β::Union{RealQuantity,String}  = config["drift"]["velocity"]["parameters"]["e111"]["beta"], 
-        e111E0::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["e111"]["E0"],
-        e111μn::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["e111"]["mun"],
-        h100μ0::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["h100"]["mu0"], 
-        h100β::Union{RealQuantity,String}  = config["drift"]["velocity"]["parameters"]["h100"]["beta"], 
-        h100E0::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["h100"]["E0"],
-        h111μ0::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["h111"]["mu0"], 
-        h111β::Union{RealQuantity,String}  = config["drift"]["velocity"]["parameters"]["h111"]["beta"], 
-        h111E0::Union{RealQuantity,String} = config["drift"]["velocity"]["parameters"]["h111"]["E0"],
-        material::Type{<:AbstractDriftMaterial} = HPGe,
-        temperature::Union{Missing, Real}= missing, 
-        phi110::Union{Missing, Real, AngleQuantity} = missing
-    )::ADLChargeDriftModel{T}
-    
-    e100 = VelocityParameters{T}(
-        _parse_value(T, e100μ0, internal_mobility_unit), 
-        _parse_value(T, e100β,  NoUnits), 
-        _parse_value(T, e100E0, internal_efield_unit),
-        _parse_value(T, e100μn, internal_mobility_unit)
-    )
-    
-    e111 = VelocityParameters{T}(
-        _parse_value(T, e111μ0, internal_mobility_unit), 
-        _parse_value(T, e111β,  NoUnits), 
-        _parse_value(T, e111E0, internal_efield_unit),
-        _parse_value(T, e111μn, internal_mobility_unit)
-    )
-    
-    h100 = VelocityParameters{T}(
-        _parse_value(T, h100μ0, internal_mobility_unit), 
-        _parse_value(T, h100β,  NoUnits), 
-        _parse_value(T, h100E0, internal_efield_unit),
-        0
-    )
-    
-    h111 = VelocityParameters{T}(
-        _parse_value(T, h111μ0, internal_mobility_unit), 
-        _parse_value(T, h111β,  NoUnits), 
-        _parse_value(T, h111E0, internal_efield_unit),
-        0
-    )
-
-    electrons = CarrierParameters{T}(e100, e111)
-    holes     = CarrierParameters{T}(h100, h111)
-    
-    
-    if "material" in keys(config)
-        config_material::String = config["material"]
-        if config_material == "HPGe"
-            material = HPGe
-        elseif config_material == "Si"
-            material = Si
-        else
-            @warn "Material \"$(config_material)\" not supported for ADLChargeDriftModel.\nSupported materials are \"Si\" and \"HPGe\".\nUsing \"$(Symbol(material))\" as default."
-        end
-    end
-
-    parameters = if "masses" in keys(config["drift"])
-        ml = T(config["drift"]["masses"]["ml"])
-        mt = T(config["drift"]["masses"]["mt"])
-        ADLParameters{T}(ml, mt, material)
-    else
-        ml = T(material_properties[Symbol(material)].ml)
-        mt = T(material_properties[Symbol(material)].mt)
-        ADLParameters{T}(ml, mt, material)
-    end
-
-    crystal_orientation::SMatrix{3,3,T,9} = if ismissing(phi110) 
-        if "phi110" in keys(config)
-            RotZ{T}(- π/4 - _parse_value(T, config["phi110"], u"rad"))
-        else
-            transpose(parse_rotation_matrix(T, config, u"rad")) # replace u"rad" with the units in the config file
-        end
-    else
-        RotZ{T}(- π/4 - _parse_value(T, phi110, u"rad"))
-    end
-
-    γ = setup_γj(crystal_orientation, parameters, material)
-
-    if !ismissing(temperature) temperature = T(temperature) end  #if you give the temperature it will be used, otherwise read from config file                         
-
-    if "temperature_dependence" in keys(config)
-        if "model" in keys(config["temperature_dependence"])
-            model::String = config["temperature_dependence"]["model"]
-            if model == "Linear"
-                temperaturemodel = LinearModel{T}(config, temperature = temperature)
-            elseif model == "PowerLaw"
-                temperaturemodel = PowerLawModel{T}(config, temperature = temperature)
-            elseif model == "Boltzmann"
-                temperaturemodel = BoltzmannModel{T}(config, temperature = temperature)
-            else
-                temperaturemodel = VacuumModel{T}(config)
-                println("Config File does not suit any of the predefined temperature models. The drift velocity will not be rescaled.")
-            end
-        else
-            temperaturemodel = VacuumModel{T}(config)
-            println("No temperature model specified. The drift velocity will not be rescaled.")
-        end
-    else
-        temperaturemodel = VacuumModel{T}(config)
-        # println("No temperature dependence found in Config File. The drift velocity will not be rescaled.")
-    end
-    return ADLChargeDriftModel{T,material,length(γ),typeof(temperaturemodel)}(electrons, holes, crystal_orientation, γ, parameters, temperaturemodel)
-end
-
-
 @inline function _get_AE_and_RE(cdm::ADLChargeDriftModel{T, HPGe}, V100e::T, V111e::T)::Tuple{T,T} where{T <: SSDFloat}
     edmp::ADLParameters{T} = cdm.parameters
     AE::T = edmp.Γ0 * V100e 
@@ -350,9 +167,30 @@ end
     end
 end
 
+# Electron model parameterization from Bruyneel (2006), equations (1) - (8)
+ν(E::T, params::ADLParameters{T}) where {T <: SSDFloat} = E ^ (params.Γ0 + params.Γ1 * log(E / params.Γ2))
+ν(E::SVector{3,T}, params::ADLParameters{T}) where {T <: SSDFloat} = ν(norm(E), params)
+
+@fastmath function SolidStateDetectors.getVe(fv::SVector{3,T}, cdm::ADL2016ChargeDriftModel{T,M}, Emag_threshold::T = T(1e-5))::SVector{3,T} where {T <: SSDFloat, M}
+    @inbounds begin
+        Γ0::T = sqrt((2 * cdm.parameters.mt_inv + cdm.parameters.ml_inv)/3)
+        sqrtγ = sqrt.(cdm.γ)
+        invν = broadcast(α -> inv(ν(α * fv, cdm.parameters)), sqrtγ)
+        
+        v::SVector{3,T} = SVector{3,T}([0,0,0])
+        for j in eachindex(cdm.γ)
+            Ei::SVector{3,T} = sqrtγ[j] * fv
+            Ei_mag::T = norm(Ei)
+            μ::T = Vl(Ei_mag / Γ0, cdm.electrons) / (Γ0 * Ei_mag)
+            v -= invν[j] / sum(invν) * μ * cdm.γ[j] * fv
+        end
+
+        return v
+    end
+end
 
 
-# Hole model parametrization from [1] equations (22)-(26), adjusted
+# Hole model parametrization from Bruyneel (2006) equations (22)-(26), adjusted
 @fastmath Λ(vrel::T) where {T} = T(0.75 * (1.0 - vrel))
 
 @fastmath function Ω(vrel::T, ::Type{HPGe})::T where {T}
@@ -373,7 +211,7 @@ end
     p1 * x + p2 * x^2 + p3 * x^3 + p4 * x^4
 end
 
-@fastmath function getVh(fv::SVector{3,T}, cdm::ADLChargeDriftModel{T, M}, Emag_threshold::T = T(1e-5))::SVector{3,T} where {T <: SSDFloat, M}
+@fastmath function getVh(fv::SVector{3,T}, cdm::Union{ADLChargeDriftModel{T, M}, ADL2016ChargeDriftModel{T, M}}, Emag_threshold::T = T(1e-5))::SVector{3,T} where {T <: SSDFloat, M}
     @inbounds begin
         Emag::T = norm(fv)
         Emag_inv::T = inv(Emag)

--- a/src/SolidStateDetectors.jl
+++ b/src/SolidStateDetectors.jl
@@ -68,7 +68,7 @@ export Grid, GridPoint
 export ElectricPotential, PointTypes, EffectiveChargeDensity, DielectricDistribution, WeightingPotential, ElectricField
 export apply_initial_state!
 export calculate_electric_potential!, calculate_weighting_potential!, calculate_electric_field!, calculate_drift_fields!
-export ElectricFieldChargeDriftModel, ADLChargeDriftModel, IsotropicChargeDriftModel
+export ElectricFieldChargeDriftModel, ADLChargeDriftModel, ADL2016ChargeDriftModel, IsotropicChargeDriftModel
 export NoChargeTrappingModel, BoggsChargeTrappingModel
 export get_active_volume, is_depleted, estimate_depletion_voltage
 export calculate_stored_energy, calculate_mutual_capacitance, calculate_capacitance_matrix

--- a/test/test_charge_drift_models.jl
+++ b/test/test_charge_drift_models.jl
@@ -325,6 +325,45 @@ end
         @test cdm0.holes == cdmdict.holes
         @test cdm0.crystal_orientation == cdmdict.crystal_orientation
     end
+
+    @testset "Test parsing of ADL2016ChargeDriftModel config files with units" begin
+        cdm0 = ADL2016ChargeDriftModel(T=T) # default charge drift model
+        @test cdm0.electrons.mu0      == 3.7165f0
+        @test cdm0.electrons.beta     == 0.804f0
+        @test cdm0.electrons.E0       == 50770f0
+        @test cdm0.electrons.mun      == -0.0145f0
+        @test cdm0.parameters.Γ0      == 0.496f0  # η0
+        @test cdm0.parameters.Γ1      == 0.0296f0 # b
+        @test cdm0.parameters.Γ2      == 120000f0 # Eref
+        @test cdm0.holes.axis100.mu0  == 6.2934f0
+        @test cdm0.holes.axis100.beta == 0.735f0
+        @test cdm0.holes.axis100.E0   == 18190f0
+        @test cdm0.holes.axis111.mu0  == 6.2383f0
+        @test cdm0.holes.axis111.beta == 0.749f0
+        @test cdm0.holes.axis111.E0   == 14390f0
+    end
+
+    @testset "Test equivalence of longitudinal drift parameter implementation" begin
+    
+        # The function to determine the hole drift for both models is equivalent,
+        # so the hole drift parameters should be stored in the same way
+        cdm2016 = ADL2016ChargeDriftModel(T=T)
+        cdm = ADLChargeDriftModel(T=T,
+            e100μ0 = 37165u"cm^2/(V*s)",
+            e100β  = 0.804,
+            e100E0 = 507.7u"V/cm",
+            e100μn = -145u"cm^2/(V*s)",
+            h100μ0 = 62934u"cm^2/(V*s)",
+            h100β  = 0.735,
+            h100E0 = 181.9u"V/cm",
+            h111μ0 = 62383u"cm^2/(V*s)",
+            h111β  = 0.749,
+            h111E0 = 143.9u"V/cm"
+        )
+        
+        @test cdm2016.electrons == cdm.electrons.axis100
+        @test cdm2016.holes     == cdm.holes
+    end
 end
 
 @timed_testset "Test grouping of charges" begin


### PR DESCRIPTION
I added the charge drift model from a paper from [Bruyneel _et al._, EPJA 52, 70 (2016)](https://doi.org/10.1140/epja/i2016-16070-9), including the values quoted in Tab. 2, as well as the intervalley scattering for electrons described in [36] [Bruyneel _et al._, NIMA 569, 764 (2006)](https://doi.org/10.1016/j.nima.2006.08.130).

I named the new charge drift model `ADL2016ChargeDriftModel`, because it's also published by the same `ADL` group, just 10 years later than the `ADLChargeDriftModel` from 2006.

The values I see there are also consistent with what I saw in my PhD thesis.

<img width="400" height="280" alt="image" src="https://github.com/user-attachments/assets/3d638e17-0afd-42dd-81a5-b6e906c64581" /><img width="400" height="280" alt="image" src="https://github.com/user-attachments/assets/5590e77e-1267-4498-b586-e0aa0f7a2a24" />

I still need to add tests and some stuff in the constructor is still hard-coded, so I'll leave this as a draft PR for now.

