### PR TITLE
Support ArraysOfArrays v1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -49,7 +49,7 @@ SolidStateDetectorsGeant4Ext = "Geant4"
 
 [compat]
 Adapt = "3, 4"
-ArraysOfArrays = "0.5, 0.6"
+ArraysOfArrays = "0.5, 0.6, 1"
 Clustering = "0.15"
 DataStructures = "0.17, 0.18, 0.19"
 Distributions = "0.24.5, 0.25"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SolidStateDetectors"
 uuid = "71e43887-2bd9-5f77-aebd-47f656f0a3f0"
-version = "0.11.6"
+version = "0.11.7"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Adds ArraysOfArrays v1 to the compat bounds while keeping support for v0.5 and v0.6. All ArraysOfArrays API used by SolidStateDetectors, including `VectorOfVectors`, is available unchanged on v1 (`VectorOfVectors` stays a supported alias as of ArraysOfArrays v1.0.1).

Running CI against ArraysOfArrays v1 also needs the compatible RadiationDetectorSignals release (JuliaPhysics/RadiationDetectorSignals.jl#54), until then the resolver picks ArraysOfArrays v0.6.

Includes a patch version bump.

Created by generative AI.
