### PR TITLE
Include `Geant4` tests on `pre`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,10 +67,10 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
         env:
           PYTHON: 'Conda'
-      - name: Remove Geant4 on x86 and pre
+      - name: Remove Geant4 on x86
         run: julia --project="test" -e 'using Pkg; Pkg.resolve(); Pkg.rm("Geant4")'
         shell: bash
-        if: matrix.arch == 'x86' || matrix.version == 'pre'
+        if: matrix.arch == 'x86'
       - uses: julia-actions/julia-runtest@v1
         with:
           coverage: ${{ matrix.version == '1.10' && matrix.os == 'ubuntu-latest' && matrix.arch == 'x64' }}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,7 +54,7 @@ end
 end
 
 @timed_testset "Geant4 extension" begin
-    if Sys.WORD_SIZE == 64 && VERSION <= v"1.12-" include("test_geant4.jl") end
+    if Sys.WORD_SIZE == 64 include("test_geant4.jl") end
 end
 
 display(testtimer())


### PR DESCRIPTION
Now with `Geant4@0.2.3`, we can revert the changes made in #517 and include the `Geant4` tests on `pre` again.