### PR TITLE
Exclude inactive layer when searching for potential overshoots

### DIFF
--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -1048,14 +1048,18 @@ function _calculate_potential!( sim::Simulation{T, CS}, potential_type::UnionAll
             maximum_applied_potential = maximum(broadcast(c -> c.potential, sim.detector.contacts))
             minimum_applied_potential = minimum(broadcast(c -> c.potential, sim.detector.contacts))
             @inbounds for i in eachindex(sim.electric_potential.data)
-                if sim.electric_potential.data[i] < minimum_applied_potential && sim.point_types.data[i] & bulk_bit > 0 # p-type
+                if sim.electric_potential.data[i] < minimum_applied_potential && # p-type
+                    sim.point_types.data[i] & inactive_layer_bit == 0 # exclude grid points in the inactive layer
+                    sim.point_types.data[i] & bulk_bit > 0 # exclude grid points outside of the bulk
                     @warn """At least one grid point in the detector has a smaller potential value ($(sim.electric_potential.data[i]) V)
                         than the minimum applied potential ($(minimum_applied_potential) V). 
                         A fully depleted detector should not have local extrema in a converged electric potential.
                         However, small overshoots can occur due to numerical precision."""
                     break
                 end
-                if sim.electric_potential.data[i] > maximum_applied_potential && sim.point_types.data[i] & bulk_bit > 0 # n-type
+                if sim.electric_potential.data[i] > maximum_applied_potential && # n-type
+                    sim.point_types.data[i] & inactive_layer_bit == 0 # exclude grid points in the inactive layer
+                    sim.point_types.data[i] & bulk_bit > 0 # exclude grid points outside of the bulk
                     @warn """At least one grid point in the detector has a higher potential value ($(sim.electric_potential.data[i]) V)
                         than the maximum applied potential ($(maximum_applied_potential) V). 
                         A fully depleted detector should not have local extrema in a converged electric potential.


### PR DESCRIPTION
Follow-up of #597: the warning still appears for simulations with small overshoots in the inactive layer.
```julia
using SolidStateDetectors, CUDA
T = Float64
sim = Simulation{T}(SSD_examples[:IVCIlayer]) # setting spacing_surface_refinement = [1e-5, 1e-5, 1e-5]
g = Grid(sim)
apply_initial_state!(sim, ElectricPotential, g)

t = @elapsed begin
    calculate_electric_potential!(
        sim,
        device_array_type = CuArray,
        grid = g,
        verbose = true,
        depletion_handling = true
    )
end
println("Elapsed time: $(t) seconds")
```

Before this PR:
```
┌ Warning: At least one grid point in the detector has a higher potential value (3500.0000000000014 V)
│ than the maximum applied potential (3500.0 V). 
│ A fully depleted detector should not have local extrema in a converged electric potential.
│ However, small overshoots can occur due to numerical precision.
└ @ SolidStateDetectors /volumes/mobius/users/felix/test/SolidStateDetectors.jl/src/Simulation/Simulation.jl:1216
```

After this PR: no warning