### PR TITLE
Exclude Geant4 tests on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Remove Geant4 on x86
         run: julia --project="test" -e 'using Pkg; Pkg.resolve(); Pkg.rm("Geant4"); Pkg.develop(path = pwd())'
         shell: bash
-        if: matrix.arch == 'x86'
+        if: matrix.arch == 'x86' || matrix.os == 'windows-latest'
       - uses: julia-actions/julia-runtest@v1
         with:
           coverage: ${{ matrix.version == '1.10' && matrix.os == 'ubuntu-latest' && matrix.arch == 'x64' }}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,7 +58,7 @@ end
 end
 
 @timed_testset "Geant4 extension" begin
-    if Sys.WORD_SIZE == 64 include("test_geant4.jl") end
+    if Sys.WORD_SIZE == 64 && !Sys.iswindows() include("test_geant4.jl") end
 end
 
 display(testtimer())


### PR DESCRIPTION
With Geant4@0.3.0, the Geant4 tests on windows do not seem to pass.
I've excluded them for now, until this is addressed.