### PR TITLE
Improve IO by using `_parse_value` more consistently

### DIFF
--- a/src/ConstructiveSolidGeometry/IO.jl
+++ b/src/ConstructiveSolidGeometry/IO.jl
@@ -71,7 +71,7 @@ function _parse_interval_from_to(::Type{T}, dict::AbstractDict, unit::Unitful.Un
 end
 
 # parses dictionary entries of type Real, String or {"from": ..., "to": ... } to respective AbstractFloat/Interval
-@inline _parse_radial_interval(::Type{T}, x::Union{Real, String}, unit::Unitful.Units) where {T} = _parse_value(T, x, unit)
+@inline _parse_radial_interval(::Type{T}, x::Union{Real, Quantity, String}, unit::Unitful.Units) where {T} = _parse_value(T, x, unit)
 function _parse_radial_interval(::Type{T}, dict::AbstractDict, unit::Unitful.Units) where {T}
     @assert haskey(dict, "from") && haskey(dict, "to") "Please specify 'from' and 'to' in $(dict)."
     From::T, To::T = _parse_interval_from_to(T, dict, unit)
@@ -80,13 +80,14 @@ function _parse_radial_interval(::Type{T}, dict::AbstractDict, unit::Unitful.Uni
 end
 
 # parses dictionary entries of type Real, String or {"from": ..., "to": ... } to respective AbstractFloat/Interval
-@inline _parse_linear_interval(::Type{T}, x::Union{Real, String}, unit::Unitful.Units) where {T} = _parse_value(T, x, unit)/2
+@inline _parse_linear_interval(::Type{T}, x::Union{Real, Quantity, String}, unit::Unitful.Units) where {T} = _parse_value(T, x, unit)/2
 function _parse_linear_interval(::Type{T}, dict::AbstractDict, unit::Unitful.Units) where {T}
     @assert haskey(dict, "from") && haskey(dict, "to") "Please specify 'from' and 'to' in $(dict)."
     From::T, To::T = _parse_interval_from_to(T, dict, unit)
     To == -From == zero(T) ? To : (From, To) # if != 0 is influences the origin 
 end
 
+@inline _parse_linear_interval(::Type{T}, tuple::Tuple{<:Union{<:Real,<:Quantity,String}, <:Union{<:Real,<:Quantity,String}}, unit::Unitful.Units) where {T} = _parse_linear_interval(T, _parse_value.(T, tuple, unit), unit)
 function _parse_linear_interval(::Type{T}, tuple::Tuple{Real,Real}, unit::Unitful.Units) where {T}
     tuple[2] == -tuple[1] == zero(T) ? tuple[2] : (tuple[1], tuple[2]) # if != 0 is influences the origin 
 end

--- a/src/ImpurityDensities/ConstantImpurityDensity.jl
+++ b/src/ImpurityDensities/ConstantImpurityDensity.jl
@@ -27,7 +27,7 @@ function get_impurity_density(cdm::ConstantImpurityDensity{T}, pt::AbstractCoord
 end
 
 function ImpurityDensity(T::DataType, t::Val{:constant}, dict::AbstractDict, input_units::NamedTuple)
-    ρ::T = haskey(dict, "value") ? _parse_value(T, dict["value"], input_units.length^(-3)) : T(0)
+    ρ::T = _parse_value(T, get(dict, "value", 0), input_units.length^(-3))
     ConstantImpurityDensity{T}( ρ )
 end
 

--- a/src/SolidStateDetector/Contacts.jl
+++ b/src/SolidStateDetector/Contacts.jl
@@ -56,7 +56,7 @@ function Contact{T}(dict::AbstractDict, input_units::NamedTuple, outer_transform
     inner_transformations = parse_CSG_transformation(T, dict, input_units)
     transformations = combine_transformations(inner_transformations, outer_transformations)
     geometry = Geometry(T, dict["geometry"], input_units, transformations)
-    return Contact( T(dict["potential"]), material, id, name, geometry )
+    return Contact( _parse_value(T, dict["potential"], input_units.potential), material, id, name, geometry )
 end
 
 function println(io::IO, d::Contact) 

--- a/src/SolidStateDetector/Passive.jl
+++ b/src/SolidStateDetector/Passive.jl
@@ -59,11 +59,11 @@ end
 const POTENTIAL_FLOATING = NaN
 
 function Passive{T}(dict::AbstractDict, input_units::NamedTuple, outer_transformations) where {T <: SSDFloat}
-    name = haskey(dict, "name") ? dict["name"] : "External part"
-    id::Int = haskey(dict, "id") ? dict["id"] : -1
-    potential = haskey(dict, "potential") ? T(dict["potential"]) : T(POTENTIAL_FLOATING)
+    name::String = get(dict, "name", "External part")
+    id::Int = get(dict, "id", -1)
+    potential::T = _parse_value(T, get(dict, "potential", POTENTIAL_FLOATING), input_units.potential)
     material = material_properties[materials[dict["material"]]]
-    temperature = haskey(dict, "temperature") ? T(dict["temperature"]) : T(293)
+    temperature::T = _parse_value(T, get(dict, "temperature", 293u"K"), input_units.temperature)
     charge_density_model = if haskey(dict, "charge_density") 
         ChargeDensity(T, dict["charge_density"], input_units)
     elseif haskey(dict, "charge_density_model") 


### PR DESCRIPTION
Sometimes, when config files are not read in using `YAML` or `JSON` but created in a Julia session using units from `Unitful`, the IO is a bit inconsistent what can be parsed and what not.

I encountered some places where units where not allowed and adjusted the code accordingly.