### PR TITLE
Remove explicit definition of axis units in plot recipes

### DIFF
--- a/src/ConstructiveSolidGeometry/plotting/CSG/CSG.jl
+++ b/src/ConstructiveSolidGeometry/plotting/CSG/CSG.jl
@@ -29,18 +29,18 @@ end
             v = v[idx]
         end
         proj = filter(x -> x != axis, fieldnames(pointtype))
-        yunit --> internal_length_unit
+        # yunit --> internal_length_unit
         xguide --> string(proj[1])
         yguide --> string(proj[2])
         if linewidth != :auto
             markersize := linewidth
         end
         if projection == :polar && axis == :z
-            xunit --> internal_angle_unit
+            # xunit --> internal_angle_unit
             uconvert.(internal_angle_unit, atan.(v,u)), internal_length_unit*sqrt.(u.^2 + v.^2)
         else
             if isgr aspect_ratio --> 1.0 end
-            xunit --> internal_length_unit
+            # xunit --> internal_length_unit
             internal_length_unit*u, internal_length_unit*v
         end
     else

--- a/src/ConstructiveSolidGeometry/plotting/Meshing.jl
+++ b/src/ConstructiveSolidGeometry/plotting/Meshing.jl
@@ -32,11 +32,11 @@ end
 @recipe function f(m::Mesh{T}) where {T}
     seriestype := :mesh3d
     xguide --> "x"
-    xunit --> internal_length_unit
+    # xunit --> internal_length_unit
     yguide --> "y"
-    yunit --> internal_length_unit
+    # yunit --> internal_length_unit
     zguide --> "z"
-    zunit --> internal_length_unit
+    # zunit --> internal_length_unit
     unitformat --> :slash
     label --> ""
     if occursin("GRBackend", string(typeof(plotattributes[:plot_object].backend)))

--- a/src/ConstructiveSolidGeometry/plotting/PointsAndVectors/Points.jl
+++ b/src/ConstructiveSolidGeometry/plotting/PointsAndVectors/Points.jl
@@ -1,10 +1,10 @@
 @recipe function f(pt::CartesianPoint)
     xguide --> "x"
-    xunit --> internal_length_unit
+    # xunit --> internal_length_unit
     yguide --> "y"
-    yunit --> internal_length_unit
+    # yunit --> internal_length_unit
     zguide --> "z"
-    zunit --> internal_length_unit
+    # zunit --> internal_length_unit
     unitformat --> :slash
     if occursin("GRBackend", string(typeof(plotattributes[:plot_object].backend)))
         aspect_ratio --> 1.0
@@ -23,11 +23,11 @@ end
 
 @recipe function f(v::AbstractVector{<:CartesianPoint})
     xguide --> "x"
-    xunit --> internal_length_unit
+    # xunit --> internal_length_unit
     yguide --> "y"
-    yunit --> internal_length_unit
+    # yunit --> internal_length_unit
     zguide --> "z"
-    zunit --> internal_length_unit
+    # zunit --> internal_length_unit
     unitformat --> :slash
     if occursin("GRBackend", string(typeof(plotattributes[:plot_object].backend)))
         aspect_ratio --> 1.0

--- a/src/ConstructiveSolidGeometry/plotting/PointsAndVectors/Vectors.jl
+++ b/src/ConstructiveSolidGeometry/plotting/PointsAndVectors/Vectors.jl
@@ -19,11 +19,11 @@
     label --> nothing
     linecolor --> :black
     xguide --> "x"
-    xunit --> internal_length_unit
+    # xunit --> internal_length_unit
     yguide --> "y"
-    yunit --> internal_length_unit
+    # yunit --> internal_length_unit
     zguide --> "z"
-    zunit --> internal_length_unit
+    # zunit --> internal_length_unit
     unitformat --> :slash
     if occursin("GRBackend", string(typeof(plotattributes[:plot_object].backend)))
         aspect_ratio --> 1.0

--- a/src/ConstructiveSolidGeometry/plotting/VolumePrimitives/VolumePrimitives.jl
+++ b/src/ConstructiveSolidGeometry/plotting/VolumePrimitives/VolumePrimitives.jl
@@ -53,18 +53,18 @@ end
             v = v[idx]
         end
         proj = filter(x -> x != axis, fieldnames(pointtype))
-        yunit --> internal_length_unit
+        # yunit --> internal_length_unit
         xguide --> string(proj[1])
         yguide --> string(proj[2])
         if linewidth != :auto
             markersize := linewidth
         end
         if projection == :polar && axis == :z
-            xunit --> internal_angle_unit
+            # xunit --> internal_angle_unit
             uconvert.(internal_angle_unit, atan.(v,u)), internal_length_unit*sqrt.(u.^2 + v.^2)
         else
             if isgr aspect_ratio --> 1.0 end
-            xunit --> internal_length_unit
+            # xunit --> internal_length_unit
             internal_length_unit*u, internal_length_unit*v
         end
     else

--- a/src/PlotRecipes/Potentials.jl
+++ b/src/PlotRecipes/Potentials.jl
@@ -91,10 +91,10 @@ end
         if cross_section == :φ
             aspect_ratio --> 1
             xguide --> "r"
-            xunit --> internal_length_unit
+            # xunit --> internal_length_unit
             xlims --> extrema(grid.r).*internal_length_unit
             yguide --> "z"
-            yunit --> internal_length_unit
+            # yunit --> internal_length_unit
             ylims --> extrema(grid.z).*internal_length_unit
             gr_ext::Array{T,1} = midpoints(get_extended_ticks(grid.r))
             gz_ext::Array{T,1} = midpoints(get_extended_ticks(grid.z))
@@ -108,9 +108,9 @@ end
             end
         elseif cross_section == :r
             xguide --> "φ"
-            xunit --> internal_angle_unit
+            # xunit --> internal_angle_unit
             yguide --> "z"
-            yunit --> internal_length_unit
+            # yunit --> internal_length_unit
             ylims --> extrema(grid.z)*internal_length_unit
             grid.φ*internal_angle_unit, grid.z*internal_length_unit, data[idx,:,:]'*punit
         elseif cross_section == :z
@@ -167,17 +167,17 @@ end
         if cross_section == :φ
             aspect_ratio --> 1
             xguide --> "r"
-            xunit --> internal_length_unit
+            # xunit --> internal_length_unit
             yguide --> "z"
-            yunit --> internal_length_unit
+            # yunit --> internal_length_unit
             xlims --> (grid.r[2],grid.r[end-1]).*internal_length_unit
             ylims --> (grid.z[2],grid.z[end-1]).*internal_length_unit
             gr_ext*internal_length_unit, gz_ext*internal_length_unit, ϵ.data[:,idx,:]'
         elseif cross_section == :r
             xguide --> "φ"
-            xunit --> internal_angle_unit
+            # xunit --> internal_angle_unit
             yguide --> "z"
-            yunit --> internal_length_unit
+            # yunit --> internal_length_unit
             ylims --> (grid.z[2],grid.z[end-1]).*internal_length_unit
             gφ_ext*internal_angle_unit, gz_ext*internal_length_unit, ϵ.data[idx,:,:]'
         elseif cross_section == :z
@@ -235,8 +235,8 @@ end
         foreground_color_border --> nothing
         tick_direction --> :out
         unitformat --> :slash
-        xunit --> internal_length_unit
-        yunit --> internal_length_unit
+        # xunit --> internal_length_unit
+        # yunit --> internal_length_unit
         if cross_section == :x
             aspect_ratio --> 1
             xguide --> "y"
@@ -308,8 +308,8 @@ end
 
     @series begin
         unitformat --> :slash
-        xunit --> internal_length_unit
-        yunit --> internal_length_unit
+        # xunit --> internal_length_unit
+        # yunit --> internal_length_unit
         if cross_section == :x
             aspect_ratio --> 1
             xguide --> "y"


### PR DESCRIPTION
`Plots@0.14.15` introduced a new `unit` axis attribute (see https://github.com/JuliaPlots/Plots.jl/pull/5098), which in our case results in the plot recipes behaving wrongly.

We explicitly define a default value for `xunit` and `yunit` (and `zunit` in 3D plots), which can interfere if several things are plotted into the same plot.

One example of this happening is shown in the ICPC simulation tutorial, where the values are in `mm`, but the axis displays `m` and a warning is thrown.
<img width="671" height="891" alt="Screenshot from 2025-07-25 09-22-31" src="https://github.com/user-attachments/assets/d3197677-0dc9-475c-a71b-c245a7b4adb3" />

In this PR, I try the naive approach of removing the explicit definition of axis units.
We will see from the documentation build, if this was successful.
