### PR TITLE
Temperature handling for charge drift and trapping models

### DIFF
--- a/docs/src/man/charge_drift.md
+++ b/docs/src/man/charge_drift.md
@@ -217,10 +217,11 @@ The `InactiveLayerChargeDriftModel` can be specified in the configuration file a
 ```yaml 
 detectors:
   semiconductor:
+    temperature: 90K  # temperature must be defined here for InactiveLayerChargeDriftModel
     # ...
     charge_drift_model:
       model: InactiveLayerChargeDriftModel
-      temperature: 90K
+      # temperature: 90K  # optional: if provided, must match semiconductor.temperature (used for validation only)
       bulk_impurity_density:
         name: constant
         value: -1e10cm^-3
@@ -236,12 +237,14 @@ detectors:
 
 The `charge_drift_model` needs:
 - `model`: the name of the charge drift model, which in this case is `InactiveLayerChargeDriftModel`.
-- `temperature`: the crystal temperature.
+- `temperature` (optional): if provided, validated against `semiconductor.temperature` — both must match or an error is raised. Temperature must be defined in the `semiconductor` and cannot be set only inside the charge drift model, because it is also used independently for diffusion calculations during charge drift.
 - `bulk_impurity_density` (optional): the density of the p-type impurity in the crystal.
 - `surface_impurity_density` (optional): the density profile of lithium (n-type) in the surface layer.
 - `neutral_impurity_density`: the density profile of the non-ionized impurity in the crystal.
 
 > Note that the fields `bulk_impurity_density` and `surface_impurity_density` do not need to be explicitly defined if `PtypePNJunctionImpurityDensity` is chosen as the overall impurity density profile.
+
+> Note that temperature must be defined in `semiconductor.temperature` — it cannot be set only inside the charge drift model config, because the semiconductor temperature is also used independently for diffusion calculations during charge drift. Optionally, a `temperature` field can be added to the `charge_drift_model` config for validation: if provided, it must match `semiconductor.temperature` or an error is raised. If `semiconductor.temperature` is not set, a material-specific default is used (77 K for High Purity Germanium, 293 K otherwise) and a warning is issued — this applies even if a `temperature` is specified in the charge drift model config, since that field only validates, not sets, the semiconductor temperature.
 
 ### Custom Charge Drift Model
 
@@ -336,27 +339,31 @@ The `BoggsChargeTrappingModel` can be applied in the configuration file by addin
 detectors:
   - semiconductor:
       material: #...
+      temperature: 78K  # preferred: define temperature here
       geometry: #...
       charge_trapping_model:
         model: Boggs
         parameters:
           nσe-1: 1020cm
           nσh-1: 2040cm
-          temperature: 78K
+          # temperature: 78K  # optional: if provided, must match semiconductor.temperature
 
 # ... or ...
 
 detectors:
   - semiconductor:
       material: #...
+      temperature: 78K  # preferred: define temperature here
       geometry: #...
       charge_trapping_model:
         model: Boggs
         parameters:
           nσe: 0.001cm^-1
           nσh: 0.0005cm^-1
-          temperature: 78K
+          # temperature: 78K  # optional: if provided, must match semiconductor.temperature
 ```
+
+> Note that temperature is preferably defined in `semiconductor.temperature` and will be passed automatically to the trapping model. A `temperature` field can also be specified inside `parameters`; if both are provided they must match or an error is raised. Unlike the charge drift model, if no `semiconductor.temperature` is defined, a `temperature` inside `parameters` alone is also accepted. If `semiconductor.temperature` is not set, a material-specific default is used (77 K for High Purity Germanium, 293 K otherwise) and a warning is issued — this applies even if a `temperature` is specified inside `parameters`, since the semiconductor temperature is always resolved first and passed to the trapping model.
 
 It can also be applied to an already read-in `SolidStateDetector` using for example:
 ```julia
@@ -437,6 +444,8 @@ charge_trapping_model:
 
 This model also allows disabling the charge trapping model inside the inactive layer by having `model_inactive:` and the bulk by deleting `model:` from the `charge_trapping_model:` block.
 If `inactive_layer_geometry` is passed to the yaml file, this is the region used for the inactive layer charge trapping model, else, the model will use the inactive layer geometry defined by the impurity density model (`PtypePNJunctionImpurityDensity`) using the point types.
+
+> Note that temperature is preferably defined in `semiconductor.temperature` and will be passed automatically. Optionally, a `temperature` field can be added at the top level of the `charge_trapping_model` config (i.e. alongside `model` and `model_inactive`, not inside `parameters`); if both are provided they must match or an error is raised. Unlike the charge drift model, if no `semiconductor.temperature` is defined, a top-level `temperature` in the `charge_trapping_model` alone is also accepted. If `semiconductor.temperature` is not set, a material-specific default is used (77 K for High Purity Germanium, 293 K otherwise) and a warning is issued — this applies even if a `temperature` is specified in the `charge_trapping_model` config, since the semiconductor temperature is always resolved first and passed to the trapping model.
 
 ```julia
 using SolidStateDetectors, Unitful

--- a/docs/src/man/charge_drift.md
+++ b/docs/src/man/charge_drift.md
@@ -242,9 +242,11 @@ The `charge_drift_model` needs:
 - `surface_impurity_density` (optional): the density profile of lithium (n-type) in the surface layer.
 - `neutral_impurity_density`: the density profile of the non-ionized impurity in the crystal.
 
-> Note that the fields `bulk_impurity_density` and `surface_impurity_density` do not need to be explicitly defined if `PtypePNJunctionImpurityDensity` is chosen as the overall impurity density profile.
+!!! note 
+    The fields `bulk_impurity_density` and `surface_impurity_density` do not need to be explicitly defined if `PtypePNJunctionImpurityDensity` is chosen as the overall impurity density profile.
 
-> Note that temperature must be defined in `semiconductor.temperature` — it cannot be set only inside the charge drift model config, because the semiconductor temperature is also used independently for diffusion calculations during charge drift. Optionally, a `temperature` field can be added to the `charge_drift_model` config for validation: if provided, it must match `semiconductor.temperature` or an error is raised. If `semiconductor.temperature` is not set, a material-specific default is used (77 K for High Purity Germanium, 293 K otherwise) and a warning is issued — this applies even if a `temperature` is specified in the charge drift model config, since that field only validates, not sets, the semiconductor temperature.
+!!! note
+    The temperature must be defined in `semiconductor.temperature` — it cannot be set only inside the charge drift model config, because the semiconductor temperature is also used independently for diffusion calculations during charge drift. Optionally, a `temperature` field can be added to the `charge_drift_model` config for validation: if provided, it must match `semiconductor.temperature` or an error is raised. If `semiconductor.temperature` is not set, a material-specific default is used (77 K for High Purity Germanium, 293 K otherwise) and a warning is issued — this applies even if a `temperature` is specified in the charge drift model config, since that field only validates, not sets, the semiconductor temperature.
 
 ### Custom Charge Drift Model
 
@@ -363,7 +365,8 @@ detectors:
           # temperature: 78K  # optional: if provided, must match semiconductor.temperature
 ```
 
-> Note that temperature is preferably defined in `semiconductor.temperature` and will be passed automatically to the trapping model. A `temperature` field can also be specified inside `parameters`; if both are provided they must match or an error is raised. Unlike the charge drift model, if no `semiconductor.temperature` is defined, a `temperature` inside `parameters` alone is also accepted. If `semiconductor.temperature` is not set, a material-specific default is used (77 K for High Purity Germanium, 293 K otherwise) and a warning is issued — this applies even if a `temperature` is specified inside `parameters`, since the semiconductor temperature is always resolved first and passed to the trapping model.
+!!! note
+    The temperature is preferably defined in `semiconductor.temperature` and will be passed automatically to the trapping model. A `temperature` field can also be specified inside `parameters`; if both are provided they must match or an error is raised. Unlike the charge drift model, if no `semiconductor.temperature` is defined, a `temperature` inside `parameters` alone is also accepted. If `semiconductor.temperature` is not set, a material-specific default is used (77 K for High Purity Germanium, 293 K otherwise) and a warning is issued — this applies even if a `temperature` is specified inside `parameters`, since the semiconductor temperature is always resolved first and passed to the trapping model.
 
 It can also be applied to an already read-in `SolidStateDetector` using for example:
 ```julia
@@ -445,7 +448,8 @@ charge_trapping_model:
 This model also allows disabling the charge trapping model inside the inactive layer by having `model_inactive:` and the bulk by deleting `model:` from the `charge_trapping_model:` block.
 If `inactive_layer_geometry` is passed to the yaml file, this is the region used for the inactive layer charge trapping model, else, the model will use the inactive layer geometry defined by the impurity density model (`PtypePNJunctionImpurityDensity`) using the point types.
 
-> Note that temperature is preferably defined in `semiconductor.temperature` and will be passed automatically. Optionally, a `temperature` field can be added at the top level of the `charge_trapping_model` config (i.e. alongside `model` and `model_inactive`, not inside `parameters`); if both are provided they must match or an error is raised. Unlike the charge drift model, if no `semiconductor.temperature` is defined, a top-level `temperature` in the `charge_trapping_model` alone is also accepted. If `semiconductor.temperature` is not set, a material-specific default is used (77 K for High Purity Germanium, 293 K otherwise) and a warning is issued — this applies even if a `temperature` is specified in the `charge_trapping_model` config, since the semiconductor temperature is always resolved first and passed to the trapping model.
+!!! note
+    The temperature is preferably defined in `semiconductor.temperature` and will be passed automatically. Optionally, a `temperature` field can be added at the top level of the `charge_trapping_model` config (i.e. alongside `model` and `model_inactive`, not inside `parameters`); if both are provided they must match or an error is raised. Unlike the charge drift model, if no `semiconductor.temperature` is defined, a top-level `temperature` in the `charge_trapping_model` alone is also accepted. If `semiconductor.temperature` is not set, a material-specific default is used (77 K for High Purity Germanium, 293 K otherwise) and a warning is issued — this applies even if a `temperature` is specified in the `charge_trapping_model` config, since the semiconductor temperature is always resolved first and passed to the trapping model.
 
 ```julia
 using SolidStateDetectors, Unitful

--- a/examples/example_config_files/ivc_inactivelayer.yaml
+++ b/examples/example_config_files/ivc_inactivelayer.yaml
@@ -36,7 +36,6 @@ detectors:
         value: -1e10cm^-3
     charge_drift_model:
       model: InactiveLayerChargeDriftModel
-      temperature: 90K
       neutral_impurity_density:
         name: constant
         value: 5.6769e15cm^-3

--- a/examples/example_config_files/public_TrueCoaxial.yaml
+++ b/examples/example_config_files/public_TrueCoaxial.yaml
@@ -37,7 +37,6 @@ detectors:
         value: -1e10cm^-3
     charge_drift_model:
       model: InactiveLayerChargeDriftModel
-      temperature: 90K
       neutral_impurity_density:
         name: constant
         value: 5.6769e15cm^-3

--- a/src/ChargeDriftModels/InactiveLayerChargeDriftModel/InactiveLayerChargeDriftModel.jl
+++ b/src/ChargeDriftModels/InactiveLayerChargeDriftModel/InactiveLayerChargeDriftModel.jl
@@ -74,7 +74,7 @@ function InactiveLayerChargeDriftModel{T}(config::AbstractDict,
             throw(ConfigFileError(
                 "Temperature mismatch: InactiveLayerChargeDriftModel defines temperature = $(cdm_temperature) K, " *
                 "but the semiconductor temperature is $(temperature) K. " *
-                "Remove `temperature` from the charge drift model and define it only in the semiconductor."
+                "Define `temperature` in the semiconductor and either remove it from the charge drift model or make sure that the temperatures match."
             ))
         end
     end

--- a/src/ChargeDriftModels/InactiveLayerChargeDriftModel/InactiveLayerChargeDriftModel.jl
+++ b/src/ChargeDriftModels/InactiveLayerChargeDriftModel/InactiveLayerChargeDriftModel.jl
@@ -63,11 +63,14 @@ function _calculate_mobility_with_impurities(
 end
 
 function InactiveLayerChargeDriftModel{T}(config::AbstractDict,
-        imp_model::AbstractImpurityDensity, input_units::NamedTuple,
+        imp_model::AbstractImpurityDensity, input_units::NamedTuple, temperature::RealQuantity
     ) where {T <: SSDFloat}
 
-    temperature = _parse_value(T, get(config, "temperature", 90u"K"), input_units.temperature)
+    temperature::T = _parse_value(T, temperature, input_units.temperature)
 
+    if temperature < 50 || temperature > 150
+        @warn "Temperature = $(temperature) K is outside the typical validated range (50–150 K)."
+    end
     neutral_imp_model = if haskey(config, "neutral_impurity_density")
         ImpurityDensity(T, config["neutral_impurity_density"], input_units)
     else

--- a/src/ChargeDriftModels/InactiveLayerChargeDriftModel/InactiveLayerChargeDriftModel.jl
+++ b/src/ChargeDriftModels/InactiveLayerChargeDriftModel/InactiveLayerChargeDriftModel.jl
@@ -66,11 +66,11 @@ function InactiveLayerChargeDriftModel{T}(config::AbstractDict,
         imp_model::AbstractImpurityDensity, input_units::NamedTuple, temperature::RealQuantity
     ) where {T <: SSDFloat}
 
-    temperature::T = _parse_value(T, temperature, input_units.temperature)
+    temp::T = _parse_value(T, temperature, input_units.temperature)
 
     if haskey(config, "temperature")
         cdm_temperature::T = _parse_value(T, config["temperature"], input_units.temperature)
-        if cdm_temperature != temperature
+        if cdm_temperature != temp
             throw(ConfigFileError(
                 "Temperature mismatch: InactiveLayerChargeDriftModel defines temperature = $(cdm_temperature) K, " *
                 "but the semiconductor temperature is $(temperature) K. " *
@@ -79,8 +79,8 @@ function InactiveLayerChargeDriftModel{T}(config::AbstractDict,
         end
     end
 
-    if temperature < 50 || temperature > 150
-        @warn "Temperature = $(temperature) K is outside the typical validated range (50–150 K)."
+    if temp < 50 || temp > 150
+        @warn "Temperature = $(temp) K is outside the typical validated range (50–150 K)."
     end
     neutral_imp_model = if haskey(config, "neutral_impurity_density")
         ImpurityDensity(T, config["neutral_impurity_density"], input_units)
@@ -103,7 +103,7 @@ function InactiveLayerChargeDriftModel{T}(config::AbstractDict,
     else
         throw(ConfigFileError("There is no surface impurity density profile provided."))
     end
-    InactiveLayerChargeDriftModel{T}(temperature, neutral_imp_model, bulk_imp_model, surface_imp_model)
+    InactiveLayerChargeDriftModel{T}(temp, neutral_imp_model, bulk_imp_model, surface_imp_model)
 end
 
 @fastmath function getVe(fv::SVector{3, T}, cdm::InactiveLayerChargeDriftModel{T}, current_pos::CartesianPoint{T} = zero(CartesianPoint{T})) where {T <: SSDFloat}

--- a/src/ChargeDriftModels/InactiveLayerChargeDriftModel/InactiveLayerChargeDriftModel.jl
+++ b/src/ChargeDriftModels/InactiveLayerChargeDriftModel/InactiveLayerChargeDriftModel.jl
@@ -68,6 +68,17 @@ function InactiveLayerChargeDriftModel{T}(config::AbstractDict,
 
     temperature::T = _parse_value(T, temperature, input_units.temperature)
 
+    if haskey(config, "temperature")
+        cdm_temperature::T = _parse_value(T, config["temperature"], input_units.temperature)
+        if cdm_temperature != temperature
+            throw(ConfigFileError(
+                "Temperature mismatch: InactiveLayerChargeDriftModel defines temperature = $(cdm_temperature) K, " *
+                "but the semiconductor temperature is $(temperature) K. " *
+                "Remove `temperature` from the charge drift model and define it only in the semiconductor."
+            ))
+        end
+    end
+
     if temperature < 50 || temperature > 150
         @warn "Temperature = $(temperature) K is outside the typical validated range (50–150 K)."
     end

--- a/src/ChargeTrapping/ChargeTrapping.jl
+++ b/src/ChargeTrapping/ChargeTrapping.jl
@@ -66,7 +66,6 @@ Charge trapping model presented in [Boggs _et al._ (2023)](https://doi.org/10.10
 ## Fields
 * `nσe::T`: Trapping product for electrons (default: `(nσe)^-1 = 1020cm`).
 * `nσh::T`: Trapping product for holes (default: `(nσh)^-1 = 2040cm`).
-* `temperature::T`: Temperature of the crystal (default: `78K`).
 
 See also [Charge Trapping Models](@ref).
 """
@@ -124,7 +123,7 @@ end
 
 
 BoggsChargeTrappingModel(args...; T::Type{<:SSDFloat}, kwargs...) = BoggsChargeTrappingModel{T}(args...; kwargs...)
-function BoggsChargeTrappingModel{T}(config_dict::AbstractDict = Dict(); temperature::RealQuantity = T(78)) where {T <: SSDFloat}
+function BoggsChargeTrappingModel{T}(temperature::RealQuantity, config_dict::AbstractDict = Dict()) where {T <: SSDFloat}
     nσe::T = ustrip(u"m^-1", inv(1020u"cm"))
     nσh::T = ustrip(u"m^-1", inv(2040u"cm"))
     meffe::T = 0.12
@@ -147,7 +146,7 @@ function BoggsChargeTrappingModel{T}(config_dict::AbstractDict = Dict(); tempera
     if haskey(parameters, "nσh-1") nσh = inv(_parse_value(T, parameters["nσh-1"], internal_length_unit)) end
     if haskey(parameters, "meffe") meffe =   _parse_value(T, parameters["meffe"], Unitful.NoUnits) end
     if haskey(parameters, "meffh") meffh =   _parse_value(T, parameters["meffh"], Unitful.NoUnits) end
-    if haskey(parameters, "temperature") temperature = _parse_value(T, parameters["temperature"], internal_temperature_unit) end
+    
     BoggsChargeTrappingModel{T}(nσe, nσh, meffe, meffh, temperature)
 end
 
@@ -330,7 +329,7 @@ end
 
 
 CombinedChargeTrappingModel(args...; T::Type{<:SSDFloat}, kwargs...) = CombinedChargeTrappingModel{T}(args...; kwargs...)
-function CombinedChargeTrappingModel{T}(config_dict::AbstractDict = Dict(); temperature::RealQuantity = T(78)) where {T <: SSDFloat}
+function CombinedChargeTrappingModel{T}(temperature::RealQuantity, config_dict::AbstractDict = Dict()) where {T <: SSDFloat}
 
     if haskey(config_dict, "model") && config_dict["model"] !== nothing && !(haskey(config_dict, "parameters"))
         throw(ConfigFileError("`CombinedChargeTrappingModel` does not have `parameters`"))
@@ -347,7 +346,7 @@ function CombinedChargeTrappingModel{T}(config_dict::AbstractDict = Dict(); temp
             if isnothing(model)
                 throw(ConfigFileError("`model` is defined but empty in config. Remove it or provide a valid name."))
         elseif model == "Boggs"
-                BoggsChargeTrappingModel{T}(config_dict; temperature)
+                BoggsChargeTrappingModel{T}(temperature, config_dict)
             elseif model == "ConstantLifetime"
                 ConstantLifetimeChargeTrappingModel{T}(config_dict)
             else

--- a/src/ChargeTrapping/ChargeTrapping.jl
+++ b/src/ChargeTrapping/ChargeTrapping.jl
@@ -123,19 +123,34 @@ end
 
 
 BoggsChargeTrappingModel(args...; T::Type{<:SSDFloat}, kwargs...) = BoggsChargeTrappingModel{T}(args...; kwargs...)
-function BoggsChargeTrappingModel{T}(temperature::RealQuantity, config_dict::AbstractDict = Dict()) where {T <: SSDFloat}
+function BoggsChargeTrappingModel{T}(config_dict::AbstractDict = Dict(), temperature::Union{RealQuantity, Missing} = missing) where {T <: SSDFloat}
     nσe::T = ustrip(u"m^-1", inv(1020u"cm"))
     nσh::T = ustrip(u"m^-1", inv(2040u"cm"))
     meffe::T = 0.12
     meffh::T = 0.21
-    temperature::T = _parse_value(T, temperature, internal_temperature_unit)
 
     if haskey(config_dict, "model") && !haskey(config_dict, "parameters")
         throw(ConfigFileError("`BoggsChargeTrappingModel` does not have `parameters`"))
     end
 
     parameters = haskey(config_dict, "parameters") ? config_dict["parameters"] : config_dict
-    
+
+    temp::Union{T, Missing} = temperature === missing ? missing : _parse_value(T, temperature, internal_temperature_unit)
+
+    if haskey(parameters, "temperature")
+        cfg_temp::T = _parse_value(T, parameters["temperature"], internal_temperature_unit)
+        if temp !== missing && cfg_temp != temp
+            throw(ConfigFileError(
+                "Temperature mismatch: BoggsChargeTrappingModel defines temperature = $(cfg_temp) K, " *
+                "but the semiconductor temperature is $(temp) K. " *
+                "Remove `temperature` from the charge trapping model and define it only in the semiconductor."
+            ))
+        end
+        temp = cfg_temp
+    end
+
+    temp === missing && throw(ConfigFileError("No temperature specified for `BoggsChargeTrappingModel`"))
+
     allowed_keys = ("nσe","nσe-1","nσh","nσh-1","meffe","meffh","temperature")
     k = filter(k -> !(k in allowed_keys), keys(parameters))
     !isempty(k) && @warn "The following keys will be ignored: $(k).\nAllowed keys are: $(allowed_keys)"
@@ -146,8 +161,8 @@ function BoggsChargeTrappingModel{T}(temperature::RealQuantity, config_dict::Abs
     if haskey(parameters, "nσh-1") nσh = inv(_parse_value(T, parameters["nσh-1"], internal_length_unit)) end
     if haskey(parameters, "meffe") meffe =   _parse_value(T, parameters["meffe"], Unitful.NoUnits) end
     if haskey(parameters, "meffh") meffh =   _parse_value(T, parameters["meffh"], Unitful.NoUnits) end
-    
-    BoggsChargeTrappingModel{T}(nσe, nσh, meffe, meffh, temperature)
+
+    BoggsChargeTrappingModel{T}(nσe, nσh, meffe, meffh, temp)
 end
 
 
@@ -329,7 +344,23 @@ end
 
 
 CombinedChargeTrappingModel(args...; T::Type{<:SSDFloat}, kwargs...) = CombinedChargeTrappingModel{T}(args...; kwargs...)
-function CombinedChargeTrappingModel{T}(temperature::RealQuantity, config_dict::AbstractDict = Dict()) where {T <: SSDFloat}
+function CombinedChargeTrappingModel{T}(config_dict::AbstractDict = Dict(), temperature::Union{RealQuantity, Missing} = missing) where {T <: SSDFloat}
+
+    temp::Union{T, Missing} = temperature === missing ? missing : _parse_value(T, temperature, internal_temperature_unit)
+
+    if haskey(config_dict, "temperature")
+        cfg_temp::T = _parse_value(T, config_dict["temperature"], internal_temperature_unit)
+        if temp !== missing && cfg_temp != temp
+            throw(ConfigFileError(
+                "Temperature mismatch: CombinedChargeTrappingModel defines temperature = $(cfg_temp) K, " *
+                "but the semiconductor temperature is $(temp) K. " *
+                "Remove `temperature` from the charge trapping model and define it only in the semiconductor."
+            ))
+        end
+        temp = cfg_temp
+    end
+
+    temp === missing && throw(ConfigFileError("No temperature specified for `CombinedChargeTrappingModel`"))
 
     if haskey(config_dict, "model") && config_dict["model"] !== nothing && !(haskey(config_dict, "parameters"))
         throw(ConfigFileError("`CombinedChargeTrappingModel` does not have `parameters`"))
@@ -345,8 +376,8 @@ function CombinedChargeTrappingModel{T}(temperature::RealQuantity, config_dict::
             model = config_dict["model"]
             if isnothing(model)
                 throw(ConfigFileError("`model` is defined but empty in config. Remove it or provide a valid name."))
-        elseif model == "Boggs"
-                BoggsChargeTrappingModel{T}(temperature, config_dict)
+            elseif model == "Boggs"
+                BoggsChargeTrappingModel{T}(config_dict, temp)
             elseif model == "ConstantLifetime"
                 ConstantLifetimeChargeTrappingModel{T}(config_dict)
             else

--- a/src/ChargeTrapping/ChargeTrapping.jl
+++ b/src/ChargeTrapping/ChargeTrapping.jl
@@ -123,7 +123,7 @@ end
 
 
 BoggsChargeTrappingModel(args...; T::Type{<:SSDFloat}, kwargs...) = BoggsChargeTrappingModel{T}(args...; kwargs...)
-function BoggsChargeTrappingModel{T}(config_dict::AbstractDict = Dict(), temperature::Union{RealQuantity, Missing} = missing) where {T <: SSDFloat}
+function BoggsChargeTrappingModel{T}(config_dict::AbstractDict = Dict(), temperature::RealQuantity = NaN) where {T <: SSDFloat}
     nσe::T = ustrip(u"m^-1", inv(1020u"cm"))
     nσh::T = ustrip(u"m^-1", inv(2040u"cm"))
     meffe::T = 0.12
@@ -135,21 +135,21 @@ function BoggsChargeTrappingModel{T}(config_dict::AbstractDict = Dict(), tempera
 
     parameters = haskey(config_dict, "parameters") ? config_dict["parameters"] : config_dict
 
-    temp::Union{T, Missing} = temperature === missing ? missing : _parse_value(T, temperature, internal_temperature_unit)
+    temp::T = isnan(temperature) ? T(NaN) : _parse_value(T, temperature, internal_temperature_unit)
 
     if haskey(parameters, "temperature")
         cfg_temp::T = _parse_value(T, parameters["temperature"], internal_temperature_unit)
-        if temp !== missing && cfg_temp != temp
+        if !isnan(temp) && cfg_temp != temp
             throw(ConfigFileError(
                 "Temperature mismatch: BoggsChargeTrappingModel defines temperature = $(cfg_temp) K, " *
                 "but the semiconductor temperature is $(temp) K. " *
-                "Remove `temperature` from the charge trapping model and define it only in the semiconductor."
+                "Define `temperature` in the semiconductor and either remove it from the charge trapping model or make sure that the temperatures match."
             ))
         end
         temp = cfg_temp
     end
 
-    temp === missing && throw(ConfigFileError("No temperature specified for `BoggsChargeTrappingModel`"))
+    isnan(temp) && throw(ConfigFileError("No temperature specified for `BoggsChargeTrappingModel`"))
 
     allowed_keys = ("nσe","nσe-1","nσh","nσh-1","meffe","meffh","temperature")
     k = filter(k -> !(k in allowed_keys), keys(parameters))
@@ -344,23 +344,23 @@ end
 
 
 CombinedChargeTrappingModel(args...; T::Type{<:SSDFloat}, kwargs...) = CombinedChargeTrappingModel{T}(args...; kwargs...)
-function CombinedChargeTrappingModel{T}(config_dict::AbstractDict = Dict(), temperature::Union{RealQuantity, Missing} = missing) where {T <: SSDFloat}
+function CombinedChargeTrappingModel{T}(config_dict::AbstractDict = Dict(), temperature::RealQuantity = NaN) where {T <: SSDFloat}
 
-    temp::Union{T, Missing} = temperature === missing ? missing : _parse_value(T, temperature, internal_temperature_unit)
+    temp::T = isnan(temperature) ? T(NaN) : _parse_value(T, temperature, internal_temperature_unit)
 
     if haskey(config_dict, "temperature")
         cfg_temp::T = _parse_value(T, config_dict["temperature"], internal_temperature_unit)
-        if temp !== missing && cfg_temp != temp
+        if !isnan(temp) && cfg_temp != temp
             throw(ConfigFileError(
                 "Temperature mismatch: CombinedChargeTrappingModel defines temperature = $(cfg_temp) K, " *
                 "but the semiconductor temperature is $(temp) K. " *
-                "Remove `temperature` from the charge trapping model and define it only in the semiconductor."
+                "Define `temperature` in the semiconductor and either remove it from the charge trapping model or make sure that the temperatures match."
             ))
         end
         temp = cfg_temp
     end
 
-    temp === missing && throw(ConfigFileError("No temperature specified for `CombinedChargeTrappingModel`"))
+    isnan(temp) && throw(ConfigFileError("No temperature specified for `CombinedChargeTrappingModel`"))
 
     if haskey(config_dict, "model") && config_dict["model"] !== nothing && !(haskey(config_dict, "parameters"))
         throw(ConfigFileError("`CombinedChargeTrappingModel` does not have `parameters`"))

--- a/src/SolidStateDetector/Semiconductor.jl
+++ b/src/SolidStateDetector/Semiconductor.jl
@@ -58,11 +58,13 @@ function Semiconductor{T}(dict::AbstractDict, input_units::NamedTuple, outer_tra
 
     material = material_properties[materials[dict["material"]]]
 
-    temperature = if haskey(dict, "temperature") 
+    temperature = if haskey(dict, "temperature")
         _parse_value(T, dict["temperature"], input_units.temperature)
     elseif material.name == "High Purity Germanium"
+        @warn "No temperature defined for semiconductor. Using default value of 77 K for High Purity Germanium."
         T(77)
     else
+        @warn "No temperature defined for semiconductor. Using default value of 293 K."
         T(293)
     end
     

--- a/src/SolidStateDetector/Semiconductor.jl
+++ b/src/SolidStateDetector/Semiconductor.jl
@@ -98,11 +98,11 @@ function Semiconductor{T}(dict::AbstractDict, input_units::NamedTuple, outer_tra
             ctm_dict["parameters"]==ctm_dict["parameters_inactive"] && ctm_dict["model"] == "ConstantLifetime"
             ConstantLifetimeChargeTrappingModel{T}(ctm_dict)
         else
-            CombinedChargeTrappingModel{T}(temperature, ctm_dict)
+            CombinedChargeTrappingModel{T}(ctm_dict, temperature)
         end
         
     elseif haskey(ctm_dict, "model") && !haskey(ctm_dict, "model_inactive") && ctm_dict["model"] == "Boggs"
-        BoggsChargeTrappingModel{T}(temperature, ctm_dict)
+        BoggsChargeTrappingModel{T}(ctm_dict, temperature)
         
     elseif haskey(ctm_dict, "model") && !haskey(ctm_dict, "model_inactive") && ctm_dict["model"] == "ConstantLifetime"
         ConstantLifetimeChargeTrappingModel{T}(ctm_dict)

--- a/src/SolidStateDetector/Semiconductor.jl
+++ b/src/SolidStateDetector/Semiconductor.jl
@@ -70,7 +70,7 @@ function Semiconductor{T}(dict::AbstractDict, input_units::NamedTuple, outer_tra
         model = Symbol(dict["charge_drift_model"]["model"])
         cdm = if isdefined(SolidStateDetectors, model) && getfield(SolidStateDetectors, model) <: AbstractChargeDriftModel
             if model == :InactiveLayerChargeDriftModel
-                InactiveLayerChargeDriftModel{T}(dict["charge_drift_model"], impurity_density_model, input_units)
+                InactiveLayerChargeDriftModel{T}(dict["charge_drift_model"], impurity_density_model, input_units, temperature)
             else
                 getfield(SolidStateDetectors, model){T}(dict["charge_drift_model"], input_units, temperature = temperature)
             end
@@ -98,11 +98,11 @@ function Semiconductor{T}(dict::AbstractDict, input_units::NamedTuple, outer_tra
             ctm_dict["parameters"]==ctm_dict["parameters_inactive"] && ctm_dict["model"] == "ConstantLifetime"
             ConstantLifetimeChargeTrappingModel{T}(ctm_dict)
         else
-            CombinedChargeTrappingModel{T}(ctm_dict, temperature = temperature)
+            CombinedChargeTrappingModel{T}(temperature, ctm_dict)
         end
         
     elseif haskey(ctm_dict, "model") && !haskey(ctm_dict, "model_inactive") && ctm_dict["model"] == "Boggs"
-        BoggsChargeTrappingModel{T}(ctm_dict, temperature = temperature)
+        BoggsChargeTrappingModel{T}(temperature, ctm_dict)
         
     elseif haskey(ctm_dict, "model") && !haskey(ctm_dict, "model_inactive") && ctm_dict["model"] == "ConstantLifetime"
         ConstantLifetimeChargeTrappingModel{T}(ctm_dict)

--- a/test/test_charge_drift_models.jl
+++ b/test/test_charge_drift_models.jl
@@ -76,7 +76,7 @@ end
 end
 
 @timed_testset "Charge Trapping: BoggsChargeTrappingModel" begin
-    sim.detector = SolidStateDetector(sim.detector, BoggsChargeTrappingModel{T}())
+    sim.detector = SolidStateDetector(sim.detector, BoggsChargeTrappingModel{T}(sim.detector.semiconductor.temperature))
     evt = Event(pos, Edep)
     timed_simulate!(evt, sim)
     signalsum = T(0)
@@ -92,15 +92,13 @@ end
             "model" => "Boggs",
             "parameters" => Dict(
                 "nσe" => "0.001cm^-1",
-                "nσh" => "0.0005cm^-1",
-                "temperature" => "78K"
+                "nσh" => "0.0005cm^-1"
             )
         )
         simA = @test_nowarn Simulation{T}(config_dict)
         @test simA.detector.semiconductor.charge_trapping_model isa BoggsChargeTrappingModel{T}
         @test simA.detector.semiconductor.charge_trapping_model.nσe == T(0.1)
         @test simA.detector.semiconductor.charge_trapping_model.nσh == T(0.05)
-        @test simA.detector.semiconductor.charge_trapping_model.temperature == T(78)
     end
     @testset "Parse config file 2" begin
         config_dict["detectors"][1]["semiconductor"]["charge_trapping_model"] = Dict(
@@ -109,8 +107,7 @@ end
                 "nσe-1" => "500cm",
                 "nσh-1" => "500cm",
                 "meffe" => 0.1,
-                "meffh" => 0.2,
-                "temperature" => "100K"
+                "meffh" => 0.2
             )
         )
         simB = @test_nowarn Simulation{T}(config_dict)
@@ -119,7 +116,6 @@ end
         @test simB.detector.semiconductor.charge_trapping_model.nσh == T(0.2)
         @test simB.detector.semiconductor.charge_trapping_model.meffe == T(0.1)
         @test simB.detector.semiconductor.charge_trapping_model.meffh == T(0.2)
-        @test simB.detector.semiconductor.charge_trapping_model.temperature == T(100)
 
     end
 end
@@ -175,7 +171,7 @@ end
     for (τ,τ_inactive) in zip(τ_list, τ_inactive_list)
         parameters = Dict("model" => "ConstantLifetime", "model_inactive" => "ConstantLifetime", "parameters" => Dict("τh" => τ, "τe" => τ), "parameters_inactive" => Dict("τh" => τ_inactive, "τe" => τ_inactive),
             "inactive_layer_geometry" => simA_inactive_layer_geometry)
-        trapping_model=CombinedChargeTrappingModel{T}(parameters)
+        trapping_model=CombinedChargeTrappingModel{T}(simA.detector.semiconductor.temperature, parameters)
         simA.detector = SolidStateDetector(simA.detector, trapping_model)
         evt_bulk = Event(pos_bulk , Edep)
         timed_simulate!(evt_bulk, simA)
@@ -205,7 +201,7 @@ end
     τ, τ_inactive = 1u"ms", 100u"ns"
     parameters = Dict("model" => "ConstantLifetime", "model_inactive" => "ConstantLifetime", "parameters" => Dict("τh" => τ, "τe" => τ), "parameters_inactive" => Dict("τh" => τ_inactive, "τe" => τ_inactive),
         "inactive_layer_geometry" => simA_inactive_layer_geometry)
-    trapping_model=CombinedChargeTrappingModel{T}(parameters)
+    trapping_model=CombinedChargeTrappingModel{T}(simA.detector.semiconductor.temperature, parameters)
     simA.detector = SolidStateDetector(simA.detector, trapping_model)
     signalsum_list_inactive = T[]
     for depth in (0.1:0.1:0.9)/1000

--- a/test/test_charge_drift_models.jl
+++ b/test/test_charge_drift_models.jl
@@ -76,7 +76,7 @@ end
 end
 
 @timed_testset "Charge Trapping: BoggsChargeTrappingModel" begin
-    sim.detector = SolidStateDetector(sim.detector, BoggsChargeTrappingModel{T}(sim.detector.semiconductor.temperature))
+    sim.detector = SolidStateDetector(sim.detector, BoggsChargeTrappingModel{T}(Dict(), sim.detector.semiconductor.temperature))
     evt = Event(pos, Edep)
     timed_simulate!(evt, sim)
     signalsum = T(0)
@@ -92,13 +92,15 @@ end
             "model" => "Boggs",
             "parameters" => Dict(
                 "nσe" => "0.001cm^-1",
-                "nσh" => "0.0005cm^-1"
+                "nσh" => "0.0005cm^-1",
+                "temperature" => "78K"
             )
         )
         simA = @test_nowarn Simulation{T}(config_dict)
         @test simA.detector.semiconductor.charge_trapping_model isa BoggsChargeTrappingModel{T}
         @test simA.detector.semiconductor.charge_trapping_model.nσe == T(0.1)
         @test simA.detector.semiconductor.charge_trapping_model.nσh == T(0.05)
+        @test simA.detector.semiconductor.charge_trapping_model.temperature == T(78)
     end
     @testset "Parse config file 2" begin
         config_dict["detectors"][1]["semiconductor"]["charge_trapping_model"] = Dict(
@@ -107,7 +109,8 @@ end
                 "nσe-1" => "500cm",
                 "nσh-1" => "500cm",
                 "meffe" => 0.1,
-                "meffh" => 0.2
+                "meffh" => 0.2,
+                "temperature" => "78K"
             )
         )
         simB = @test_nowarn Simulation{T}(config_dict)
@@ -116,7 +119,30 @@ end
         @test simB.detector.semiconductor.charge_trapping_model.nσh == T(0.2)
         @test simB.detector.semiconductor.charge_trapping_model.meffe == T(0.1)
         @test simB.detector.semiconductor.charge_trapping_model.meffh == T(0.2)
-
+        @test simB.detector.semiconductor.charge_trapping_model.temperature == T(78)
+    end
+    @testset "CTM temperature is inherited from semiconductor when not in config" begin
+        config_dict = SolidStateDetectors.parse_config_file(SSD_examples[:InvertedCoax])
+        config_dict["detectors"][1]["semiconductor"]["charge_trapping_model"] = Dict(
+            "model" => "Boggs",
+            "parameters" => Dict("nσe" => "0.001cm^-1", "nσh" => "0.0005cm^-1")
+        )
+        sim_boggs = @test_nowarn Simulation{T}(config_dict)
+        @test sim_boggs.detector.semiconductor.charge_trapping_model.temperature == sim_boggs.detector.semiconductor.temperature
+    end
+    @testset "Temperature mismatch in parameters raises ConfigFileError" begin
+        config_dict = SolidStateDetectors.parse_config_file(SSD_examples[:InvertedCoax])
+        config_dict["detectors"][1]["semiconductor"]["charge_trapping_model"] = Dict(
+            "model" => "Boggs",
+            "parameters" => Dict("nσe" => "0.001cm^-1", "nσh" => "0.0005cm^-1", "temperature" => "100K")
+        )
+        @test_throws SolidStateDetectors.ConfigFileError Simulation{T}(config_dict)
+    end
+    @testset "Temperature from config only (no argument)" begin
+        ctm = @test_nowarn BoggsChargeTrappingModel{T}(Dict(
+            "parameters" => Dict("nσe" => "0.001cm^-1", "temperature" => "78K")
+        ))
+        @test ctm.temperature == T(78)
     end
 end
 @timed_testset "Charge Trapping: ConstantLifetimeChargeTrappingModel" begin
@@ -171,7 +197,7 @@ end
     for (τ,τ_inactive) in zip(τ_list, τ_inactive_list)
         parameters = Dict("model" => "ConstantLifetime", "model_inactive" => "ConstantLifetime", "parameters" => Dict("τh" => τ, "τe" => τ), "parameters_inactive" => Dict("τh" => τ_inactive, "τe" => τ_inactive),
             "inactive_layer_geometry" => simA_inactive_layer_geometry)
-        trapping_model=CombinedChargeTrappingModel{T}(simA.detector.semiconductor.temperature, parameters)
+        trapping_model=CombinedChargeTrappingModel{T}(parameters, simA.detector.semiconductor.temperature)
         simA.detector = SolidStateDetector(simA.detector, trapping_model)
         evt_bulk = Event(pos_bulk , Edep)
         timed_simulate!(evt_bulk, simA)
@@ -201,7 +227,7 @@ end
     τ, τ_inactive = 1u"ms", 100u"ns"
     parameters = Dict("model" => "ConstantLifetime", "model_inactive" => "ConstantLifetime", "parameters" => Dict("τh" => τ, "τe" => τ), "parameters_inactive" => Dict("τh" => τ_inactive, "τe" => τ_inactive),
         "inactive_layer_geometry" => simA_inactive_layer_geometry)
-    trapping_model=CombinedChargeTrappingModel{T}(simA.detector.semiconductor.temperature, parameters)
+    trapping_model=CombinedChargeTrappingModel{T}(parameters, simA.detector.semiconductor.temperature)
     simA.detector = SolidStateDetector(simA.detector, trapping_model)
     signalsum_list_inactive = T[]
     for depth in (0.1:0.1:0.9)/1000
@@ -218,6 +244,17 @@ end
     end
     @test all(signalsum_list_inactive .< T(2.0))
     @test all(diff(signalsum_list_inactive) .> 0)
+
+    @testset "Matching temperature in CombinedCTM config is allowed" begin
+        config_dict = SolidStateDetectors.parse_config_file(SSD_examples[:TrueCoaxial])
+        config_dict["detectors"][1]["semiconductor"]["charge_trapping_model"]["temperature"] = 90
+        @test_nowarn Simulation{T}(config_dict)
+    end
+    @testset "Temperature mismatch in CombinedCTM config raises ConfigFileError" begin
+        config_dict = SolidStateDetectors.parse_config_file(SSD_examples[:TrueCoaxial])
+        config_dict["detectors"][1]["semiconductor"]["charge_trapping_model"]["temperature"] = 100
+        @test_throws SolidStateDetectors.ConfigFileError Simulation{T}(config_dict)
+    end
 end
 
 @timed_testset "Test completeness of charge drift models" begin
@@ -284,6 +321,22 @@ end
         pt_inactive = CartesianPoint{T}(0.0095, 0.0, 0.005)
         @test SolidStateDetectors.in_inactive_layer(pt_active, nothing, simA.point_types) == false
         @test SolidStateDetectors.in_inactive_layer(pt_inactive, nothing, simA.point_types) == true
+    end
+
+    @testset "CDM temperature is inherited from semiconductor when not in config" begin
+        @test simA.detector.semiconductor.charge_drift_model.temperature == simA.detector.semiconductor.temperature
+
+        # A matching temperature in the Charge Drift Model config entry is allowed
+        config_dict = SolidStateDetectors.parse_config_file(SSD_examples[:TrueCoaxial])
+        config_dict["detectors"][1]["semiconductor"]["charge_drift_model"]["temperature"] = 90
+        @test_nowarn Simulation{T}(config_dict)
+    end
+
+    @testset "Temperature mismatch in Charge Drift Model config raises ConfigFileError" begin
+        config_dict = SolidStateDetectors.parse_config_file(SSD_examples[:TrueCoaxial])
+        # semiconductor temperature is 90 K; setting Charge Drift Model temperature to a different value must throw
+        config_dict["detectors"][1]["semiconductor"]["charge_drift_model"]["temperature"] = 100
+        @test_throws SolidStateDetectors.ConfigFileError Simulation{T}(config_dict)
     end
 end
 


### PR DESCRIPTION
This PR fixes the temperature handling across charge drift and charge trapping models to ensure that model temperatures are inherited consistently from the semiconductor configuration rather than being independently specified 
Updated semiconductor model construction to propagate the detector temperature to:
    * InactiveLayerChargeDriftModel
    * BoggsChargeTrappingModel
    * CombinedChargeTrappingModel
Updated charge trapping tests to construct models using the detector semiconductor temperature.
Removed tests that relied on model-specific temperature values in configuration files.
This change eliminates duplicated temperature definitions across detector models and prevents inconsistencies between semiconductor and trapping/drift temperatures.
