### PR TITLE
Exclude plot recipes from codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,10 @@
 # configuration related to pull request comments
 comment: false # do not comment PR with the result
 
+ignore:
+  - src/PlotRecipes
+  - src/ConstructiveSolidGeometry/plotting
+
 coverage:
   range: 30..80 # coverage lower than 50 is red, higher than 90 green, between color code
 


### PR DESCRIPTION
Code coverage is underestimated as it's missing a lot of lines in the plot recipes.
After this PR, we should get a more realistic value for the code coverage.