### PR TITLE
Update Downgrade workflow after julia-1.13 release

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['1.10', '1']
+        version: ['1.10', '1.12', '1']
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -33,8 +33,8 @@ jobs:
         run: julia --project=. -e 'using Pkg; Pkg.add(name = "NearestNeighbors", version = "0.4.13"); Pkg.compat("NearestNeighbors", "0.4.13")'
         shell: bash
         if: matrix.version == '1.10'
-      - name: Downgrade NearestNeighbors # Temporary fix: this is needed for Unitful to downgrade to a version that works with julia-1.13
-        run: julia --project=. -e 'using Pkg; Pkg.add(name = "Unitful", version = "1.25.1"); Pkg.compat("Unitful", "1.25.1")'
+      - name: Fix dependencies for julia-1.13 # Temporary fix: this is needed for Unitful and KernelAbstractions to downgrade to a version that works with julia-1.13
+        run: julia --project=. -e 'using Pkg; Pkg.add(name = "Unitful", version = "1.25.1"); Pkg.compat("Unitful", "1.25.1"); Pkg.compat("KernelAbstractions", "0.8.1, 0.9")'
         shell: bash
         if: matrix.version == '1'
       - uses: julia-actions/julia-downgrade-compat@v2

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -33,6 +33,10 @@ jobs:
         run: julia --project=. -e 'using Pkg; Pkg.add(name = "NearestNeighbors", version = "0.4.13"); Pkg.compat("NearestNeighbors", "0.4.13")'
         shell: bash
         if: matrix.version == '1.10'
+      - name: Downgrade NearestNeighbors # Temporary fix: this is needed for Unitful to downgrade to a version that works with julia-1.13
+        run: julia --project=. -e 'using Pkg; Pkg.add(name = "Unitful", version = "1.25.1"); Pkg.compat("Unitful", "1.25.1")'
+        shell: bash
+        if: matrix.version == '1'
       - uses: julia-actions/julia-downgrade-compat@v2
         with:
           julia_version: ${{ matrix.version }}


### PR DESCRIPTION
With the release of julia-1.13.0, the Downgrade tests seem to fail because the [lowest allowed compat for `Unitful`](https://github.com/JuliaRegistries/General/blob/master/U/Unitful/Compat.toml) for julia-1.13 (v1.12.3) does not compile under julia-1.13 (see https://github.com/JuliaPhysics/Unitful.jl/issues/815).

Temporary fix: fix the `Unitful` compat for Downgrade tests on `1` manually to 1.25.1, which is the lowest version that compiles under julia-1.13. 

This can be removed once things are sorted out, either in julia-1.13 itself, or in the `Compat.toml` of `Unitful` in the General registry.