### PR TITLE
Add option to pass simulated electric field to `G4JLApplication`

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -12,3 +12,4 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 Documenter = "1"
+Geant4 = "0.3.1"

--- a/docs/src/tutorials/geant4_ssd_lit.jl
+++ b/docs/src/tutorials/geant4_ssd_lit.jl
@@ -112,9 +112,7 @@ plot!(flatview(events[1:1000].pos), ms = 0.5, msw = 0, color=:black, label = "")
 # In order to visualize the energy spectrum of the events in a histogram, the following code can be used:
 
 using StatsBase
-
 h = fit(Histogram, ustrip.(u"keV", sum.(events.edep)), Weights(fill(10,length(events.edep))), 0:10:3000)
-
 plot(h, title = "Energy spectrum", bins = 500, yscale = :log10, st = :step, label = "")
 xlims!(0,3000, xlabel = "E in keV", ylabel = "counts")
 #jl savefig("spectrum.pdf") # hide
@@ -151,3 +149,26 @@ plot(w[1:20], label = "")
 #md savefig("wf_and_amplitude.pdf") # hide
 #md savefig("wf_and_amplitude.svg"); nothing # hide
 #md # [![wf_and_amplitude](wf_and_amplitude.svg)](wf_and_amplitude.pdf) 
+
+
+# The electric field calculated with SolidStateDetectors.jl can also be passed to the `G4JLApplication` via the `field` keyword argument to include it in the Geant4 simulation
+
+# ```Julia
+# app = G4JLApplication(sim, source_1, field = G4JLElectricField(sim), verbose = false)
+# ```
+
+#md ef = G4JLElectricField(sim) # hide
+#md sf = Geant4.make_callback(ef.data, ef.getfield, Nothing, (CxxRef{G4ThreeVector}, ConstCxxRef{G4ThreeVector})) |> Geant4.closure # hide
+#md E = G4JLElecField(sf...) # hide
+#md ef.base = [E] # hide
+#md G4JL_setupElectroMagneticField(G4TransportationManager!GetTransportationManager() |> GetFieldManager, CxxPtr(E), 0.010Geant4.SystemOfUnits.mm) # hide
+
+#md events_ef = run_geant4_simulation(app, N_events)
+#md stephist(sum.(events.edep), bins = 2614.7:0.005:2615.3, label = "Excluding electric field\nin Geant4")
+#md stephist!(sum.(events_ef.edep), bins = 2614.7:0.005:2615.3, label = "Including electric field\nin Geant4")
+#md xlims!(2614.7,2615.3, xlabel = "E", unitformat = " in ", ylabel = "counts", title = "Energy spectrum")
+#md ylims!(0,580, legend = :topleft)
+#md savefig("spectrum_electric_field.pdf") # hide
+#md savefig("spectrum_electric_field.svg"); nothing # hide
+#md # [![spectrum_electric_field](spectrum_electric_field.svg)](spectrum_electric_field.pdf) 
+

--- a/ext/Geant4/g4jl_application.jl
+++ b/ext/Geant4/g4jl_application.jl
@@ -158,3 +158,18 @@ function SSDGenerator(source::SolidStateDetectors.IsotopeSource; kwargs...)
     
     G4JLPrimaryGenerator("SSDGenerator", data; init_method=_init, generate_method=_gen)
 end
+
+
+struct SSDElectricFieldData{T,CS <: SolidStateDetectors.AbstractCoordinateSystem} <: G4JLFieldData
+    efield_itp::Interpolations.Extrapolation{<:StaticArrays.SVector{3}, 3}
+    function SSDElectricFieldData(sim::Simulation{T,CS}) where {T,CS} 
+        if ismissing(sim.electric_field)
+            throw(ArgumentError("Electric field has not been calculated yet. Please run `calculate_electric_field!(sim)` first."))
+        end
+        new{T,CS}(SolidStateDetectors.interpolated_vectorfield(sim.electric_field))
+    end
+end
+
+Base.print(io::IO, d::SSDElectricFieldData) = print(io, "SSD electric field interpolation - $(Base.size(Interpolations.coefficients(d.efield_itp.itp)))")
+Base.show(io::IO, d::SSDElectricFieldData) = print(io, d)
+Base.show(io::IO,::MIME"text/plain", d::SSDElectricFieldData) = show(io, d)

--- a/ext/SolidStateDetectorsGeant4Ext.jl
+++ b/ext/SolidStateDetectorsGeant4Ext.jl
@@ -17,6 +17,8 @@ using Suppressor
 using TypedTables
 using Unitful
 
+const GEANT4VERSION = pkgversion(Geant4)
+
 include(joinpath(@__DIR__, "Geant4", "io_gdml.jl"))
 include(joinpath(@__DIR__, "Geant4", "g4jl_application.jl"))
 
@@ -203,6 +205,8 @@ function Geant4.G4JLApplication(
 end
 
 
+@static if GEANT4VERSION >= v"0.3.1"
+
 """
     G4JLElectricField(sim::Simulation)
 
@@ -253,6 +257,7 @@ function Geant4.G4JLElectricField(sim::Simulation{T,CS}) where {T,CS}
         return
     end
     G4JLElectricField("SSDElectricField", data; getfield_method = getfield!)
+end
 end
 
 

--- a/ext/SolidStateDetectorsGeant4Ext.jl
+++ b/ext/SolidStateDetectorsGeant4Ext.jl
@@ -5,6 +5,7 @@ module SolidStateDetectorsGeant4Ext
 using Geant4
 using Geant4.SystemOfUnits
 
+using Interpolations
 using LightXML
 using LinearAlgebra
 using Parameters
@@ -199,6 +200,59 @@ function Geant4.G4JLApplication(
         endeventaction_method = endevent            # end-event action (fill histogram per event data)
     )
     =#
+end
+
+
+"""
+    G4JLElectricField(sim::Simulation)
+
+Creates a `Geant4.G4JLElectricField` from the electric field of an SSD simulation,
+that can be passed via the `field` keyword argument to `Geant4.G4JLApplication`.
+
+## Arguments
+* `sim::Simulation`: SSD Simulation.
+
+## Examples
+```julia 
+source = MonoenergeticSource("gamma", 2.615u"MeV", CartesianPoint(0.065, 0., 0.05), CartesianVector(-1,0,0))
+sim = Simulation{Float32}(SSD_examples[:InvertedCoax])
+calculate_electric_potential!(sim)
+calculate_electric_field!(sim)
+app = G4JLApplication(sim, source, field = G4JLElectricField(sim))
+```
+
+!!! note
+    The electric field in `sim` needs to be calculated using [`calculate_electric_field!`](@ref) before calling this function.
+"""
+function Geant4.G4JLElectricField(sim::Simulation{T,CS}) where {T,CS}
+
+    data = SSDElectricFieldData(sim)
+    function getfield!(result::G4ThreeVector, pos::G4ThreeVector, data::SSDElectricFieldData{T,CS})
+
+        # convert all coordinates into units of meter for SolidStateDetectors.jl
+        car_pt = CartesianPoint{T}(
+            x(pos) / Geant4.SystemOfUnits.meter,
+            y(pos) / Geant4.SystemOfUnits.meter,
+            z(pos) / Geant4.SystemOfUnits.meter
+        )
+
+        # convert to the position to the same coordinates as the electric field
+        pt = SolidStateDetectors._convert_point(car_pt, CS)
+
+        # evaluate the electric field at the given position
+        E::CartesianVector{T} = SolidStateDetectors.get_velocity_vector(data.efield_itp, pt)
+
+        # return the electric field as G4ThreeVector (interpreted in units of V/m)
+        G4E = G4ThreeVector(
+                E.x * Geant4.SystemOfUnits.volt / Geant4.SystemOfUnits.meter,
+                E.y * Geant4.SystemOfUnits.volt / Geant4.SystemOfUnits.meter,
+                E.z * Geant4.SystemOfUnits.volt / Geant4.SystemOfUnits.meter
+        )
+        assign(result, G4E)
+
+        return
+    end
+    G4JLElectricField("SSDElectricField", data; getfield_method = getfield!)
 end
 
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -21,5 +21,6 @@ TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
+Geant4 = "0.3.1"
 LegendDataTypes = "0.1.3"
 LegendHDF5IO = "0.1"

--- a/test/test_geant4.jl
+++ b/test/test_geant4.jl
@@ -66,6 +66,9 @@ end
     source = MonoenergeticSource("gamma", 2.615u"MeV", CartesianPoint(0.04, 0, 0.05), CartesianVector(-1,0,0))
     app = Geant4.G4JLApplication(sim, source, verbose = false)
 
+    # Test G4JLElectricField throws an ArgumentError if sim.electric_field is missing
+    @test_throws ArgumentError Geant4.G4JLElectricField(sim)
+
     # Simulate Geant4 events
     N = 100
     evts = run_geant4_simulation(app, N)
@@ -222,6 +225,19 @@ end
     @test SolidStateDetectors.is_detector_hits_table(ievts)
     @test length(ievts) == N
 
+    # Test G4JLElectricField using electric field from the simulation
+    g4ef = @test_nowarn @inferred Geant4.G4JLElectricField(sim)
+    
+    # Hack: apply the field to the Field manager (essentially what G4JLApplication(field = g4ef) would do)
+    sf = Geant4.make_callback(g4ef.data, g4ef.getfield, Nothing, (Geant4.CxxRef{Geant4.G4ThreeVector}, Geant4.ConstCxxRef{Geant4.G4ThreeVector})) |> Geant4.closure
+    E = Geant4.G4JLElecField(sf...)
+    g4ef.base = [E]
+    Geant4.G4JL_setupElectroMagneticField(Geant4.G4TransportationManager!GetTransportationManager() |> Geant4.GetFieldManager, Geant4.CxxPtr(E), 0.010Geant4.SystemOfUnits.mm)
+    eevts = run_geant4_simulation(app, N)
+
+    @test eevts isa Table
+    @test SolidStateDetectors.is_detector_hits_table(eevts)
+    @test length(eevts) == N
 end
 
 @testset "Construct G4JLDetectors from config files" begin


### PR DESCRIPTION
This should close #397:

Now with the newest `Geant4@0.3.1`, we can define electric fields and include them in the Geant4 simulations.
This PR adds a convenience function `G4JLElectricField(sim::Simulation)` to generate a `G4JLElectricField` that can be passed to the `G4JLApplication` via the `field` keyword:
```julia
app = G4JLApplication(sim, source, field = G4JLElectricField(sim))
```
<img width="2500" height="1666" alt="spectrum_electric_field" src="https://github.com/user-attachments/assets/ebcdc8a7-4bf6-4bce-b360-2b164333a975" />

I also added tests, a short description for the documentation.

