### PR TITLE
Fix weighting potential calculation using floating passives on Cartesian grids

### DIFF
--- a/src/PotentialCalculation/PotentialCalculationSetup/PotentialCalculationSetupCartesian3D.jl
+++ b/src/PotentialCalculation/PotentialCalculationSetup/PotentialCalculationSetupCartesian3D.jl
@@ -32,22 +32,23 @@ function set_point_types_and_fixed_potentials!(point_types::Array{PointType, 3},
                 end
             end
         end
-    end   
+    end
+    isEP = ismissing(weighting_potential_contact_id)
     if !ismissing(det.passives)
         for passive in det.passives
-            pot::T = ismissing(weighting_potential_contact_id) ? passive.potential : zero(T)
+            pot::T = isEP ? passive.potential : (isnan(passive.potential) ? passive.potential : zero(T))
             set_passive_or_contact_points(point_types, potential, grid, passive.geometry, pot, use_nthreads)                              
         end
     end
     if NotOnlyPaintContacts
         for contact in det.contacts
-            pot::T = ismissing(weighting_potential_contact_id) ? contact.potential : contact.id == weighting_potential_contact_id
+            pot::T = isEP ? contact.potential : contact.id == weighting_potential_contact_id
             set_passive_or_contact_points(point_types, potential, grid, contact.geometry, pot, use_nthreads)
         end
     end
     if PaintContacts
         for contact in det.contacts
-            pot::T = ismissing(weighting_potential_contact_id) ? contact.potential : contact.id == weighting_potential_contact_id
+            pot::T = isEP ? contact.potential : contact.id == weighting_potential_contact_id
             fs = ConstructiveSolidGeometry.surfaces(contact.geometry)
             for face in fs
                 paint!(point_types, potential, face, contact.geometry, pot, grid)


### PR DESCRIPTION
Long time ago (https://github.com/JuliaPhysics/SolidStateDetectors.jl/commit/fa705cd692385cc1774d8e28377b67a6a3291e11 in #261), there seems to have been a fix how to properly include floating passives (`passive.potential = NaN`) in the weighting potential calculation, but it was only applied to the Cylindrical grid, not to the Cartesian one.

This resulted in the fact that, **on Cartesian grids**, floating passives were treated as conducting surfaces in the weighting potential calculation, hence obtaining a WRONG fixed value of 0 and distorting the weighting potential.

```julia
using SolidStateDetectors, Plots, Unitful

config_dict = SolidStateDetectors.parse_config_file(SSD_examples[:InvertedCoax])

# Move the passivated surfaced into the bulk to see it better
config_dict["surroundings"][1]["geometry"]["tube"]["h"] = 1e-3
config_dict["surroundings"][1]["geometry"]["tube"]["origin"] = [0,0,10]

# Run simulation on a Cartesian grid
config_dict["grid"] = Dict(
    "coordinates" => "cartesian",
    "axes" => Dict(
        "x" => Dict("from" => -40, "to" => 40),
        "y" => Dict("from" => -40, "to" => 40),
        "z" => config_dict["grid"]["axes"]["z"]
    )
)

T = Float32
simPF = Simulation{T}(config_dict)
calculate_electric_potential!(simPF, refinement_limits = [0.2, 0.1], depletion_handling = true)
calculate_electric_field!(simPF)
calculate_weighting_potential!(simPF, 2,
                              refinement_limits = [0.2, 0.1],                
                              depletion_handling = false)
plot(simPF.weighting_potentials[2])
```

Before this PR:
<img width="600" height="400" alt="image" src="https://github.com/user-attachments/assets/d825331b-b39b-4a0f-8378-edf2df4d04f7" />


With this PR:
<img width="600" height="400" alt="image" src="https://github.com/user-attachments/assets/5f15f611-fbd1-493e-81c9-16efa01040a8" />
