### PR TITLE
Fix plotting `CartesianPoint` with correct units

### DIFF
--- a/src/ConstructiveSolidGeometry/plotting/PointsAndVectors/Points.jl
+++ b/src/ConstructiveSolidGeometry/plotting/PointsAndVectors/Points.jl
@@ -7,7 +7,9 @@
     end
     @series begin
         seriestype --> :scatter
-        [pt.x], [pt.y], [pt.z]
+        [to_internal_units(pt.x) * internal_length_unit], 
+        [to_internal_units(pt.y) * internal_length_unit], 
+        [to_internal_units(pt.z) * internal_length_unit]
     end
 end
 
@@ -35,7 +37,9 @@ end
     end 
     @series begin
         if !isempty(v) seriestype --> :scatter end
-        [v[i].x for i in eachindex(v)], [v[i].y for i in eachindex(v)], [v[i].z for i in eachindex(v)]
+        [to_internal_units(v[i].x) * internal_length_unit for i in eachindex(v)],
+        [to_internal_units(v[i].y) * internal_length_unit for i in eachindex(v)],
+        [to_internal_units(v[i].z) * internal_length_unit for i in eachindex(v)]
     end
 end
 


### PR DESCRIPTION
Quick attempt to fix #550:
`CartesianPoints` can now have units or be unitless.
However, when plotting, it would be nice to always have them have units.
Right now, if a CartesianPoint does not have units, there is no way that the plot recipe knows what units the coordinates should have. According to our docstrings, we expect x, y and z to be in units of meters though, so this should also be reflected in the plots or be updated.
https://github.com/JuliaPhysics/SolidStateDetectors.jl/blob/610bcce7ccdd765b0c3e7e2a5b87e8a5305eb8d7/src/ConstructiveSolidGeometry/PointsAndVectors/Points.jl#L46-L60
