### PR TITLE
Exclude `Geant4` tests on `pre`

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -42,6 +42,10 @@ jobs:
         with:
           skip: Pkg,TOML,Distributions,FillArrays,StaticArrays,Unitful,Geant4
       - uses: julia-actions/julia-buildpkg@v1
+      - name: Remove Geant4 on pre
+        run: julia --project="test" -e 'using Pkg; Pkg.resolve(); Pkg.rm("Geant4")'
+        shell: bash
+        if: matrix.version == 'pre'
       - uses: julia-actions/julia-runtest@v1
         with:
           coverage: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,10 +67,10 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
         env:
           PYTHON: 'Conda'
-      - name: Remove Geant4 on x86
-        run: julia --project="test" -e 'using Pkg; Pkg.rm("Geant4")'
+      - name: Remove Geant4 on x86 and pre
+        run: julia --project="test" -e 'using Pkg; Pkg.resolve(); Pkg.rm("Geant4")'
         shell: bash
-        if: matrix.arch == 'x86'
+        if: matrix.arch == 'x86' || matrix.version == 'pre'
       - uses: julia-actions/julia-runtest@v1
         with:
           coverage: ${{ matrix.version == '1.10' && matrix.os == 'ubuntu-latest' && matrix.arch == 'x64' }}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,7 +54,7 @@ end
 end
 
 @timed_testset "Geant4 extension" begin
-    if Sys.WORD_SIZE == 64 include("test_geant4.jl") end
+    if Sys.WORD_SIZE == 64 && VERSION <= v"1.12-" include("test_geant4.jl") end
 end
 
 display(testtimer())


### PR DESCRIPTION
Currently, tests on `pre` are failing due to some incompatibility with `Geant4`.
I would suggest to exclude the `Geant4` tests on `pre` until this is sorted out.