### PR TITLE
Support ArraysOfArrays v1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -49,7 +49,7 @@ SolidStateDetectorsGeant4Ext = "Geant4"
 
 [compat]
 Adapt = "3, 4"
-ArraysOfArrays = "0.5, 0.6"
+ArraysOfArrays = "0.5, 0.6, 1"
 Clustering = "0.15"
 DataStructures = "0.17, 0.18, 0.19"
 Distributions = "0.24.5, 0.25"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SolidStateDetectors"
 uuid = "71e43887-2bd9-5f77-aebd-47f656f0a3f0"
-version = "0.11.6"
+version = "0.11.7"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/ext/SolidStateDetectorsLegendHDF5IOExt.jl
+++ b/ext/SolidStateDetectorsLegendHDF5IOExt.jl
@@ -5,7 +5,7 @@ module SolidStateDetectorsLegendHDF5IOExt
 import ..LegendHDF5IO
 
 using ..SolidStateDetectors
-using ..SolidStateDetectors: RealQuantity, SSDFloat, to_internal_units, chunked_ranges, LengthQuantity
+using ..SolidStateDetectors: RealQuantity, SSDFloat, to_internal_units, chunked_ranges, LengthQuantity, PartsView
 using ..SolidStateDetectors.ConstructiveSolidGeometry: AbstractCoordinatePoint
 
 using ArraysOfArrays
@@ -58,7 +58,7 @@ function SolidStateDetectors.simulate_waveforms( mcevents::AbstractVector{<:Name
         mcevents_sub = simulate_waveforms(mcevents[evtrange], sim; Δt, max_nsteps, diffusion, self_repulsion, number_of_carriers, number_of_shells, signal_unit, max_interaction_distance, end_drift_when_no_field, geometry_check, verbose)
 
         # # LH5 couldn't handle CartesianPoint, turn positions into CartesianVectors which will be saved as SVectors
-        # pos_vec = VectorOfVectors([[CartesianPoint(p...) - cartesian_zero for p in ps] for ps in mcevents_sub.pos])
+        # pos_vec = PartsView([[CartesianPoint(p...) - cartesian_zero for p in ps] for ps in mcevents_sub.pos])
         # new_mcevents_sub = TypedTables.Table(merge(Tables.columns(mcevents_sub), (pos = pos_vec,)))
 
         LegendHDF5IO.lh5open(ofn, "w") do h5f
@@ -94,18 +94,18 @@ end
 # support writing arrays of points to HDF5 file using LH5Array
 function LegendHDF5IO.create_entry(parent::LegendHDF5IO.LHDataStore, name::AbstractString, 
     pts::T; kwargs...) where {T <: AbstractVector{<:AbstractCoordinatePoint}}
-    LegendHDF5IO.create_entry(parent, name, VectorOfVectors([getindex.(Ref(pt), 1:3) for pt in pts]); kwargs...)
+    LegendHDF5IO.create_entry(parent, name, PartsView([getindex.(Ref(pt), 1:3) for pt in pts]); kwargs...)
     LegendHDF5IO.setdatatype!(parent.data_store[name], T)
     return nothing
 end
 
 function LegendHDF5IO.LH5Array(ds::LegendHDF5IO.HDF5.Group, T::Type{<:AbstractVector{<:CartesianPoint}})
-    data = LegendHDF5IO.LH5Array(ds, VectorOfVectors)
+    data = LegendHDF5IO.LH5Array(ds, PartsView)
     Vector([CartesianPoint(d...) for d in data])
 end
 
 function LegendHDF5IO.LH5Array(ds::LegendHDF5IO.HDF5.Group, T::Type{<:AbstractVector{<:CylindricalPoint}})
-    data = LegendHDF5IO.LH5Array(ds, VectorOfVectors)
+    data = LegendHDF5IO.LH5Array(ds, PartsView)
     Vector([CylindricalPoint(d...) for d in data])
 end
 
@@ -134,7 +134,7 @@ function LegendHDF5IO.writedata(
     pts::AbstractVector{<:AbstractCoordinatePoint},
     fulldatatype::DataType = typeof(pts)
 )
-    data = VectorOfVectors([getindex.(Ref(pt), 1:3) for pt in pts])
+    data = PartsView([getindex.(Ref(pt), 1:3) for pt in pts])
     LegendHDF5IO.writedata(output, name, data, fulldatatype)
     LegendHDF5IO.setdatatype!(output[name], fulldatatype)
     return nothing
@@ -144,7 +144,7 @@ function LegendHDF5IO.readdata(
     input::LegendHDF5IO.HDF5.H5DataStore, name::AbstractString,
     fulldatatype::Type{T}
 ) where {T <:AbstractVector{<:CartesianPoint}}
-    data = LegendHDF5IO.readdata(input, name, VectorOfVectors)
+    data = LegendHDF5IO.readdata(input, name, PartsView)
     output = [CartesianPoint(d...) for d in data]
     @assert output isa T
     return output
@@ -154,7 +154,7 @@ function LegendHDF5IO.readdata(
     input::LegendHDF5IO.HDF5.H5DataStore, name::AbstractString,
     fulldatatype::Type{T}
 ) where {T <:AbstractVector{<:CylindricalPoint}}
-    data = LegendHDF5IO.readdata(input, name, VectorOfVectors)
+    data = LegendHDF5IO.readdata(input, name, PartsView)
     output = [CylindricalPoint(d...) for d in data]
     @assert output isa T
     return output

--- a/src/ChargeClustering/ChargeClustering.jl
+++ b/src/ChargeClustering/ChargeClustering.jl
@@ -71,7 +71,7 @@ function cluster_detector_hits(table::TypedTables.Table, cluster_radius::RealQua
     TypedTables.Table(merge(
         TypedTables.columns(table),
         map(
-            VectorOfVectors,
+            PartsView,
             TypedTables.columns(clustered_nt)
         )
     ))
@@ -114,19 +114,19 @@ function _group_points_by_distance(pts::AbstractVector{CartesianPoint{T}}, group
     clustersidx, elem_ptr[begin:Cidx]
 end
 
-function group_points_by_distance(pts::AbstractVector{CartesianPoint{T}}, group_distance::T)::VectorOfVectors{CartesianPoint{T}} where {T <: SSDFloat}
+function group_points_by_distance(pts::AbstractVector{CartesianPoint{T}}, group_distance::T)::PartsView{CartesianPoint{T}} where {T <: SSDFloat}
     clustersidx, elem_ptr = _group_points_by_distance(pts, group_distance)
-    VectorOfVectors(pts[clustersidx], elem_ptr)
+    PartsView(pts[clustersidx], elem_ptr)
 end
 
-function group_points_by_distance(pts::AbstractVector{CartesianPoint{T}}, energies::AbstractVector{T}, group_distance::T)::Tuple{VectorOfVectors{CartesianPoint{T}}, VectorOfVectors{T}} where {T <: SSDFloat}
+function group_points_by_distance(pts::AbstractVector{CartesianPoint{T}}, energies::AbstractVector{T}, group_distance::T)::Tuple{PartsView{CartesianPoint{T}}, PartsView{T}} where {T <: SSDFloat}
     @assert eachindex(pts) == eachindex(energies)
     clustersidx, elem_ptr = _group_points_by_distance(pts, group_distance)
-    VectorOfVectors(pts[clustersidx], elem_ptr), VectorOfVectors(energies[clustersidx], elem_ptr)
+    PartsView(pts[clustersidx], elem_ptr), PartsView(energies[clustersidx], elem_ptr)
 end
 
-function group_points_by_distance(pts::AbstractVector{CartesianPoint{T}}, energies::AbstractVector{T}, radius::AbstractVector{T}, group_distance::T)::Tuple{VectorOfVectors{CartesianPoint{T}}, VectorOfVectors{T}, VectorOfVectors{T}} where {T <: SSDFloat}
+function group_points_by_distance(pts::AbstractVector{CartesianPoint{T}}, energies::AbstractVector{T}, radius::AbstractVector{T}, group_distance::T)::Tuple{PartsView{CartesianPoint{T}}, PartsView{T}, PartsView{T}} where {T <: SSDFloat}
     @assert eachindex(pts) == eachindex(energies) == eachindex(radius)
     clustersidx, elem_ptr = _group_points_by_distance(pts, group_distance)
-    VectorOfVectors(pts[clustersidx], elem_ptr), VectorOfVectors(energies[clustersidx], elem_ptr), VectorOfVectors(radius[clustersidx], elem_ptr)
+    PartsView(pts[clustersidx], elem_ptr), PartsView(energies[clustersidx], elem_ptr), PartsView(radius[clustersidx], elem_ptr)
 end

--- a/src/MCEventsProcessing/table_utils.jl
+++ b/src/MCEventsProcessing/table_utils.jl
@@ -29,7 +29,7 @@ function common_length(x, y)
 end
 common_length(x, y, z...) = common_length(common_length(x, y), z...)
 
-nested_col(x::AbstractVector, n::AbstractVector{<:Integer}) = VectorOfVectors(Fill.(x, n))
+nested_col(x::AbstractVector, n::AbstractVector{<:Integer}) = PartsView(Fill.(x, n))
 
 function nested_col(x::AbstractVector{<:AbstractVector}, n::AbstractVector{<:Integer})
     @assert length.(x) == n
@@ -76,9 +76,9 @@ function cluster_by_time(table::TypedTables.Table, Δt = 1u"ns")
     if length(inds) > 0
         ranges = vcat( [1:inds[1]], broadcast(:, inds[1:end-1].+1, inds[2:end]), 
                         n_charge_depos > inds[end] ? [inds[end]+1:n_charge_depos] : [] )
-        TypedTables.Table(map(c -> VectorOfVectors(map(r -> c[r], ranges)), TypedTables.columns(table)))
+        TypedTables.Table(map(c -> PartsView(map(r -> c[r], ranges)), TypedTables.columns(table)))
     else
-        TypedTables.Table(map(c -> VectorOfVectors(map(r -> c[r], [1:n_charge_depos])), TypedTables.columns(table)))
+        TypedTables.Table(map(c -> PartsView(map(r -> c[r], [1:n_charge_depos])), TypedTables.columns(table)))
     end
 end
 
@@ -109,7 +109,7 @@ function split_by_time(table::TypedTables.Table, Δt = 1u"ns")
             # columns that have a single entry: clone them
             c[map(p -> findlast(p .>= table.thit.elem_ptr), elem_ptr[1:end-1])] :
             # columns that have multiple entries: split accordingly
-            VectorOfVectors(flatview(c)[idx], elem_ptr), 
+            PartsView(flatview(c)[idx], elem_ptr), 
         TypedTables.columns(table))
     )
 end
@@ -132,7 +132,7 @@ function translate_event_positions(table::TypedTables.Table, tv::AbstractVector{
     hasproperty(table, :pos) || throw(ArgumentError("Expected detector hit events table to have column named `pos`"))
     length(tv) == 3 || throw(ArgumentError("Translation vector must be of length 3"))
     eltype(eltype(eltype(table.pos))) <: Union{<:Real, <:LengthQuantity} || throw(ArgumentError("Expected table positions to be unitless or to have units of length"))
-    newpos = (pos = VectorOfVectors(map(poss -> map(pos -> _translate_event_position(pos, tv), poss), table.pos)),)
+    newpos = (pos = PartsView(map(poss -> map(pos -> _translate_event_position(pos, tv), poss), table.pos)),)
     TypedTables.Table(merge( TypedTables.columns(table), newpos ))
 end
 
@@ -140,7 +140,7 @@ end
 @inline _rotate_event_position(p::P, rot::Rotations.Rotation{3}) where {P <: AbstractVector} = P(rot * p)
 function rotate_event_positions(table, rot::Rotations.Rotation{3}) 
     hasproperty(table, :pos) || throw(ArgumentError("Expected detector hit events table to have column named `pos`"))
-    newpos = (pos = VectorOfVectors(map(poss -> map(pos -> _rotate_event_position(pos, rot), poss), table.pos)),)
+    newpos = (pos = PartsView(map(poss -> map(pos -> _rotate_event_position(pos, rot), poss), table.pos)),)
     TypedTables.Table(merge( TypedTables.columns(table), newpos ))
 end
 

--- a/src/SolidStateDetectors.jl
+++ b/src/SolidStateDetectors.jl
@@ -30,6 +30,12 @@ using Unitful
 using UnitfulAtomic
 using YAML
 
+@static if isdefined(ArraysOfArrays, :PartsView)
+    using ArraysOfArrays: PartsView
+else
+    const PartsView = ArraysOfArrays.VectorOfVectors
+end
+
 include("ka_compat.jl")
 
 include("ConstructiveSolidGeometry/ConstructiveSolidGeometry.jl")

--- a/test/ConstructiveSolidGeometry/CSG_IO.jl
+++ b/test/ConstructiveSolidGeometry/CSG_IO.jl
@@ -6,7 +6,7 @@ import SolidStateDetectors.ConstructiveSolidGeometry: Geometry
 
 import LegendHDF5IO
 import Unitful: @u_str
-import ArraysOfArrays: VectorOfVectors
+import ArraysOfArrays: VectorOfArrays
 
 T = Float64
 
@@ -84,7 +84,7 @@ end
                     
                     @testset "I/O for Vector of AbstractCoordinatePoints" begin
                         
-                        y = x isa Vector ? VectorOfVectors([x]) : [x]
+                        y = x isa Vector ? VectorOfArrays([x]) : [x]
 
                         # write to file using writedata and LH5Array
                         @test_nowarn LegendHDF5IO.writedata(h, "y1", y)

--- a/test/test_charge_drift_models.jl
+++ b/test/test_charge_drift_models.jl
@@ -649,8 +649,8 @@ end
             # Test correctness
             s0 = Set(pts)
 
-            # result should be a VectorOfVectors
-            @test ptsg isa VectorOfVectors{<:CartesianPoint{T}}
+            # result should be a VectorOfArrays
+            @test ptsg isa VectorOfArrays{<:CartesianPoint{T},1}
 
             # all points should appear in the result
             @test Set(flatview(ptsg))    == Set(pts)

--- a/test/test_geant4.jl
+++ b/test/test_geant4.jl
@@ -101,7 +101,7 @@ end
     @test eltype(first(clustered_evts.pos)) <: CartesianPoint
 
     # Try the same method using StaticVectors as eltype of pos
-    evts_static = Table(evts; pos = VectorOfVectors(broadcast.(p -> SVector{3}(p.x, p.y, p.z), evts.pos)))
+    evts_static = Table(evts; pos = VectorOfArrays(broadcast.(p -> SVector{3}(p.x, p.y, p.z), evts.pos)))
     clustered_evts_static = SolidStateDetectors.cluster_detector_hits(evts_static, 10u"µm", 1u"ns")
     @test length(clustered_evts_static) == length(evts_static)
     @test length(flatview(clustered_evts_static.pos)) <= length(flatview(evts_static.pos))
@@ -158,7 +158,7 @@ end
     @test length(wf_fano) == length(evts_fano) * sum(.!ismissing.(sim.weighting_potentials))
 
     # Try the same method using StaticVectors as eltype of pos (with units of mm)
-    evts_static = Table(evts; pos = VectorOfVectors(broadcast.(p -> SVector{3}(p.x, p.y, p.z) * 1000u"mm", SolidStateDetectors.to_internal_units(evts.pos))))
+    evts_static = Table(evts; pos = VectorOfArrays(broadcast.(p -> SVector{3}(p.x, p.y, p.z) * 1000u"mm", SolidStateDetectors.to_internal_units(evts.pos))))
     clustered_evts_static = SolidStateDetectors.cluster_detector_hits(evts_static, 10u"µm", 1u"ns")
     @test length(clustered_evts_static) == length(evts_static)
     @test length(flatview(clustered_evts_static.pos)) <= length(flatview(evts_static.pos))

--- a/test/test_io.jl
+++ b/test/test_io.jl
@@ -91,9 +91,9 @@ end
         evt_table = Table(
             evtno = Int32[1], 
             detno = Int32[1],
-            thit = VectorOfVectors([T[0] * u"s"]),
-            edep = VectorOfVectors([T[1] * u"eV"]),
-            pos = VectorOfVectors([pos])
+            thit = VectorOfArrays([T[0] * u"s"]),
+            edep = VectorOfArrays([T[1] * u"eV"]),
+            pos = VectorOfArrays([pos])
         )
 
         contact_charge_signals = timed_simulate_waveforms(      


### PR DESCRIPTION
Adds compatibility with ArraysOfArrays v1 while keeping support for v0.5 and v0.6.

* `VectorOfVectors` is deprecated in ArraysOfArrays v1 in favor of `PartsView`, which is now used throughout (including the two-argument `(data, elem_ptr)` constructor) and aliased to `VectorOfVectors` on older ArraysOfArrays versions.
* The tests use `VectorOfArrays`, available on all supported versions.

Running CI against ArraysOfArrays v1 also needs the compatible RadiationDetectorSignals release (JuliaPhysics/RadiationDetectorSignals.jl#53), until then the resolver picks ArraysOfArrays v0.6.

Includes a patch version bump.

Created by generative AI.
