### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,20 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+type: software
+title: "End-to-end simulations of semiconductor detectors using the `Geant4.jl` extension of `SolidStateDetectors.jl`"
+authors:
+  - family-names: "Hagemann"
+    given-names: "Felix"
+    orcid: "https://orcid.org/0000-0001-5021-3328"
+  - family-names: "Henzler"
+    given-names: "Julian "
+    orcid: "https://orcid.org/0009-0000-6977-8687"
+  - family-names: "Nagler"
+    given-names: "Benedikt"
+    orcid: "https://orcid.org/0009-0004-0906-4286"
+  - family-names: "Schulz"
+    given-names: "Oliver"
+    orcid: "https://orcid.org/0000-0002-4200-5905"
+repository-code: "https://github.com/JuliaPhysics/SolidStateDetectors.jl"
+license: "MIT"
+version: "0.11.8"


### PR DESCRIPTION
JOSS reviewers ask for a `CITATION.cff`, and this repository does not have one yet.

Generated from the author list in `origin/joss-paper:paper.md`: 4 author(s), with given and family names taken from each author's ORCID record rather than split from the display name, because compound surnames do not split reliably.

`license` is `MIT`, read from the LICENSE file. `version` is `0.11.8`, the newest release tag. 

Verified with `cffconvert --validate`: valid against schema 1.2.0.