### PR TITLE
Correct default value in `calculate_potential!` docstrings

### DIFF
--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -1067,7 +1067,7 @@ There are several keyword arguments which can be used to tune the calculation.
     First element should be smaller than the second one and both should be `∈ [1.0, 2.0]`. Default is `[1.4, 1.85]`.
     In case of Cartesian coordinates, only one value is taken.
 * `max_n_iterations::Int`: Set the maximum number of iterations which are performed after each grid refinement.
-    Default is `10000`. If set to `-1` there will be no limit.
+    Default is `50000`. If set to `-1` there will be no limit.
 * `not_only_paint_contacts::Bool = true`: Whether to only use the painting algorithm of the surfaces of [`Contact`](@ref)
     without checking if points are actually inside them.
     Setting it to `false` should improve the performance but the points inside of [`Contact`](@ref) are not fixed anymore.    
@@ -1130,7 +1130,7 @@ There are several keyword arguments which can be used to tune the calculation.
     First element should be smaller than the second one and both should be `∈ [1.0, 2.0]`. Default is `[1.4, 1.85]`.
     In case of Cartesian coordinates, only one value is taken.
 * `max_n_iterations::Int`: Set the maximum number of iterations which are performed after each grid refinement.
-    Default is `10000`. If set to `-1` there will be no limit.
+    Default is `50000`. If set to `-1` there will be no limit.
 * `not_only_paint_contacts::Bool = true`: Whether to only use the painting algorithm of the surfaces of [`Contact`](@ref)
     without checking if points are actually inside them.
     Setting it to `false` should improve the performance but the points inside of [`Contact`](@ref) are not fixed anymore.    
@@ -1265,7 +1265,7 @@ There are several keyword arguments which can be used to tune the simulation.
     First element should be smaller than the second one and both should be `∈ [1.0, 2.0]`. Default is `[1.4, 1.85]`.
     In case of Cartesian coordinates, only one value is taken.
 * `max_n_iterations::Int`: Set the maximum number of iterations which are performed after each grid refinement.
-    Default is `10000`. If set to `-1` there will be no limit.
+    If set to `-1` there will be no limit. Default is no limit.
 * `not_only_paint_contacts::Bool = true`: Whether to only use the painting algorithm of the surfaces of [`Contact`](@ref)
     without checking if points are actually inside them.
     Setting it to `false` should improve the performance but the points inside of [`Contact`](@ref) are not fixed anymore.    


### PR DESCRIPTION
For `calculate_electric_potential!` and `calculate_weighting_potential!` (which call `_calculate_potential!`), the default value for `max_n_iterations` is `50000`
https://github.com/JuliaPhysics/SolidStateDetectors.jl/blob/6591930028f43ba3c3fc90627fd6806be23cf006/src/Simulation/Simulation.jl#L816-L833
whereas the docstring quotes the default to be `10000`.

In addition, when using `simulate!`, the default is having no limit (`-1`)
https://github.com/JuliaPhysics/SolidStateDetectors.jl/blob/6591930028f43ba3c3fc90627fd6806be23cf006/src/Simulation/Simulation.jl#L1282-L1295

I updated the respective docstring to reflect the correct defaults.