### PR TITLE
Add support for simulation for dead layer - Step9: Identification of the inactive layer contact and allow for depletion voltage calculation with inactive layer

### DIFF
--- a/src/ImpurityDensities/PtypePNJunctionImpurityDensity.jl
+++ b/src/ImpurityDensities/PtypePNJunctionImpurityDensity.jl
@@ -16,10 +16,11 @@ function PtypePNJunctionImpurityDensity{T}(
     lithium_annealing_temperature::T,
     lithium_annealing_time::T,
     contact_with_lithium_doped::G,
+    inactive_contact_id::Int,
     bulk_imp_model::AbstractImpurityDensity{T},
     distance_to_contact::Function = pt::AbstractCoordinatePoint{T} -> ConstructiveSolidGeometry.distance_to_surface(pt, contact_with_lithium_doped)
     ) where {T <: SSDFloat, G <: Union{<:AbstractGeometry, Nothing}}
-    surface_imp_model = ThermalDiffusionLithiumDensity{T}(lithium_annealing_temperature, lithium_annealing_time, contact_with_lithium_doped, distance_to_contact=distance_to_contact)
+    surface_imp_model = ThermalDiffusionLithiumDensity{T}(lithium_annealing_temperature, lithium_annealing_time, contact_with_lithium_doped, inactive_contact_id, distance_to_contact=distance_to_contact)
     PtypePNJunctionImpurityDensity{T}(surface_imp_model, bulk_imp_model)
 end
 
@@ -27,8 +28,9 @@ function ImpurityDensity(T::DataType, t::Val{:PtypePNjunction}, dict::AbstractDi
     lithium_annealing_temperature = _parse_value(T, get(dict, "lithium_annealing_temperature", 623u"K"), input_units.temperature)
     lithium_annealing_time = _parse_value(T, get(dict, "lithium_annealing_time", 18u"minute"), internal_time_unit)
     contact_with_lithium_doped = get(dict, "contact_with_lithium_doped", nothing)
+    inactive_contact_id = get(dict, "doped_contact_id", 1)
     bulk_imp_model = haskey(dict, "bulk_imp_model") ? ImpurityDensity(T, dict["bulk_imp_model"], input_units) : ConstantImpurityDensity{T}(-1e16)
-    PtypePNJunctionImpurityDensity{T}(lithium_annealing_temperature, lithium_annealing_time, contact_with_lithium_doped, bulk_imp_model)
+    PtypePNJunctionImpurityDensity{T}(lithium_annealing_temperature, lithium_annealing_time, contact_with_lithium_doped, inactive_contact_id, bulk_imp_model)
 end
 
 function get_impurity_density(PtypePNjunction::PtypePNJunctionImpurityDensity{T}, pt::AbstractCoordinatePoint{T})::T where {T <: SSDFloat}

--- a/src/ImpurityDensities/ThermalDiffusionLithiumDensity.jl
+++ b/src/ImpurityDensities/ThermalDiffusionLithiumDensity.jl
@@ -22,9 +22,10 @@ Lithium impurity density model. Ref: [Dai _et al._ (2023)](https://doi.org/10.10
 * `lithium_density_on_contact::T`: optional, default is the saturated lithium density at the given temperature
 * `lithium_diffusivity_in_germanium::T`: optional, default is calculated with the annealing temperature
 """
-struct ThermalDiffusionLithiumDensity{T <: SSDFloat} <: AbstractImpurityDensity{T}
+struct ThermalDiffusionLithiumDensity{T <: SSDFloat, G <: Union{<:AbstractGeometry, Nothing}} <: AbstractImpurityDensity{T}
     lithium_annealing_temperature::T
     lithium_annealing_time::T
+    contact_with_lithium_doped::G
     distance_to_contact::Function
     lithium_density_on_contact::T
     lithium_diffusivity_in_germanium::T
@@ -48,7 +49,7 @@ function ThermalDiffusionLithiumDensity{T}(
     lithium_density_on_contact::T = calculate_lithium_saturated_density(lithium_annealing_temperature),
     lithium_diffusivity_in_germanium::T = calculate_lithium_diffusivity_in_germanium(lithium_annealing_temperature),
 ) where {T <: SSDFloat, G <: Union{<:AbstractGeometry, Nothing}}
-    ThermalDiffusionLithiumDensity{T}(lithium_annealing_temperature, lithium_annealing_time, distance_to_contact, lithium_density_on_contact, lithium_diffusivity_in_germanium)
+    ThermalDiffusionLithiumDensity{T,G}(lithium_annealing_temperature, lithium_annealing_time, contact_with_lithium_doped, distance_to_contact, lithium_density_on_contact, lithium_diffusivity_in_germanium)
 end
 
 function ImpurityDensity(T::DataType, t::Val{:li_diffusion}, dict::AbstractDict, input_units::NamedTuple)

--- a/src/PotentialCalculation/Painting.jl
+++ b/src/PotentialCalculation/Painting.jl
@@ -1,3 +1,4 @@
+
 function get_sub_ind_ranges(a::Union{
         <:Tuple{AbstractVector{<:CartesianPoint{T}}, CartesianTicksTuple{T}},
         <:Tuple{AbstractVector{<:CylindricalPoint{T}}, CylindricalTicksTuple{T}}
@@ -35,7 +36,7 @@ get_sub_ind_ranges(p::ConstructiveSolidGeometry.AbstractSurfacePrimitive{T}, gri
 get_sub_ind_ranges(p::ConstructiveSolidGeometry.AbstractSurfacePrimitive{T}, grid::CylindricalGrid{T}) where {T} = 
     get_sub_ind_ranges((CylindricalPoint.(ConstructiveSolidGeometry.extreme_points(p)), TicksTuple(grid)))
 
-function paint!(point_types, potential, face::AbstractSurfacePrimitive{T}, geometry, pot_value, grid::CartesianGrid3D{T}) where {T}
+function paint!(point_types, potential, face::AbstractSurfacePrimitive{T}, geometry, pot_value, grid::CartesianGrid3D{T}, det::SolidStateDetector{T}) where {T}
     t_idx_r1, t_idx_r2, t_idx_r3 = get_sub_ind_ranges(face, grid)
     ticks = (grid.axes[1].ticks, grid.axes[2].ticks, grid.axes[3].ticks)
     eX = CartesianVector{T}(1,0,0);
@@ -69,6 +70,12 @@ function paint!(point_types, potential, face::AbstractSurfacePrimitive{T}, geome
                 if in(pt, grid) && in(pt, geometry, csgtol)
                     point_types[i1, i2, i3] = zero(PointType)
                     potential[i1, i2, i3] = pot_value
+                    if isdefined(det.semiconductor.impurity_density_model, :surface_imp_model)
+                        doped_contact_geom = det.semiconductor.impurity_density_model.surface_imp_model.contact_with_lithium_doped
+                        if in_inactive_contact(pt, doped_contact_geom)
+                            point_types[i1, i2, i3] |= inactive_contact_bit
+                        end
+                    end
                 end
             end
         end
@@ -86,6 +93,12 @@ function paint!(point_types, potential, face::AbstractSurfacePrimitive{T}, geome
                 if in(pt, grid) && in(pt, geometry, csgtol)
                     point_types[i1, i2, i3] = zero(PointType)
                     potential[i1, i2, i3] = pot_value
+                    if isdefined(det.semiconductor.impurity_density_model, :surface_imp_model)
+                        doped_contact_geom = det.semiconductor.impurity_density_model.surface_imp_model.contact_with_lithium_doped
+                        if in_inactive_contact(pt, doped_contact_geom)
+                            point_types[i1, i2, i3] |= inactive_contact_bit
+                        end
+                    end
                 end
             end
         end
@@ -103,6 +116,12 @@ function paint!(point_types, potential, face::AbstractSurfacePrimitive{T}, geome
                 if in(pt, grid) && in(pt, geometry, csgtol)
                     point_types[i1, i2, i3] = zero(PointType)
                     potential[i1, i2, i3] = pot_value
+                    if isdefined(det.semiconductor.impurity_density_model, :surface_imp_model)
+                        doped_contact_geom = det.semiconductor.impurity_density_model.surface_imp_model.contact_with_lithium_doped
+                        if in_inactive_contact(pt, doped_contact_geom)
+                            point_types[i1, i2, i3] |= inactive_contact_bit
+                        end
+                    end
                 end
             end
         end
@@ -111,7 +130,7 @@ function paint!(point_types, potential, face::AbstractSurfacePrimitive{T}, geome
 end
 
 
-function paint!(point_types, potential, face::AbstractSurfacePrimitive{T}, geometry, pot_value, grid::CylindricalGrid) where {T}
+function paint!(point_types, potential, face::AbstractSurfacePrimitive{T}, geometry, pot_value, grid::CylindricalGrid, det::SolidStateDetector{T}) where {T}
     t_idx_r1, t_idx_r2, t_idx_r3 = get_sub_ind_ranges(face, grid)
     ticks = (grid.axes[1].ticks, grid.axes[2].ticks, grid.axes[3].ticks)
     eZ = CartesianVector{T}(0,0,1);
@@ -143,6 +162,12 @@ function paint!(point_types, potential, face::AbstractSurfacePrimitive{T}, geome
                 if in(pt, grid) && in(pt, geometry, csgtol)
                     point_types[i1, i2, i3] = zero(PointType)
                     potential[i1, i2, i3] = pot_value
+                    if isdefined(det.semiconductor.impurity_density_model, :surface_imp_model)
+                        doped_contact_geom = det.semiconductor.impurity_density_model.surface_imp_model.contact_with_lithium_doped
+                        if in_inactive_contact(pt, doped_contact_geom)
+                            point_types[i1, i2, i3] |= inactive_contact_bit
+                        end
+                    end
                 end
             end
         end
@@ -182,6 +207,12 @@ function paint!(point_types, potential, face::AbstractSurfacePrimitive{T}, geome
                 if in(pt_cyl, grid) && abs(pt_cyl[2] - ticks[2][i2]) < T(0.1) && in(pt_car, geometry, csgtol)
                     point_types[i1, i2, i3] = zero(PointType)
                     potential[i1, i2, i3] = pot_value
+                    if isdefined(det.semiconductor.impurity_density_model, :surface_imp_model)
+                        doped_contact_geom = det.semiconductor.impurity_density_model.surface_imp_model.contact_with_lithium_doped
+                        if in_inactive_contact(pt_cyl, doped_contact_geom)
+                            point_types[i1, i2, i3] |= inactive_contact_bit
+                        end
+                    end
                 end
             end
         end

--- a/src/PotentialCalculation/Painting.jl
+++ b/src/PotentialCalculation/Painting.jl
@@ -36,7 +36,7 @@ get_sub_ind_ranges(p::ConstructiveSolidGeometry.AbstractSurfacePrimitive{T}, gri
 get_sub_ind_ranges(p::ConstructiveSolidGeometry.AbstractSurfacePrimitive{T}, grid::CylindricalGrid{T}) where {T} = 
     get_sub_ind_ranges((CylindricalPoint.(ConstructiveSolidGeometry.extreme_points(p)), TicksTuple(grid)))
 
-function paint!(point_types, potential, face::AbstractSurfacePrimitive{T}, geometry, pot_value, grid::CartesianGrid3D{T}, det::SolidStateDetector{T}) where {T}
+function paint!(point_types, potential, face::AbstractSurfacePrimitive{T}, geometry, pot_value, grid::CartesianGrid3D{T}, is_inactive_layer_contact::Bool) where {T}
     t_idx_r1, t_idx_r2, t_idx_r3 = get_sub_ind_ranges(face, grid)
     ticks = (grid.axes[1].ticks, grid.axes[2].ticks, grid.axes[3].ticks)
     eX = CartesianVector{T}(1,0,0);
@@ -70,11 +70,8 @@ function paint!(point_types, potential, face::AbstractSurfacePrimitive{T}, geome
                 if in(pt, grid) && in(pt, geometry, csgtol)
                     point_types[i1, i2, i3] = zero(PointType)
                     potential[i1, i2, i3] = pot_value
-                    if isdefined(det.semiconductor.impurity_density_model, :surface_imp_model)
-                        doped_contact_geom = det.semiconductor.impurity_density_model.surface_imp_model.contact_with_lithium_doped
-                        if in_inactive_contact(pt, doped_contact_geom)
-                            point_types[i1, i2, i3] |= inactive_contact_bit
-                        end
+                    if is_inactive_layer_contact
+                        point_types[i1, i2, i3] |= inactive_contact_bit
                     end
                 end
             end
@@ -93,11 +90,8 @@ function paint!(point_types, potential, face::AbstractSurfacePrimitive{T}, geome
                 if in(pt, grid) && in(pt, geometry, csgtol)
                     point_types[i1, i2, i3] = zero(PointType)
                     potential[i1, i2, i3] = pot_value
-                    if isdefined(det.semiconductor.impurity_density_model, :surface_imp_model)
-                        doped_contact_geom = det.semiconductor.impurity_density_model.surface_imp_model.contact_with_lithium_doped
-                        if in_inactive_contact(pt, doped_contact_geom)
-                            point_types[i1, i2, i3] |= inactive_contact_bit
-                        end
+                    if is_inactive_layer_contact
+                        point_types[i1, i2, i3] |= inactive_contact_bit
                     end
                 end
             end
@@ -116,11 +110,8 @@ function paint!(point_types, potential, face::AbstractSurfacePrimitive{T}, geome
                 if in(pt, grid) && in(pt, geometry, csgtol)
                     point_types[i1, i2, i3] = zero(PointType)
                     potential[i1, i2, i3] = pot_value
-                    if isdefined(det.semiconductor.impurity_density_model, :surface_imp_model)
-                        doped_contact_geom = det.semiconductor.impurity_density_model.surface_imp_model.contact_with_lithium_doped
-                        if in_inactive_contact(pt, doped_contact_geom)
-                            point_types[i1, i2, i3] |= inactive_contact_bit
-                        end
+                    if is_inactive_layer_contact
+                        point_types[i1, i2, i3] |= inactive_contact_bit
                     end
                 end
             end
@@ -129,8 +120,7 @@ function paint!(point_types, potential, face::AbstractSurfacePrimitive{T}, geome
     nothing
 end
 
-
-function paint!(point_types, potential, face::AbstractSurfacePrimitive{T}, geometry, pot_value, grid::CylindricalGrid, det::SolidStateDetector{T}) where {T}
+function paint!(point_types, potential, face::AbstractSurfacePrimitive{T}, geometry, pot_value, grid::CylindricalGrid, is_inactive_layer_contact::Bool) where {T}
     t_idx_r1, t_idx_r2, t_idx_r3 = get_sub_ind_ranges(face, grid)
     ticks = (grid.axes[1].ticks, grid.axes[2].ticks, grid.axes[3].ticks)
     eZ = CartesianVector{T}(0,0,1);
@@ -162,11 +152,8 @@ function paint!(point_types, potential, face::AbstractSurfacePrimitive{T}, geome
                 if in(pt, grid) && in(pt, geometry, csgtol)
                     point_types[i1, i2, i3] = zero(PointType)
                     potential[i1, i2, i3] = pot_value
-                    if isdefined(det.semiconductor.impurity_density_model, :surface_imp_model)
-                        doped_contact_geom = det.semiconductor.impurity_density_model.surface_imp_model.contact_with_lithium_doped
-                        if in_inactive_contact(pt, doped_contact_geom)
-                            point_types[i1, i2, i3] |= inactive_contact_bit
-                        end
+                    if is_inactive_layer_contact
+                        point_types[i1, i2, i3] |= inactive_contact_bit
                     end
                 end
             end
@@ -207,11 +194,8 @@ function paint!(point_types, potential, face::AbstractSurfacePrimitive{T}, geome
                 if in(pt_cyl, grid) && abs(pt_cyl[2] - ticks[2][i2]) < T(0.1) && in(pt_car, geometry, csgtol)
                     point_types[i1, i2, i3] = zero(PointType)
                     potential[i1, i2, i3] = pot_value
-                    if isdefined(det.semiconductor.impurity_density_model, :surface_imp_model)
-                        doped_contact_geom = det.semiconductor.impurity_density_model.surface_imp_model.contact_with_lithium_doped
-                        if in_inactive_contact(pt_cyl, doped_contact_geom)
+                    if is_inactive_layer_contact
                             point_types[i1, i2, i3] |= inactive_contact_bit
-                        end
                     end
                 end
             end

--- a/src/PotentialCalculation/PotentialCalculationSetup/PotentialCalculationSetupCartesian3D.jl
+++ b/src/PotentialCalculation/PotentialCalculationSetup/PotentialCalculationSetupCartesian3D.jl
@@ -1,5 +1,6 @@
+
 function set_passive_or_contact_points(point_types::Array{PointType, 3}, potential::Array{T, 3},
-                        grid::CartesianGrid3D{T}, obj, pot::T, det::SolidStateDetector{T}, use_nthreads::Int = 1) where {T}
+                        grid::CartesianGrid3D{T}, obj, pot::T, is_inactive_layer_contact::Bool, use_nthreads::Int = 1) where {T}
     if !isnan(pot)
         @onthreads 1:use_nthreads for iz in workpart(axes(potential, 3), 1:use_nthreads, Base.Threads.threadid())
             @inbounds for iy in axes(potential, 2)
@@ -8,13 +9,9 @@ function set_passive_or_contact_points(point_types::Array{PointType, 3}, potenti
                     if pt in obj
                         potential[ ix, iy, iz ] = pot
                         point_types[ ix, iy, iz ] = zero(PointType)
-                        if isdefined(det.semiconductor.impurity_density_model, :surface_imp_model)
-                            doped_contact_geom = det.semiconductor.impurity_density_model.surface_imp_model.contact_with_lithium_doped
-                            if in_inactive_contact(pt, doped_contact_geom)
-                                point_types[ir, iφ, iz] |= inactive_contact_bit
-                            end
+                        if is_inactive_layer_contact
+                            point_types[ ix, iy, iz ] |= inactive_contact_bit
                         end
-
                     end
                 end
             end
@@ -39,26 +36,44 @@ function set_point_types_and_fixed_potentials!(point_types::Array{PointType, 3},
                 end
             end
         end
-    end   
+    end
+
+    is_inactive_layer_contact::Bool = false
+    
     if !ismissing(det.passives)
         for passive in det.passives
             pot::T = ismissing(weighting_potential_contact_id) ? passive.potential : zero(T)
-            set_passive_or_contact_points(point_types, potential, grid, passive.geometry, pot, det, use_nthreads)
+            set_passive_or_contact_points(point_types, potential, grid, passive.geometry, pot, is_inactive_layer_contact, use_nthreads)
         end
     end
     if NotOnlyPaintContacts
         for contact in det.contacts
+            is_inactive_layer_contact = false
             pot::T = ismissing(weighting_potential_contact_id) ? contact.potential : contact.id == weighting_potential_contact_id
-            set_passive_or_contact_points(point_types, potential, grid, contact.geometry, pot, det, use_nthreads)
+            if isdefined(det.semiconductor.impurity_density_model, :surface_imp_model)
+                doped_contact_id = det.semiconductor.impurity_density_model.surface_imp_model.inactive_contact_id
+                if doped_contact_id == contact.id
+                    is_inactive_layer_contact = true
+                end
+            end
+            set_passive_or_contact_points(point_types, potential, grid, contact.geometry, pot, is_inactive_layer_contact, use_nthreads)
         end
     end
     if PaintContacts
         for contact in det.contacts
+            is_inactive_layer_contact = false
             pot::T = ismissing(weighting_potential_contact_id) ? contact.potential : contact.id == weighting_potential_contact_id
+            if isdefined(det.semiconductor.impurity_density_model, :surface_imp_model)
+		doped_contact_id = det.semiconductor.impurity_density_model.surface_imp_model.inactive_contact_id
+		if doped_contact_id == contact.id
+                    is_inactive_layer_contact =	true
+                end
+	    end
             fs = ConstructiveSolidGeometry.surfaces(contact.geometry)
             for face in fs
-                paint!(point_types, potential, face, contact.geometry, pot, grid, det)
+                paint!(point_types, potential, face, contact.geometry, pot, grid, is_inactive_layer_contact)
             end
+           
         end
     end
     nothing

--- a/src/PotentialCalculation/PotentialCalculationSetup/PotentialCalculationSetupCylindrical.jl
+++ b/src/PotentialCalculation/PotentialCalculationSetup/PotentialCalculationSetupCylindrical.jl
@@ -1,5 +1,5 @@
 function set_passive_or_contact_points(point_types::Array{PointType, 3}, potential::Array{T, 3},
-                        grid::CylindricalGrid{T}, obj, pot::T, use_nthreads::Int = 1) where {T}
+                        grid::CylindricalGrid{T}, obj, pot::T, det::SolidStateDetector{T}, use_nthreads::Int = 1) where {T}
     if !isnan(pot)
         @onthreads 1:use_nthreads for iz in workpart(axes(potential, 3), 1:use_nthreads, Base.Threads.threadid())
             @inbounds for iφ in axes(potential, 2)
@@ -8,6 +8,12 @@ function set_passive_or_contact_points(point_types::Array{PointType, 3}, potenti
                     if pt in obj
                         potential[ ir, iφ, iz ] = pot
                         point_types[ ir, iφ, iz ] = zero(PointType)
+                        if isdefined(det.semiconductor.impurity_density_model, :surface_imp_model)
+                            doped_contact_geom = det.semiconductor.impurity_density_model.surface_imp_model.contact_with_lithium_doped
+                            if in_inactive_contact(pt, doped_contact_geom)
+                                point_types[ir, iφ, iz] |= inactive_contact_bit
+                            end
+                        end
                     end
                 end
             end
@@ -37,13 +43,13 @@ function set_point_types_and_fixed_potentials!(point_types::Array{PointType, 3},
     if !ismissing(det.passives)
         for passive in det.passives
             pot::T = isEP ? passive.potential : (isnan(passive.potential) ? passive.potential : zero(T))
-            set_passive_or_contact_points(point_types, potential, grid, passive.geometry, pot, use_nthreads)                              
+            set_passive_or_contact_points(point_types, potential, grid, passive.geometry, pot, det, use_nthreads)                              
         end
     end
     if NotOnlyPaintContacts
         for contact in det.contacts
             pot::T = isEP ? contact.potential : contact.id == weighting_potential_contact_id
-            set_passive_or_contact_points(point_types, potential, grid, contact.geometry, pot, use_nthreads)
+            set_passive_or_contact_points(point_types, potential, grid, contact.geometry, pot, det, use_nthreads)
         end
     end
     if PaintContacts
@@ -51,7 +57,7 @@ function set_point_types_and_fixed_potentials!(point_types::Array{PointType, 3},
             pot::T = isEP ? contact.potential : contact.id == weighting_potential_contact_id
             fs = ConstructiveSolidGeometry.surfaces(contact.geometry)
             for face in fs
-                paint!(point_types, potential, face, contact.geometry, pot, grid)
+                paint!(point_types, potential, face, contact.geometry, pot, grid, det)
             end
         end
     end

--- a/src/ScalarPotentials/PointTypes.jl
+++ b/src/ScalarPotentials/PointTypes.jl
@@ -5,11 +5,12 @@ Stores certain information about a grid point via bit-flags.
 
 Right now, there are:
 
-    const update_bit         = 0x01
-    const undepleted_bit     = 0x02
-    const pn_junction_bit    = 0x04
-    const bulk_bit           = 0x08
-    const inactive_layer_bit = 0x10
+    const update_bit           = 0x01
+    const undepleted_bit       = 0x02
+    const pn_junction_bit      = 0x04
+    const bulk_bit             = 0x08
+    const inactive_layer_bit   = 0x10
+    const inactive_contact_bit = 0x20
 
 ## Examples
 
@@ -20,15 +21,17 @@ How to get information out of a `PointType` variable `point_type`:
 4. `point_type & pn_junction_bit > 0` -> this point belongs to the solid state detector, meaning that it is in the volume of the n-type or p-type material.
 5. `point_type & bulk_bit > 0` -> this point is only surrounded by points marked as `pn_junction_bit`
 6. `point_type & inactive_layer_bit > 0` -> this point is part of the inactive layer
+7. `point_type & inactive_contact_bit > 0` -> this point is part of the contact next to the inactive layer
 """
 const PointType       = UInt8
 
 # Point types for electric potential calculation
-const update_bit         = 0x01 # parse(UInt8, "00000001", base=2) # 1 -> do update; 0 -> do not update
-const undepleted_bit     = 0x02 # parse(UInt8, "00000010", base=2) # 0 -> depleted point; 1 -> undepleted point
-const pn_junction_bit    = 0x04 # parse(UInt8, "00000100", base=2) # 0 -> point is not part of pn-junction; 1 -> point is part of the pn-junction
-const bulk_bit           = 0x08 # parse(UInt8, "00001000", base=2) # 0 -> point is surrounded by points that do not belong to the pn-junction; 1 -> point is only surrounded by points in the pn-junction
-const inactive_layer_bit = 0x10 # parse(UInt8, "00010000", base=2) # 0 -> point is not part of the inactive layer; 1 -> point is part of the inactive layer
+const update_bit           = 0x01 # parse(UInt8, "00000001", base=2) # 1 -> do update; 0 -> do not update
+const undepleted_bit       = 0x02 # parse(UInt8, "00000010", base=2) # 0 -> depleted point; 1 -> undepleted point
+const pn_junction_bit      = 0x04 # parse(UInt8, "00000100", base=2) # 0 -> point is not part of pn-junction; 1 -> point is part of the pn-junction
+const bulk_bit             = 0x08 # parse(UInt8, "00001000", base=2) # 0 -> point is surrounded by points that do not belong to the pn-junction; 1 -> point is only surrounded by points in the pn-junction
+const inactive_layer_bit   = 0x10 # parse(UInt8, "00010000", base=2) # 0 -> point is not part of the inactive layer; 1 -> point is part of the inactive layer
+const inactive_contact_bit = 0x20 # parse(UInt8, "00100000", base=2) # 0 -> point is not part of the contact next to the inactive layer; 1 -> point is part of the contact next to the inactive layer 
 
 is_pn_junction_point_type(p::PointType) = p & pn_junction_bit > 0
 is_undepleted_point_type(p::PointType) = p & undepleted_bit > 0
@@ -93,7 +96,8 @@ end
     
 Returns `true` if all [`PointType`](@ref) values of
 the [`PointTypes`](@ref) of a [`Simulation`](@ref) are marked as depleted
-and `false` if any point in the [`PointTypes`](@ref) is marked as undepleted.
+and `false` if any point in the [`PointTypes`](@ref) is marked as undepleted
+excluding the inactive layer.
 
 It can be used to determine whether the [`SolidStateDetector`](@ref) is
 depleted at the provided bias voltage.
@@ -107,8 +111,8 @@ is_depleted(sim.point_types)
 ```
 """
 is_depleted(point_types::PointTypes)::Bool = 
-    !any(b -> bulk_bit & b > 0 && undepleted_bit & b > 0, point_types.data)
-
+    !any(b -> (bulk_bit & b > 0) && (undepleted_bit & b > 0) &&
+    (inactive_layer_bit & b == 0), point_types.data)
 
 """
     get_active_volume(point_types::PointTypes{T}) where {T}
@@ -235,71 +239,42 @@ Base.convert(T::Type{NamedTuple}, x::PointTypes) = T(x)
 """
     get_inactivelayer_indices(vec::AbstractVector{PointType})::Vector{Vector{Int}}
 
-Scans a 1D vector and returns index groups that surround a `0x00` (outside the detector) and
-contain both `0x07`(part of the inactive layer, not only surrounded by pn_junction point types) and `0x0f` (also part of the inactive layer), bounded by `0x0d` (depleted region inside the detector). It finds the inactive layer bounded by 0x00 and 0x0d.
+Scans a 1D vector and returns index groups adjacent to points flagged with `inactive_contact_bit` (points that belongs yo the contact next to the inactive layer). Each group consists of consecutive indices where all of the `required_bits` (`update_bit | undepleted_bit | pn_junction_bit`) are set (undepleted points that belong to the inactive layer).
 
 Note: For detectors with undepleted regions touching the inactive layer, this method is not recommended since it won't identify the inactive layer. In this extreme case, define the inactive layer geometry boundaries via inactive_layer_geometry.
 """
+
 function get_inactivelayer_indices(vec::AbstractVector{PointType})
     pt_indices = Vector{Vector{Int}}()
     len = length(vec)
+    required_bits = update_bit | undepleted_bit | pn_junction_bit
+
     i = 1
-
     while i <= len
-        if (vec[i] & 0x0f) == 0x00
-            zero_start = i
-            while i <= len && (vec[i] & 0x0f) == 0x00
-                i += 1
+        if (vec[i] & inactive_contact_bit) != 0
+            # start checking to the right
+            region = Int[]
+            j = i + 1
+            while j <= len && (vec[j] & required_bits) == required_bits
+                push!(region, j)
+                j += 1
             end
-            zero_end = i - 1
-            zero_count = zero_end - zero_start + 1
 
-            if zero_count ≤ 2
-                start_idx = zero_start
-                while start_idx > 1 && (vec[start_idx - 1] & 0x0f) != 0x0d
-                    start_idx -= 1
-                end
-
-                end_idx = zero_end
-                while end_idx < len && (vec[end_idx + 1] & 0x0f) != 0x0d
-                    end_idx += 1
-                end
-
-                has_07 = false
-                has_0f = false
-                matching = Int[]
-                for idx in start_idx:end_idx
-                    v = vec[idx] & 0x0f
-                    if v == 0x07
-                        has_07 = true
-                        push!(matching, idx)
-                    elseif v == 0x0f
-                        has_0f = true
-                        push!(matching, idx)
-                    end
-                end
-
-                if has_07 && has_0f
-                    push!(pt_indices, matching)
-                end
+            # start checking to the left
+            j = i - 1
+            while j >= 1 && (vec[j] & required_bits) == required_bits
+                push!(region, j)
+                j -= 1
             end
-        else
-            i += 1
+
+            if !isempty(region)
+                push!(pt_indices, sort(region))
+            end
         end
+        i += 1
     end
-    
+
     return pt_indices
-end
-
-function propagate_inactive!(vec::AbstractVector{PointType})
-    for i in eachindex(vec)
-        if (vec[i] & undepleted_bit) != 0
-            if (i > firstindex(vec) && (vec[i-1] & inactive_layer_bit) != 0) ||
-               (i < lastindex(vec)  && (vec[i+1] & inactive_layer_bit) != 0)
-                vec[i] |= inactive_layer_bit
-            end
-        end
-    end
 end
 
 """
@@ -337,19 +312,6 @@ function mark_inactivelayer_bits!(point_types::Array{PointType, 3})
             vec[idx] |= inactive_layer_bit
         end
     end
-
-
-    if any((point_types .& undepleted_bit) .!= 0)
-        for j in 1:sz2, k in 1:sz3
-            propagate_inactive!(@view point_types[:, j, k])
-        end
-        for i in 1:sz1, k in 1:sz3
-            propagate_inactive!(@view point_types[i, :, k])
-        end
-        for i in 1:sz1, j in 1:sz2
-            propagate_inactive!(@view point_types[i, j, :])
-        end
-    end    
 end
 
 
@@ -368,3 +330,5 @@ Returns if a CartesianPoint belongs to the inactive layer using point types
 
 @inline in_inactive_layer(pt::CartesianPoint{T}, g::AbstractGeometry{T}, ::PointTypes{T}) where {T} = in(pt, g)
 @inline in_inactive_layer(pt::CartesianPoint{T}, ::Nothing, point_types::PointTypes{T}) where {T} = is_in_inactive_layer(point_types[pt])
+
+@inline in_inactive_contact(pt::AbstractCoordinatePoint{T}, g::AbstractGeometry{T}) where {T} = in(pt, g)

--- a/src/Simulation/DepletionVoltage.jl
+++ b/src/Simulation/DepletionVoltage.jl
@@ -94,9 +94,10 @@ function estimate_depletion_voltage(sim::Simulation{T},
     ϕρ = simDV.electric_potential.data
     ϕV = simDV.weighting_potentials[contact_id].data   
 
-    ϕρ .-= simDV.detector.contacts[contact_id].potential .* ϕV
+    ϕρ .-= simDV.detector.contacts[contact_id].potential .* ϕV    
     Urng = Umin..Umax
-    inside = findall(simDV.point_types .& 4 .> 0)
+    inside = findall((simDV.point_types .& 4 .> 0) .&
+        (simDV.point_types .& inactive_layer_bit .== 0))
     U::T = NaN
     ϕ̃ = similar(ϕV)
     while Umax-Umin>tolerance
@@ -110,7 +111,8 @@ function estimate_depletion_voltage(sim::Simulation{T},
             ϕmax - ϕmin < abs(U) ? Umin = U : Umax = U
         end        
     end
-    bulk = findall(sim.point_types.data .& bulk_bit .> 0)
+    bulk = findall((sim.point_types.data .& bulk_bit .> 0) .&
+        (sim.point_types.data .& inactive_layer_bit .== 0))
     U_min_max = filter(in(Urng), _find_depletion_voltage_candidates(ϕρ, ϕV, bulk))
     U2 = isempty(U_min_max) ? U : only(U_min_max)    
     U = U > 0 ? max(U, U2) : min(U, U2)

--- a/test/test_charge_drift_models.jl
+++ b/test/test_charge_drift_models.jl
@@ -228,7 +228,7 @@ end
         @test SolidStateDetectors.calculate_mobility(simA.detector.semiconductor.charge_drift_model, CartesianPoint{T}(0,0,0), SolidStateDetectors.Hole) isa T
     end
 
-    @testset "Test if the detector is not depleted" begin
+    @testset "Test if the detector is depleted (inactive layer is not taken into account for depletion)" begin
         mm = 1 / 1000
         pn_r = 8.957282 * mm
         g = Grid(simA)
@@ -238,7 +238,7 @@ end
         user_ax1 = typeof(ax1)(ax1.interval, user_additional_ticks_ax1)
         user_g = typeof(g)((user_ax1, ax2, ax3))
         calculate_electric_potential!(simA, grid=user_g, depletion_handling=true)
-        @test !is_depleted(simA.point_types)
+        @test is_depleted(simA.point_types)
     end
 end
 


### PR DESCRIPTION
This Pull Request includes an extra point type (inactive_contact_bit = 0x20) that identifies the contact that is next to the inactive layer. This is useful to tag the inactive layer point types in a more general way. In addition a modification is introduced to allow the depletion voltage to be calculated when an inactive layer is present. The depletion voltage excludes the undepleted inactive layer bits from the calculation.

Examples of the True and Inverted Coaxial detectors including the inactive_contact_bit painted in the point types grid for depleted and undepleted case:

```
T = Float64
sim_true = Simulation{T}(SSD_examples[:TrueCoaxial])

calculate_electric_potential!( sim_true,
                               depletion_handling = true,
                               convergence_limit = 1e-6,
                               refinement_limits = [0.2, 0.1, 0.05, 0.01],
                               verbose = false)
plot(sim_true.point_types, all_point_types=true, xlims=(0,0.02), ylims=(-0.001, 0.01))
```
<img width="600" height="400" alt="TrueCoax_PR3_depleted" src="https://github.com/user-attachments/assets/db5e0fcb-70dc-48bd-b412-7d0426da5e30" />

```
deplV = estimate_depletion_voltage(sim_true)
```
output:
[ Info: Looking for the depletion voltage applied to contact 1 in the range (-500.0 V, 0.0 V).
[ Info: The depletion voltage is around -418.3 ± 0.1 V applied to contact 1.

```
sim_undep_true = deepcopy(sim_true)
sim_undep_true.detector = SolidStateDetector(sim_undep_true.detector, contact_id = 1, contact_potential = -100);

calculate_electric_potential!( sim_undep_true,
                               depletion_handling = true,
                               convergence_limit = 1e-6,
                               refinement_limits = [0.2, 0.1, 0.05, 0.01],
                               verbose = false)

plot(sim_undep_true.point_types, all_point_types=true, xlims=(0,0.02), ylims=(-0.001, 0.01))
```
<img width="600" height="400" alt="TrueCoax_PR3_undepleted" src="https://github.com/user-attachments/assets/f137e160-0a36-493b-b084-98b9ceef8d90" />

```
T = Float64
sim = Simulation{T}(SSD_examples[:IVCIlayer])

calculate_electric_potential!( sim,
                               depletion_handling = true,
                               convergence_limit = 1e-6,
                               refinement_limits = [0.2, 0.1, 0.05, 0.01],
                               verbose = false)
plot(sim.point_types, all_point_types=true)
```
<img width="600" height="400" alt="InvertedCoax_PR3_depleted" src="https://github.com/user-attachments/assets/1ad95c64-815b-4738-847d-cfe33f682034" />

```
deplV = estimate_depletion_voltage(sim)
```
output:
[ Info: Looking for the depletion voltage applied to contact 2 in the range (0.0 V, 3500.0 V).
[ Info: The depletion voltage is around 3020.3 ± 0.1 V applied to contact 2.
```
sim_undep = deepcopy(sim)
sim_undep.detector = SolidStateDetector(sim_undep.detector, contact_id = 2, contact_potential = 500); # V  <-- Bias Voltage of Mantle

calculate_electric_potential!( sim_undep,
                               depletion_handling = true,
                               convergence_limit = 1e-6,
                               refinement_limits = [0.2, 0.1, 0.05, 0.01],
                               verbose = false)
plot(sim_undep.point_types, all_point_types=true)
```
<img width="600" height="400" alt="InvertedCoax_PR3_undepleted" src="https://github.com/user-attachments/assets/23cbe725-560f-442b-92b7-d3755cd98c89" />
