### PR TITLE
Fix bug in source emission in `Geant4` extension

### DIFF
--- a/ext/Geant4/g4jl_application.jl
+++ b/ext/Geant4/g4jl_application.jl
@@ -13,17 +13,17 @@ struct SSDPhysics <: G4VUserPhysicsList
 end
 
 struct SDData{T} <: G4JLSDData
-  detectorHits::DetectorHits
-  SDData{T}() where {T} = new(DetectorHits((evtno = Int32[], detno = Int32[], thit = typeof(zero(T)*u"s")[], edep = typeof(zero(T)*u"keV")[], pos = SVector{3,typeof(zero(T)*u"mm")}[])))
+    detectorHits::DetectorHits
+    SDData{T}() where {T} = new(DetectorHits((evtno = Int32[], detno = Int32[], thit = typeof(zero(T)*u"s")[], edep = typeof(zero(T)*u"keV")[], pos = SVector{3,typeof(zero(T)*u"mm")}[])))
 end
 
 function _initialize(::G4HCofThisEvent, data::SDData)::Nothing
-  empty!(data.detectorHits)
-  return
+    empty!(data.detectorHits)
+    return
 end
 
 function _endOfEvent(::G4HCofThisEvent, data::SDData)::Nothing
-  return
+    return
 end
 
 function _processHits(step::G4Step, ::G4TouchableHistory, data::SDData{T})::Bool where {T}
@@ -48,6 +48,10 @@ function _processHits(step::G4Step, ::G4TouchableHistory, data::SDData{T})::Bool
 end
 
 function endeventaction(evt::G4Event, app::G4JLApplication)
+    # direction = evt |> (evt -> GetPrimaryVertex(evt, 0)) |> (vertex -> GetPrimary(vertex, 0)) |> GetMomentumDirection
+    # pos = evt |> (evt -> GetPrimaryVertex(evt, 0)) |> GetPosition
+    # d = [x(direction), y(direction), z(direction)]
+    # @info [x(pos), y(pos), z(pos)], normalize(d)
     return
 end
 
@@ -66,31 +70,39 @@ function SSDGenerator(source::SolidStateDetectors.MonoenergeticSource;  kwargs..
     data = GeneratorData(;kwargs...)
 
     function _init(data::GeneratorData, ::Any)
-        gun = data.gun = move!(G4ParticleGun())
+        data.gun = move!(G4SingleParticleSource())
         particle = data.particle = FindParticle(source.particle_type)
-        data.position = G4ThreeVector(
+        SetParticleDefinition(data.gun, particle)
+
+        # Place the SingleParticleSource as point source
+            data.position = G4ThreeVector(
             source.position.x * Geant4.SystemOfUnits.meter,
             source.position.y * Geant4.SystemOfUnits.meter,
             source.position.z * Geant4.SystemOfUnits.meter
         )
-        SetParticlePosition(gun, data.position)
-        data.direction = G4ThreeVector(source.direction.x, source.direction.y, source.direction.z)
-        SetParticleMomentumDirection(gun, data.direction)
-        SetParticleEnergy(gun, ustrip(u"MeV", source.energy))
-        SetParticleDefinition(gun, particle)
+        posdist = GetPosDist(data.gun)
+        SetPosDisType(posdist, "Point")
+        SetCentreCoords(posdist, data.position)
+
+        # Define the source emission
+        d::CartesianVector = normalize(source.direction)
+        a::CartesianVector = normalize(d × (abs(d.x) == 1 ? CartesianVector(0,1,0) : CartesianVector(1,0,0)))
+        b::CartesianVector = normalize(a × d)
+        data.direction = G4ThreeVector(d.x, d.y, d.z)
+
+        angdist = GetAngDist(data.gun)
+        SetAngDistType(angdist, "iso")
+        DefineAngRefAxes(angdist, "angref1", G4ThreeVector(a...))
+        DefineAngRefAxes(angdist, "angref2", G4ThreeVector(b...))
+        SetMinTheta(angdist, 0.0)
+        SetMaxTheta(angdist, ustrip(NoUnits, source.opening_angle))  # convert to radians
+        # SetParticleMomentumDirection(angdist, data.direction)
+
+        # set energy
+        SetMonoEnergy(GetEneDist(data.gun), ustrip(u"MeV", source.energy))
     end
     
     function _gen(evt::G4Event, data::GeneratorData)::Nothing
-        if !iszero(source.opening_angle)
-            d::CartesianVector = normalize(source.direction)
-            a::CartesianVector = normalize(d × (abs(d.x) == 1 ? CartesianVector(0,1,0) : CartesianVector(1,0,0)))
-            b::CartesianVector = normalize(a × d)
-            ϕ = rand()*2π
-            θ = acos(1 - (1 - cos(source.opening_angle))*rand())
-            v = (cos(θ) * d + sin(θ) * (cos(ϕ) * a + sin(ϕ) * b))
-            direction = G4ThreeVector(v.x, v.y, v.z)
-            SetParticleMomentumDirection(data.gun, direction)
-        end
         GeneratePrimaryVertex(data.gun, CxxPtr(evt))
     end
 
@@ -103,16 +115,32 @@ function SSDGenerator(source::SolidStateDetectors.IsotopeSource; kwargs...)
 
     data = GeneratorData(;kwargs...)
     function _init(data::GeneratorData, ::Any)
-        gun = data.gun = move!(G4SingleParticleSource())
+        data.gun = move!(G4SingleParticleSource())
+
+        # Place the SingleParticleSource as point source
         data.position = G4ThreeVector(
             source.position.x * Geant4.SystemOfUnits.meter,
             source.position.y * Geant4.SystemOfUnits.meter,
             source.position.z * Geant4.SystemOfUnits.meter
         )
-        SetParticlePosition(gun, data.position)
-        data.direction = G4ThreeVector(source.direction.x, source.direction.y, source.direction.z)
-        SetParticleMomentumDirection(GetAngDist(gun), data.direction)
-        SetMonoEnergy(gun |> GetEneDist, 0.0 * Geant4.SystemOfUnits.MeV)
+        posdist = GetPosDist(data.gun)
+        SetPosDisType(posdist, "Point")
+        SetCentreCoords(posdist, data.position)
+
+        # Define the source emission
+        d::CartesianVector = normalize(source.direction)
+        a::CartesianVector = normalize(d × (abs(d.x) == 1 ? CartesianVector(0,1,0) : CartesianVector(1,0,0)))
+        b::CartesianVector = normalize(a × d)
+        data.direction = G4ThreeVector(d.x, d.y, d.z)
+
+        angdist = GetAngDist(data.gun)
+        SetAngDistType(angdist, "iso")
+        DefineAngRefAxes(angdist, "angref1", G4ThreeVector(a...))
+        DefineAngRefAxes(angdist, "angref2", G4ThreeVector(b...))
+        SetMinTheta(angdist, 0.0)
+        SetMaxTheta(angdist, ustrip(NoUnits, source.opening_angle))  # convert to radians
+
+        # SetMonoEnergy(GetEneDist(data.gun), 0.0 * Geant4.SystemOfUnits.MeV)
     end
 
     function _gen(evt::G4Event, data::GeneratorData)::Nothing
@@ -120,16 +148,6 @@ function SSDGenerator(source::SolidStateDetectors.IsotopeSource; kwargs...)
             data.particle = GetIon(source.Z, source.A, Float64(source.excitEnergy))
             SetParticleDefinition(data.gun, data.particle)
             SetParticleCharge(data.gun, source.ionCharge)
-        end
-        if !iszero(source.opening_angle)
-            d::CartesianVector = normalize(source.direction)
-            a::CartesianVector = normalize(d × (abs(d.x) == 1 ? CartesianVector(0,1,0) : CartesianVector(1,0,0)))
-            b::CartesianVector = normalize(a × d)
-            ϕ = rand()*2π
-            θ = acos(1 - (1 - cos(source.opening_angle))*rand())
-            v = (cos(θ) * d + sin(θ) * (cos(ϕ) * a + sin(ϕ) * b))
-            direction = G4ThreeVector(v.x, v.y, v.z)
-            SetParticleMomentumDirection(GetAngDist(data.gun), direction)
         end
         GeneratePrimaryVertex(data.gun, CxxPtr(evt))
     end


### PR DESCRIPTION
So, I think I found a fix for #513:

When using `G4SingleParticleSource` instead of `G4ParticleGun`, the position, direction and energy of the source have to be defined a slightly different way (namely using distributions rather than fixed values).

Also, it looks like `G4SingleParticleSource` ignores `SetParticleMomentumDirection`. Thus, when setting a `MinTheta` and `MaxTheta`, this is always with respect to the negative z-axis (see page 26 in the [Geant4 Book for Application Developers](https://geant4-userdoc.web.cern.ch/UsersGuides/ForApplicationDeveloper/fo/BookForApplicationDevelopers.pdf)):

<img width="810" height="487" alt="Screenshot from 2025-08-25 04-03-40" src="https://github.com/user-attachments/assets/138bceec-d312-46d3-b263-e19b4f954f5b" />

This requires to actually define the coordinate system using `angref1` and `angref2`.


I refactored the implementation of the `_init` and `_gen` methods for `MonoenergeticSource` and `IsotopeSource` to be based on `G4SingleParticleSource` and moved the definition of the source emission (line, conic, isotropic) from `_gen` to `_init`.

In order to check that the position and the momentum of the primary vertex is computed correctly, I tested the new code with a modified `endeventaction` to verify the position and momentum direction of every primary vertex:
```julia
function endeventaction(evt::G4Event, app::G4JLApplication)
    direction = evt |> (evt -> GetPrimaryVertex(evt, 0)) |> (vertex -> GetPrimary(vertex, 0)) |> GetMomentumDirection
    pos = evt |> (evt -> GetPrimaryVertex(evt, 0)) |> GetPosition
    d = [x(direction), y(direction), z(direction)]
    @info [x(pos), y(pos), z(pos)], normalize(d)
    return
end
```

I also performed some visual tests using the "ICPC in cryostat" example:

## Event distribution

### MonoenergeticSource

```julia
sim = Simulation{T}(SSD_examples[:InvertedCoaxInCryostat])
source = MonoenergeticSource("gamma", 2.615u"MeV", CartesianPoint(0.05,0,0.05), CartesianVector(-1,0,0), 10u"°")
app = G4JLApplication(sim, source)
evts = run_geant4_simulation(app, 5_000)
```
The event distribution is still as expected:
<img width="1000" height="1000" alt="image" src="https://github.com/user-attachments/assets/7fc9fcf6-954d-4e72-84fc-a77b7f7cc754" />




### IsotopeSource
In this case a 228Th source, which also emits electrons - hence, different results are achieved depending on whether the source is placed inside or outside of the cryostat

```julia
sim = Simulation{T}(SSD_examples[:InvertedCoaxInCryostat])
source = IsotopeSource(90, 228, 0.0, 0.0, CartesianPoint(0.05,0,0.05), CartesianVector(-1,0,0), 10u"°") # inside cryostat
app = G4JLApplication(sim, source)
evts = run_geant4_simulation(app, 5_000)
```
All hits:
<img width="1000" height="1000" alt="image" src="https://github.com/user-attachments/assets/3d196b5c-2a49-4b4d-8785-0661bba96743" />

Just the first hit in the detector of each event:
<img width="1000" height="1000" alt="image" src="https://github.com/user-attachments/assets/955e91e4-754d-4d2e-a7fe-acd963145f0f" />


```julia
sim = Simulation{T}(SSD_examples[:InvertedCoaxInCryostat])
source = IsotopeSource(90, 228, 0.0, 0.0, CartesianPoint(0.06,0,0.05), CartesianVector(-1,0,0), 10u"°") # outside cryostat
app = G4JLApplication(sim, source)
evts = run_geant4_simulation(app, 5_000)
```
All hits:
<img width="1000" height="1000" alt="outside cryostat" src="https://github.com/user-attachments/assets/eeb7bfa2-63f6-4a09-b343-c0bc1917374a" />

Just the first hit in the detector of each event:
<img width="1000" height="1000" alt="image" src="https://github.com/user-attachments/assets/881e53aa-0b49-429a-9fbf-1322417fa40a" />



## Energy spectra

### MonoenergeticSource
Monoenergetic gammas with an energy of 2.615MeV:
<img width="1200" height="900" alt="image" src="https://github.com/user-attachments/assets/9ef2e538-189a-4c82-817c-21cc5175b243" />

### IsotopeSource
A point-like 228Th source placed outside of the cryostat:
<img width="1200" height="900" alt="image" src="https://github.com/user-attachments/assets/06ccf5b2-aa59-4e15-a02b-b07e25228a88" />

