### PR TITLE
Fix `offset` for linear and cylindrical impurity densities

### DIFF
--- a/src/ImpurityDensities/CylindricalImpurityDensity.jl
+++ b/src/ImpurityDensities/CylindricalImpurityDensity.jl
@@ -55,4 +55,4 @@ end
 
 (*)(scale::Real, lcdm::CylindricalImpurityDensity{T}) where {T} = CylindricalImpurityDensity{T}(T.(scale .* lcdm.offsets), T.(scale .* lcdm.gradients))
 
-(+)(offset::Union{<:Real, <:Quantity{<:Real, Unitful.𝐋^(-3)}}, lcdm::CylindricalImpurityDensity{T}) where {T} = CylindricalImpurityDensity{T}(T.(to_internal_units(offset) .+ lcdm.offsets), lcdm.gradients)
+(+)(offset::Union{<:Real, <:Quantity{<:Real, Unitful.𝐋^(-3)}}, lcdm::CylindricalImpurityDensity{T}) where {T} = CylindricalImpurityDensity{T}(T.((zero(T), zero(T), to_internal_units(offset)) .+ lcdm.offsets), lcdm.gradients)

--- a/src/ImpurityDensities/LinearImpurityDensity.jl
+++ b/src/ImpurityDensities/LinearImpurityDensity.jl
@@ -58,4 +58,4 @@ end
 
 (*)(scale::Real, lcdm::LinearImpurityDensity{T}) where {T} = LinearImpurityDensity{T}(T.(scale .* lcdm.offsets), T.(scale .* lcdm.gradients))
 
-(+)(offset::Union{<:Real, <:Quantity{<:Real, Unitful.𝐋^(-3)}}, lcdm::LinearImpurityDensity{T}) where {T} = LinearImpurityDensity{T}(T.(to_internal_units(offset) .+ lcdm.offsets), lcdm.gradients)
+(+)(offset::Union{<:Real, <:Quantity{<:Real, Unitful.𝐋^(-3)}}, lcdm::LinearImpurityDensity{T}) where {T} = LinearImpurityDensity{T}(T.((zero(T), zero(T), to_internal_units(offset)) .+ lcdm.offsets), lcdm.gradients)


### PR DESCRIPTION
The current implementation of `offset` for `LinearImpurityDensity` and `CylindricalImpurityDensity` is wrong.
It is adding the offset to all three components of `offsets`, resulting in a three times greater offset than envisioned.

In general, we could think about moving from a tuple of `offsets` to just one number, maybe even as part of the breaking 0.11.0 release.
