### PR TITLE
Improve initial state for the weighting potential simulation

### DIFF
--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -1118,18 +1118,21 @@ function _calculate_potential!( sim::Simulation{T, CS}, potential_type::UnionAll
             # Calculate a coarse initial state on the default grid
             default_grid = Grid(sim, for_weighting_potential = true)
             apply_initial_state!(sim, potential_type, contact_id, default_grid; not_only_paint_contacts, paint_contacts, depletion_handling)
-            nt = guess_nt ? _guess_optimal_number_of_threads_for_SOR(size(default_grid), max_nthreads[1], CS) : max_nthreads[1]
-            update_till_convergence!(sim, potential_type, contact_id, convergence_limit;
-                                    n_iterations_between_checks,
-                                    max_n_iterations,
-                                    depletion_handling,
-                                    device_array_type,
-                                    use_nthreads = nt,
-                                    sor_consts,
-                                    verbose )
 
-            # Map it onto the desired grid
-            sim.weighting_potentials[contact_id] = sim.weighting_potentials[contact_id][grid]
+            if grid != default_grid
+                nt = guess_nt ? _guess_optimal_number_of_threads_for_SOR(size(default_grid), max_nthreads[1], CS) : max_nthreads[1]
+                update_till_convergence!(sim, potential_type, contact_id, convergence_limit;
+                                        n_iterations_between_checks,
+                                        max_n_iterations,
+                                        depletion_handling,
+                                        device_array_type,
+                                        use_nthreads = nt,
+                                        sor_consts,
+                                        verbose )
+
+                # Map it onto the desired grid
+                sim.weighting_potentials[contact_id] = sim.weighting_potentials[contact_id][grid]
+            end
 
             # Perform the SOR until reaching convergence
             nt = guess_nt ? _guess_optimal_number_of_threads_for_SOR(size(sim.weighting_potentials[contact_id].grid), max_nthreads[1], CS) : max_nthreads[1]

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -1105,34 +1105,42 @@ function _calculate_potential!( sim::Simulation{T, CS}, potential_type::UnionAll
     if initialize 
         if isEP
             apply_initial_state!(sim, potential_type, grid; not_only_paint_contacts, paint_contacts, depletion_handling)
-            update_till_convergence!( sim, potential_type, convergence_limit,
-                                    n_iterations_between_checks = n_iterations_between_checks,
-                                    max_n_iterations = max_n_iterations,
-                                    depletion_handling = depletion_handling,
-                                    device_array_type = device_array_type,
-                                    use_nthreads = guess_nt ? _guess_optimal_number_of_threads_for_SOR(size(sim.electric_potential.grid), max_nthreads[1], CS) : max_nthreads[1],
-                                    sor_consts = sor_consts,
-                                    verbose = verbose )
+            nt = guess_nt ? _guess_optimal_number_of_threads_for_SOR(size(sim.electric_potential.grid), max_nthreads[1], CS) : max_nthreads[1]
+            update_till_convergence!( sim, potential_type, convergence_limit;
+                                    n_iterations_between_checks,
+                                    max_n_iterations,
+                                    depletion_handling,
+                                    device_array_type,
+                                    use_nthreads = nt,
+                                    sor_consts,
+                                    verbose )
         else
-            default_grid = Grid(sim, for_weighting_potential=true)
+            # Calculate a coarse initial state on the default grid
+            default_grid = Grid(sim, for_weighting_potential = true)
             apply_initial_state!(sim, potential_type, contact_id, default_grid; not_only_paint_contacts, paint_contacts, depletion_handling)
-            update_till_convergence!(sim, potential_type, contact_id, convergence_limit,
-                n_iterations_between_checks=n_iterations_between_checks,
-                max_n_iterations=max_n_iterations,
-                depletion_handling=depletion_handling,
-                device_array_type=device_array_type,
-                use_nthreads=guess_nt ? _guess_optimal_number_of_threads_for_SOR(size(sim.weighting_potentials[contact_id].grid), max_nthreads[1], CS) : max_nthreads[1],
-                sor_consts=sor_consts)
-            new_wp = sim.weighting_potentials[contact_id][grid]
-            sim.weighting_potentials[contact_id] = new_wp
-            update_till_convergence!( sim, potential_type, contact_id, convergence_limit,
-                                        n_iterations_between_checks = n_iterations_between_checks,
-                                        max_n_iterations = max_n_iterations,
-                                        depletion_handling = depletion_handling,
-                                        device_array_type = device_array_type,
-                                        use_nthreads = guess_nt ? _guess_optimal_number_of_threads_for_SOR(size(sim.weighting_potentials[contact_id].grid), max_nthreads[1], CS) : max_nthreads[1],
-                                        sor_consts = sor_consts,
-                                        verbose = verbose )
+            nt = guess_nt ? _guess_optimal_number_of_threads_for_SOR(size(default_grid), max_nthreads[1], CS) : max_nthreads[1]
+            update_till_convergence!(sim, potential_type, contact_id, convergence_limit;
+                                    n_iterations_between_checks,
+                                    max_n_iterations,
+                                    depletion_handling,
+                                    device_array_type,
+                                    use_nthreads = nt,
+                                    sor_consts,
+                                    verbose )
+
+            # Map it onto the desired grid
+            sim.weighting_potentials[contact_id] = sim.weighting_potentials[contact_id][grid]
+
+            # Perform the SOR until reaching convergence
+            nt = guess_nt ? _guess_optimal_number_of_threads_for_SOR(size(sim.weighting_potentials[contact_id].grid), max_nthreads[1], CS) : max_nthreads[1]
+            update_till_convergence!( sim, potential_type, contact_id, convergence_limit;
+                                    n_iterations_between_checks,
+                                    max_n_iterations,
+                                    depletion_handling,
+                                    device_array_type,
+                                    use_nthreads = nt,
+                                    sor_consts,
+                                    verbose )
         end
     end
     # refinement_counter::Int = 1
@@ -1152,16 +1160,16 @@ function _calculate_potential!( sim::Simulation{T, CS}, potential_type::UnionAll
                 refine!(sim, ElectricPotential, max_diffs, new_min_tick_distance, depletion_handling = depletion_handling)
                 nt = guess_nt ? _guess_optimal_number_of_threads_for_SOR(size(sim.electric_potential.grid), max_nthreads[iref+1], CS) : max_nthreads[iref+1]
                 verbose && println("Grid size: $(size(sim.electric_potential.data)) - $(onCPU ? "using $(nt) threads now" : "GPU")") 
-                update_till_convergence!( sim, potential_type, convergence_limit,
-                                                n_iterations_between_checks = n_iterations_between_checks,
-                                                max_n_iterations = max_n_iterations,
-                                                depletion_handling = depletion_handling,
-                                                use_nthreads = nt,
-                                                device_array_type = device_array_type,
-                                                not_only_paint_contacts = not_only_paint_contacts, 
-                                                paint_contacts = paint_contacts,
-                                                sor_consts = is_last_ref ? T(1) : sor_consts,
-                                                verbose = verbose )
+                update_till_convergence!( sim, potential_type, convergence_limit;
+                                        n_iterations_between_checks,
+                                        max_n_iterations,
+                                        depletion_handling,
+                                        use_nthreads = nt,
+                                        device_array_type,
+                                        not_only_paint_contacts, 
+                                        paint_contacts,
+                                        sor_consts = is_last_ref ? T(1) : sor_consts,
+                                        verbose )
                 
                 if has_surface_model && iref == 3 && !any(isnan, sim.world.spacing_surface_refinement)
                     # perform surface refinement
@@ -1173,30 +1181,30 @@ function _calculate_potential!( sim::Simulation{T, CS}, potential_type::UnionAll
                     refine_surface!(sim, sim.world.spacing_surface_refinement; update_other_fields=true)
                     nt = guess_nt ? _guess_optimal_number_of_threads_for_SOR(size(sim.electric_potential.grid), max_nthreads[iref+1], CS) : max_nthreads[iref+1]
                     verbose && println("Grid size: $(size(sim.electric_potential.data)) - $(onCPU ? "using $(nt) threads now" : "GPU")") 
-                    update_till_convergence!( sim, potential_type, convergence_limit,
-                                              n_iterations_between_checks = n_iterations_between_checks,
-                                              max_n_iterations = max_n_iterations,
-                                              depletion_handling = depletion_handling,
-                                              device_array_type = device_array_type,
-                                              use_nthreads = nt,
-                                              sor_consts = T(1),
-                                              verbose = verbose )
+                    update_till_convergence!( sim, potential_type, convergence_limit;
+                                            n_iterations_between_checks,
+                                            max_n_iterations,
+                                            depletion_handling,
+                                            device_array_type,
+                                            use_nthreads = nt,
+                                            sor_consts = T(1),
+                                            verbose )
                 end
             else
                 max_diffs = abs.(ref_limits)
                 refine!(sim, WeightingPotential, contact_id, max_diffs, new_min_tick_distance)
                 nt = guess_nt ? _guess_optimal_number_of_threads_for_SOR(size(sim.weighting_potentials[contact_id].grid), max_nthreads[iref+1], CS) : max_nthreads[iref+1]
                 verbose && println("Grid size: $(size(sim.weighting_potentials[contact_id].data)) - $(onCPU ? "using $(nt) threads now" : "GPU")") 
-                update_till_convergence!( sim, potential_type, contact_id, convergence_limit,
-                                                n_iterations_between_checks = n_iterations_between_checks,
-                                                max_n_iterations = max_n_iterations,
-                                                depletion_handling = depletion_handling,
-                                                use_nthreads = nt,
-                                                device_array_type = device_array_type,
-                                                not_only_paint_contacts = not_only_paint_contacts, 
-                                                paint_contacts = paint_contacts,
-                                                sor_consts = is_last_ref ? T(1) : sor_consts,
-                                                verbose = verbose )
+                update_till_convergence!( sim, potential_type, contact_id, convergence_limit;
+                                        n_iterations_between_checks,
+                                        max_n_iterations,
+                                        depletion_handling,
+                                        use_nthreads = nt,
+                                        device_array_type,
+                                        not_only_paint_contacts, 
+                                        paint_contacts,
+                                        sor_consts = is_last_ref ? T(1) : sor_consts,
+                                        verbose )
             end
         end
     end

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -1114,7 +1114,17 @@ function _calculate_potential!( sim::Simulation{T, CS}, potential_type::UnionAll
                                     sor_consts = sor_consts,
                                     verbose = verbose )
         else
-            apply_initial_state!(sim, potential_type, contact_id, grid; not_only_paint_contacts, paint_contacts, depletion_handling)
+            default_grid = Grid(sim, for_weighting_potential=true)
+            apply_initial_state!(sim, potential_type, contact_id, default_grid; not_only_paint_contacts, paint_contacts, depletion_handling)
+            update_till_convergence!(sim, potential_type, contact_id, convergence_limit,
+                n_iterations_between_checks=n_iterations_between_checks,
+                max_n_iterations=max_n_iterations,
+                depletion_handling=depletion_handling,
+                device_array_type=device_array_type,
+                use_nthreads=guess_nt ? _guess_optimal_number_of_threads_for_SOR(size(sim.weighting_potentials[contact_id].grid), max_nthreads[1], CS) : max_nthreads[1],
+                sor_consts=sor_consts)
+            new_wp = sim.weighting_potentials[contact_id][grid]
+            sim.weighting_potentials[contact_id] = new_wp
             update_till_convergence!( sim, potential_type, contact_id, convergence_limit,
                                         n_iterations_between_checks = n_iterations_between_checks,
                                         max_n_iterations = max_n_iterations,


### PR DESCRIPTION
This PR introduces a new handling of the initial state application to the weighting potential calculation. (#530 )
It fixes the problem of the incorrect p+ weighting potential convergence observed in an undepleted detector when using small values of max_tick_distance (e.g.below 0.3 mm ) to build the grid; the same issue also appeared when passing to the weighting potential calculation a very refined custom grid, such as the grid obtained from the electric potential calculation.

The weighting potential calculated on grids with small max_tick_distance converges too fast; this behaviour is not related to the RCC layer model, since this was also spotted for simulations not including the RCC layer model.

 See the example below: 
P+ weighting potential for max_tick_distance = 0.5 mm (left), showing correct behaviour,  and max_tick_distance = 0.1 mm (right),  showing incorrect behaviour.

→ vacuum
<img width="400" height="200" alt="image" src="https://github.com/user-attachments/assets/56ed3c17-1b55-4650-8c83-e127f4f57bae" />

→ cryostat
<img width="400" height="200" alt="image" src="https://github.com/user-attachments/assets/393060a9-3d7e-431a-89e9-8dd970cf58c4" />

→ RCC layer
<img width="400" height="200" alt="image" src="https://github.com/user-attachments/assets/0dfe011a-f6ed-4fb9-9e21-def87e4bd02b" />



To verify if the convergence is correct or not,  the minimum of the weighting potential is evaluated in a test volume inside the undepleted region: since this region is in direct contact with the p+ electrode and behaving like a conductive material (undepleted → no charge density), the weighting potential must be equal to 1.
We can see how decreasing the value of max_tick_distance ( i.e. having a denser grid) leads to smaller and smaller weighting potential values.

<img width="250" height="200" alt="image" src="https://github.com/user-attachments/assets/afeca516-e45a-4085-9d2d-37f9ae6abc9b" />

The new implementation changes the initial state applied for the weighting potential simulation. In the original code, the simulation begins with 

`apply_initial_state!(sim, potential_type, contact_id,grid)`


In this PR, instead of applying the initial state directly to the user grid ( custom grid or build from custom max_tick_distance), the initial state is first applied to the default grid.
The simulation is therefore initialised on a coarse grid and an initial convergence is computed. 
Allowing the simulation to perform this step helps the SOR algorithm to reach the correct convergence; when the initial grid is too dense, the algorithm gets stuck around an incorrect solution, and continues to oscillate around it until the iteration stops when maximum of the residual of the weighting potential is smaller than a certain convergence limit ( default 10^(-7)).

In principle, this convergence problem can be solved by forcing the algorithm to iterate for more steps before checking convergence; this can be achieved by decreasing the convergence limit (requiring a smaller error) 
<img width="500" height="400" alt="image" src="https://github.com/user-attachments/assets/78cf5835-39f1-4576-8f04-b6ee8c42712e" />


or by increasing the number of iterations between checks ( by default fixed to 1000).
Above n_iteration_between_checks = 30.000, the convergence becomes correct.
<img width="900" height="200" alt="image" src="https://github.com/user-attachments/assets/2f86f9b2-bdba-4afb-8020-f36869158653" />

Naturally, we are not only interested in the correct convergence, but also in achieving it within computationally feasible time frames for our algorithm.
<img width="400" height="300" alt="image" src="https://github.com/user-attachments/assets/d7752b79-c496-46e4-8c14-c77067961f3f" />


That’s why it’s needed to change how the initial state is handled.

 Starting from a coarse grid, helps the convergence to not get stuck and reach the correct convergence. This has been checked using both small max_tick_distance:

<img width="600" height="300" alt="image" src="https://github.com/user-attachments/assets/06d2588f-1bc6-4526-8a0c-99ede7064757" />


 and custom grids:

<img width="800" height="450" alt="image" src="https://github.com/user-attachments/assets/a2e9d328-039f-47c8-9a32-6ef69e99fe66" />


We can now compare the minimum of the weighting potential with the ‘OLD’ and the ‘NEW’ implementation:



<img width="300" height="200" alt="image" src="https://github.com/user-attachments/assets/31d8a971-dafe-43a3-a885-5976e5fe4141" />


We can see that now the minimum of the weighting potential is no longer decreasing, and oscillates around 1; for all the max_tick_distances, the deviation from 1 is always smaller than 0.5%.



The added code  performs the following steps (only in the weighting potential simulation):

- Applies the initial state to the coarse default grid
- Updates until convergence
- Map the weighting potential obtained onto the user grid
- Updates until convergence again
- After this, the refinement on the potential is applied as usual.

 Introducing this additional convergence step does not add any significant computational time.


