### PR TITLE
Fix formulas in docs on electric field

### DIFF
--- a/docs/src/man/electric_field.md
+++ b/docs/src/man/electric_field.md
@@ -9,9 +9,9 @@ On a Cartesian grid, this results in:
 where
 ```math
 \begin{aligned}
-	\mathcal{E}_x^{i,j,k} &= \dfrac{1}{2}\left( \dfrac{\Phi_{i+1,j,k}-\Phi_{i+1,j,k}}{x_{i+1} - x_{i}} + \dfrac{\Phi_{i,j,k}-\Phi_{i-1,j,k}}{x_{i} - x_{i-1}} \right)\hspace{10pt},\\
-	\mathcal{E}_y^{i,j,k} &= \dfrac{1}{2}\left( \dfrac{\Phi_{i,j+1,k}-\Phi_{i,j,k}}{y_{j+1} - y_{j}} + \dfrac{\Phi_{i,j,k}-\Phi_{i,j-1,k}}{y_{j} - y_{j-1}} \right)\hspace{10pt},\\
-	\mathcal{E}_z^{i,j,k} &= \dfrac{1}{2}\left( \dfrac{\Phi_{i,j,k+1}-\Phi_{i,j,k}}{z_{k+1} - z_{k}} + \dfrac{\Phi_{i,j,k}-\Phi_{i,j,k-1}}{z_{k} - z_{k-1}} \right)\hspace{10pt}.
+	\mathcal{E}_x^{i,j,k} &= -\dfrac{1}{2}\left( \dfrac{\Phi_{i+1,j,k}-\Phi_{i+1,j,k}}{x_{i+1} - x_{i}} + \dfrac{\Phi_{i,j,k}-\Phi_{i-1,j,k}}{x_{i} - x_{i-1}} \right)\hspace{10pt},\\
+	\mathcal{E}_y^{i,j,k} &= -\dfrac{1}{2}\left( \dfrac{\Phi_{i,j+1,k}-\Phi_{i,j,k}}{y_{j+1} - y_{j}} + \dfrac{\Phi_{i,j,k}-\Phi_{i,j-1,k}}{y_{j} - y_{j-1}} \right)\hspace{10pt},\\
+	\mathcal{E}_z^{i,j,k} &= -\dfrac{1}{2}\left( \dfrac{\Phi_{i,j,k+1}-\Phi_{i,j,k}}{z_{k+1} - z_{k}} + \dfrac{\Phi_{i,j,k}-\Phi_{i,j,k-1}}{z_{k} - z_{k-1}} \right)\hspace{10pt}.
 \end{aligned}
 ```
 
@@ -23,9 +23,9 @@ On a cylindrical grid, the calculation is:
 where
 ```math
 \begin{aligned}
-	\mathcal{E}_r^{i,j,k} &= \dfrac{1}{2}\left(\dfrac{\Phi_{i+1,j,k}-\Phi_{i,j,k}}{r_{i+1} - r_{i}} + \dfrac{\Phi_{i,j,k}-\Phi_{i-1,j,k}}{r_{i} - r_{i-1}}\right)\hspace{10pt},\\
-	\mathcal{E}_{\varphi}^{i,j,k} &= \dfrac{1}{2 r_{i}}\left(\dfrac{\Phi_{i,j+1,k}-\Phi_{i,j,k}}{\varphi_{j+1} - \varphi_{j}} + \dfrac{\Phi_{i,j,k}-\Phi_{i,j-1,k}}{\varphi_{j} - \varphi_{j-1}}\right)\hspace{10pt},\\
-	\mathcal{E}_z^{i,j,k} &= \dfrac{1}{2}\left( \dfrac{\Phi_{i,j,k+1}-\Phi_{i,j,k}}{z_{k+1} - z_{k}} + \dfrac{\Phi_{i,j,k}-\Phi_{i,j,k-1}}{z_{k} - z_{k-1}} \right)\hspace{10pt}.
+	\mathcal{E}_r^{i,j,k} &= -\dfrac{1}{2}\left(\dfrac{\Phi_{i+1,j,k}-\Phi_{i,j,k}}{r_{i+1} - r_{i}} + \dfrac{\Phi_{i,j,k}-\Phi_{i-1,j,k}}{r_{i} - r_{i-1}}\right)\hspace{10pt},\\
+	\mathcal{E}_{\varphi}^{i,j,k} &= -\dfrac{1}{2 r_{i}}\left(\dfrac{\Phi_{i,j+1,k}-\Phi_{i,j,k}}{\varphi_{j+1} - \varphi_{j}} + \dfrac{\Phi_{i,j,k}-\Phi_{i,j-1,k}}{\varphi_{j} - \varphi_{j-1}}\right)\hspace{10pt},\\
+	\mathcal{E}_z^{i,j,k} &= -\dfrac{1}{2}\left( \dfrac{\Phi_{i,j,k+1}-\Phi_{i,j,k}}{z_{k+1} - z_{k}} + \dfrac{\Phi_{i,j,k}-\Phi_{i,j,k-1}}{z_{k} - z_{k-1}} \right)\hspace{10pt}.
 \end{aligned}
 ```
 


### PR DESCRIPTION
There are minus signs missing in the formula for calculating the electric field from the electric potential via 
```math
\vec{E}(\vec{r}) = - \nabla \phi( \vec{r} )
```

I checked if we're doing the correct thing in the actual code implementation of the electric field calculation (we are :tada:):
https://github.com/JuliaPhysics/SolidStateDetectors.jl/blob/83af3ee2bb4538a4ea0f4c22133bb92629516304/src/ElectricField/ElectricField.jl#L156

https://github.com/JuliaPhysics/SolidStateDetectors.jl/blob/83af3ee2bb4538a4ea0f4c22133bb92629516304/src/ElectricField/ElectricField.jl#L310