### PR TITLE
Bug fix in `parse_r_of_primitive`

### DIFF
--- a/src/ConstructiveSolidGeometry/IO.jl
+++ b/src/ConstructiveSolidGeometry/IO.jl
@@ -111,7 +111,7 @@ end
 function parse_r_of_primitive(::Type{T}, dict::AbstractDict, unit::Unitful.Units) where {T}
     @assert haskey(dict, "r") "Please specify 'r'."
     dictr = dict["r"]
-    if haskey(dictr, "bottom") && haskey(dictr, "top")
+    if dictr isa AbstractDict && haskey(dictr, "bottom") && haskey(dictr, "top")
         # "r" : {"bottom": {"from": ..., "to": ...}, "top": {"from": ..., "to": ...}}
         bottom = _parse_radial_interval(T, dictr["bottom"], unit)
         top = _parse_radial_interval(T, dictr["top"], unit)
@@ -125,14 +125,14 @@ end
 function parse_r_of_primitive(::Type{T}, dict::AbstractDict, unit::Unitful.Units, ::Type{Cone}) where {T}
     @assert haskey(dict, "r") "Please specify 'r'."
     dictr = dict["r"]
-    r = if haskey(dictr, "bottom") && haskey(dictr, "top")
+    r = if dictr isa AbstractDict && haskey(dictr, "bottom") && haskey(dictr, "top")
         # "r" : {"bottom": {"from": ..., "to": ...}, "top": {"from": ..., "to": ...}}
         bottom = _parse_radial_interval(T, dictr["bottom"], unit)
         top = _parse_radial_interval(T, dictr["top"], unit)
         if bottom isa Real bottom = (zero(T), bottom) end
         if top isa Real top = (zero(T), top) end
         (bottom, top)
-    elseif haskey(dictr, "from") && haskey(dictr, "to")
+    elseif dictr isa AbstractDict && haskey(dictr, "from") && haskey(dictr, "to")
         # "r" : {"from": ... , "to": ...}
         r = _parse_radial_interval(T, dictr, unit)
         if r isa Real r = (zero(T), r) end


### PR DESCRIPTION
Possible fix for #603:
In `parse_r_of_primitive` we used to check for keys of `dictr` without explicitly checking first if `dictr` is a dictionary first.
This worked because of some type piracy in `SplitApplyCombine` that was recently removed.
